### PR TITLE
V0 fix psalm warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "ext-redis": "*",
         "ext-mongodb": "*",
         "utopia-php/framework": "0.*.*",
-        "utopia-php/cache": "0.4.0",
+        "utopia-php/cache": "0.4.*",
         "mongodb/mongodb": "1.8.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa7d9c6d206e196d739c246ce67aac67",
+    "content-hash": "dd2546d5cd02cf55391c4a5cd4768bd0",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -287,16 +287,16 @@
         },
         {
             "name": "utopia-php/cache",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cache.git",
-                "reference": "81c7806e13091a9d585ad9bba57fae625a2cf26c"
+                "reference": "8c48eff73219c8c1ac2807909f0a38f3480c8938"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cache/zipball/81c7806e13091a9d585ad9bba57fae625a2cf26c",
-                "reference": "81c7806e13091a9d585ad9bba57fae625a2cf26c",
+                "url": "https://api.github.com/repos/utopia-php/cache/zipball/8c48eff73219c8c1ac2807909f0a38f3480c8938",
+                "reference": "8c48eff73219c8c1ac2807909f0a38f3480c8938",
                 "shasum": ""
             },
             "require": {
@@ -334,9 +334,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/cache/issues",
-                "source": "https://github.com/utopia-php/cache/tree/0.4.0"
+                "source": "https://github.com/utopia-php/cache/tree/0.4.1"
             },
-            "time": "2021-04-22T14:28:14+00:00"
+            "time": "2021-04-29T18:41:43+00:00"
         },
         {
             "name": "utopia-php/framework",
@@ -3922,7 +3922,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.1",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "ext-redis": "*",
+        "ext-mongodb": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -110,7 +110,7 @@ class Query
                 $input = explode('.', $filter, $stanzas);
                 $attribute = $input[0];
                 $expression = $input[1];
-                [(string)$operator, (array)$values] = self::parseExpression($expression);
+                [$operator, $values] = self::parseExpression($expression);
                 break;
         }
 
@@ -123,7 +123,7 @@ class Query
      *
      * @param string $expression
      *
-     * @return (string|array)[]
+     * @return array
      */
     protected static function parseExpression(string $expression): array
     {
@@ -153,6 +153,7 @@ class Query
 
         // Cast $value type
 
+        /** @var mixed */
         $values = array_map(function ($value) {
 
             // Trim whitespace from around $value

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -153,7 +153,7 @@ class Query
 
         // Cast $value type
 
-        /** @var mixed */
+        /** @var array */
         $values = array_map(function ($value) {
 
             // Trim whitespace from around $value

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -91,9 +91,16 @@ class Query
      * */
     public static function parse(string $filter): Query
     {
+        $attribute = '';
+        $operator = '';
+        $values = [];
+
         // get index of open parentheses
+        /** @var int */
         $end = mb_strpos($filter, '(');
+
         // count stanzas by only counting '.' that come before open parentheses
+        /** @var int */
         $stanzas = mb_substr_count(mb_substr($filter, 0, $end), ".") + 1;
 
         // TODO@kodumbeats handle relations between collections, e.g. if($stanzas > 2)
@@ -103,7 +110,7 @@ class Query
                 $input = explode('.', $filter, $stanzas);
                 $attribute = $input[0];
                 $expression = $input[1];
-                [$operator, $values] = self::parseExpression($expression);
+                [(string)$operator, (array)$values] = self::parseExpression($expression);
                 break;
         }
 


### PR DESCRIPTION
This PR addresses the included psalm warnings by:
- upgrading `utopia-php/cache` to 0.4.1, which appropriately typehints `$cache->save()`
- declare and typehint `Query::parse() where necessary`

Warnings from psalm, for reference:

```
$ docker-compose exec tests vendor/bin/psalm --show-info=true
Scanning files...
Analyzing files...

░░░░░░I░░░░I░░░░░░░░

INFO: InvalidArgument - src/Database/Database.php:488:33 - Argument 2 of Utopia\Cache\Cache::save expects string, array<array-key, mixed> provided (see https://psalm.dev/004)
        $this->cache->save($id, $document->getArrayCopy()); // save to cache after fetching from db


INFO: InvalidArgument - src/Database/Database.php:580:48 - Argument 2 of Utopia\Cache\Cache::save expects string, array<array-key, mixed> provided (see https://psalm.dev/004)
        $this->cache->save($document->getId(), $document->getArrayCopy());


INFO: PossiblyFalseArgument - src/Database/Query.php:97:58 - Argument 3 of mb_substr cannot be false, possibly false value provided (see https://psalm.dev/104)
        $stanzas = mb_substr_count(mb_substr($filter, 0, $end), ".") + 1;


INFO: PossiblyUndefinedVariable - src/Database/Query.php:110:26 - Possibly undefined variable $attribute, first seen on line 104 (see https://psalm.dev/018)
        return new Query($attribute, $operator, $values);


INFO: PossiblyUndefinedVariable - src/Database/Query.php:110:38 - Possibly undefined variable $operator, first seen on line 106 (see https://psalm.dev/018)
        return new Query($attribute, $operator, $values);


INFO: PossiblyUndefinedVariable - src/Database/Query.php:110:49 - Possibly undefined variable $values, first seen on line 106 (see https://psalm.dev/018)
        return new Query($attribute, $operator, $values);

```