### PR TITLE
Feat - Script to fill databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mock.json
 data-tests.php
 loader.php
 .phpunit.result.cache
+/bin/view/results/

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,12 @@ WORKDIR /usr/src/code
 
 RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini
 
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+RUN echo "opcache.enable_cli=1" >> $PHP_INI_DIR/php.ini
+
+RUN echo "memory_limit=1024M" >> $PHP_INI_DIR/php.ini
+
 COPY --from=step0 /usr/local/src/vendor /usr/src/code/vendor
 
 # Add Source Code

--- a/README.md
+++ b/README.md
@@ -191,28 +191,28 @@ To test your DB changes under load:
 #### Load the database
 
 ```bash
-docker-compose exec tests bin/load [dbms] [limit]
+docker-compose exec tests bin/load [adapter] [limit]
 
-# [dbms]: either 'mongodb' or 'mariadb', no quotes
+# [adapter]: either 'mongodb' or 'mariadb', no quotes
 # [limit]: integer of total documents to generate
 ```
 
 #### Create indexes
 
 ```bash
-docker-compose exec tests bin/index [dbms] [filledDB]
+docker-compose exec tests bin/index [adapter] [collection]
 
-# [dbms]: either 'mongodb' or 'mariadb', no quotes
-# [filledDB]: name of filled database by bin/load
+# [adapter]: either 'mongodb' or 'mariadb', no quotes
+# [collection]: name of filled database by bin/load
 ```
 
 #### Run Query Suite
 
 ```bash
-docker-compose exec tests bin/query [dbms] [totalDocuments] [filledDB]
+docker-compose exec tests bin/query [adapter] [collection] [limit]
 
-# [dbms]: either 'mongodb' or 'mariadb', no quotes
-# [filledDB]: name of filled database by bin/load
+# [adapter]: either 'mongodb' or 'mariadb', no quotes
+# [collection]: name of filled database by bin/load
 # [limit]: integer of query limit (default 25)
 ```
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ docker-compose exec tests bin/query --adapter=[adapter] --limit=[limit] --name=[
 # [name]: name of filled database by bin/load
 ```
 
+#### Visualize Query Results
+
+```bash
+docker-compose exec tests bin/compare
+```
+
+Navigate to `localhost:8708` to visualize query results.
+
 ## Authors
 
 **Eldad Fux**

--- a/README.md
+++ b/README.md
@@ -178,6 +178,28 @@ To run static code analysis, use the following Psalm command:
 ```bash
 docker-compose exec tests vendor/bin/psalm --show-info=true
 ```
+### Load testing
+
+Three commands have been added to `bin/` to fill, index, and query the DB to test changes:
+
+- `bin/load` invokes `bin/tasks/load.php`
+- `bin/index` invokes `bin/tasks/index.php`
+- `bin/query` invokes `bin/tasks/query.php`
+
+To test your DB changes under load:
+
+1. Enable your database of choice by uncommenting it in:
+  - `bin/tasks/load.php`
+  - `bin/tasks/index.php`
+  - `bin/tasks/query.php`
+2. Load the database with `docker-compose exec tests bin/load`
+3. Get the name of the created database from your favorite DB tool
+4. Add the database name to `$database->setNamespace('myapp_60afd9a009280');` in:
+  - `bin/tasks/index.php`
+  - `bin/tasks/query.php`
+5. Create indexes with `docker-compose exec tests bin/index`
+6. Run query test suite with `docker-compose exec tests bin/query`
+
 ## Authors
 
 **Eldad Fux**

--- a/README.md
+++ b/README.md
@@ -188,17 +188,33 @@ Three commands have been added to `bin/` to fill, index, and query the DB to tes
 
 To test your DB changes under load:
 
-1. Enable your database of choice by uncommenting it in:
-  - `bin/tasks/load.php`
-  - `bin/tasks/index.php`
-  - `bin/tasks/query.php`
-2. Load the database with `docker-compose exec tests bin/load`
-3. Get the name of the created database from your favorite DB tool
-4. Add the database name to `$database->setNamespace('myapp_60afd9a009280');` in:
-  - `bin/tasks/index.php`
-  - `bin/tasks/query.php`
-5. Create indexes with `docker-compose exec tests bin/index`
-6. Run query test suite with `docker-compose exec tests bin/query`
+#### Load the database
+
+```bash
+docker-compose exec tests bin/load [dbms] [limit]
+
+# [dbms]: either 'mongodb' or 'mariadb', no quotes
+# [limit]: integer of total documents to generate
+```
+
+#### Create indexes
+
+```bash
+docker-compose exec tests bin/index [dbms] [filledDB]
+
+# [dbms]: either 'mongodb' or 'mariadb', no quotes
+# [filledDB]: name of filled database by bin/load
+```
+
+#### Run Query Suite
+
+```bash
+docker-compose exec tests bin/query [dbms] [totalDocuments] [filledDB]
+
+# [dbms]: either 'mongodb' or 'mariadb', no quotes
+# [filledDB]: name of filled database by bin/load
+# [limit]: integer of query limit (default 25)
+```
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -191,29 +191,30 @@ To test your DB changes under load:
 #### Load the database
 
 ```bash
-docker-compose exec tests bin/load [adapter] [limit]
+docker-compose exec tests bin/load --adapter=[adapter] --limit=[limit] [--name=[name]]
 
 # [adapter]: either 'mongodb' or 'mariadb', no quotes
 # [limit]: integer of total documents to generate
+# [name]: (optional) name for new database
 ```
 
 #### Create indexes
 
 ```bash
-docker-compose exec tests bin/index [adapter] [collection]
+docker-compose exec tests bin/index --adapter=[adapter] --name=[name]
 
 # [adapter]: either 'mongodb' or 'mariadb', no quotes
-# [collection]: name of filled database by bin/load
+# [name]: name of filled database by bin/load
 ```
 
 #### Run Query Suite
 
 ```bash
-docker-compose exec tests bin/query [adapter] [collection] [limit]
+docker-compose exec tests bin/query --adapter=[adapter] --limit=[limit] --name=[name]
 
 # [adapter]: either 'mongodb' or 'mariadb', no quotes
-# [collection]: name of filled database by bin/load
 # [limit]: integer of query limit (default 25)
+# [name]: name of filled database by bin/load
 ```
 
 ## Authors

--- a/bin/cli.php
+++ b/bin/cli.php
@@ -1,0 +1,15 @@
+<?php
+
+// require_once __DIR__.'/init.php';
+require_once '/usr/src/code/vendor/autoload.php';
+
+use Utopia\CLI\CLI;
+use Utopia\CLI\Console;
+
+$cli = new CLI();
+
+include 'tasks/load.php';
+// include 'tasks/index.php';
+// include 'tasks/query.php';
+
+$cli->run();

--- a/bin/cli.php
+++ b/bin/cli.php
@@ -10,6 +10,6 @@ $cli = new CLI();
 
 include 'tasks/load.php';
 include 'tasks/index.php';
-// include 'tasks/query.php';
+include 'tasks/query.php';
 
 $cli->run();

--- a/bin/cli.php
+++ b/bin/cli.php
@@ -9,7 +9,7 @@ use Utopia\CLI\Console;
 $cli = new CLI();
 
 include 'tasks/load.php';
-// include 'tasks/index.php';
+include 'tasks/index.php';
 // include 'tasks/query.php';
 
 $cli->run();

--- a/bin/compare
+++ b/bin/compare
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo ""
+echo "Navigate to http://localhost:8708 in your browser"
+echo ""
+php -t /usr/src/code/bin/view -S 0.0.0.0:8708

--- a/bin/index
+++ b/bin/index
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+php /usr/src/code/bin/tasks/index.php $@

--- a/bin/index
+++ b/bin/index
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/bin/tasks/index.php $@
+php /usr/src/code/bin/cli.php index $@

--- a/bin/load
+++ b/bin/load
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+php /usr/src/code/bin/tasks/load.php $@

--- a/bin/load
+++ b/bin/load
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/bin/tasks/load.php $@
+php /usr/src/code/bin/cli.php load $@

--- a/bin/query
+++ b/bin/query
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php /usr/src/code/bin/tasks/query.php $@
+php /usr/src/code/bin/cli.php query $@

--- a/bin/query
+++ b/bin/query
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+php /usr/src/code/bin/tasks/query.php $@

--- a/bin/tasks/index.php
+++ b/bin/tasks/index.php
@@ -59,6 +59,23 @@ $cli
                 $database = new Database(new MariaDB($pdo), new Cache(new NoCache()));
                 break;
 
+            case 'mysql':
+                $dbHost = 'mysql';
+                $dbPort = '3307';
+                $dbUser = 'root';
+                $dbPass = 'password';
+
+                $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                    PDO::ATTR_TIMEOUT => 3, // Seconds
+                    PDO::ATTR_PERSISTENT => true,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                ]);
+
+                $database = new Database(new MariaDB($pdo), new Cache(new NoCache()));
+                break;
+
             default:
                 Console::error('Adapter not supported');
                 return;

--- a/bin/tasks/index.php
+++ b/bin/tasks/index.php
@@ -22,8 +22,14 @@ $supported = [
     'mariadb'
 ];
 
+// Check input
 if (!in_array($dbms, $supported)) {
     echo "First argument must be one of: 'mongodb', 'mariadb'";
+    return;
+}
+
+if (!$loadedDB) {
+    echo "Second argument is the name of a filled database";
     return;
 }
 

--- a/bin/tasks/index.php
+++ b/bin/tasks/index.php
@@ -13,8 +13,8 @@ use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 
-$dbms = $argv[1];
-$loadedDB = $argv[2];
+$adapter = $argv[1];
+$collection = $argv[2];
 
 // Implemented databases
 $supported = [
@@ -23,19 +23,19 @@ $supported = [
 ];
 
 // Check input
-if (!in_array($dbms, $supported)) {
+if (!in_array($adapter, $supported)) {
     echo "First argument must be one of: 'mongodb', 'mariadb'";
     return;
 }
 
-if (!$loadedDB) {
+if (!$collection) {
     echo "Second argument is the name of a filled database";
     return;
 }
 
 $database = null;
 
-if ($dbms === 'mongodb') {
+if ($adapter === 'mongodb') {
     $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
     $client = new Client('mongodb://mongo/',
         [
@@ -50,7 +50,7 @@ if ($dbms === 'mongodb') {
     $database = new Database(new MongoDB($client), $cache);
 }
 
-if ($dbms === 'mariadb') {
+if ($adapter === 'mariadb') {
     $dbHost = 'mariadb';
     $dbPort = '3306';
     $dbUser = 'root';
@@ -69,7 +69,7 @@ if ($dbms === 'mariadb') {
     $database = new Database(new MariaDB($pdo), $cache);
 }
 
-$database->setNamespace($loadedDB);
+$database->setNamespace($collection);
 
 echo "Creating indexes\n";
 

--- a/bin/tasks/index.php
+++ b/bin/tasks/index.php
@@ -5,7 +5,7 @@ require_once '/usr/src/code/vendor/autoload.php';
 use Faker\Factory;
 use MongoDB\Client;
 use Utopia\Cache\Cache;
-use Utopia\Cache\Adapter\Redis as RedisAdapter;
+use Utopia\Cache\Adapter\None as NoCache;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
@@ -13,46 +13,58 @@ use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 
-// mongodb
-$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
-$client = new Client('mongodb://mongo/',
-    [
-        'username' => 'root',
-        'password' => 'example',
-    ],
-    $options
-);
+$dbms = $argv[1];
+$loadedDB = $argv[2];
 
-$redis = new Redis();
-$redis->connect('redis', 6379);
-$redis->flushAll();
-$cache = new Cache(new RedisAdapter($redis));
+// Implemented databases
+$supported = [
+    'mongodb',
+    'mariadb'
+];
 
-$database = new Database(new MongoDB($client), $cache);
-$database->setNamespace('myapp_60afec3d936a0');
+if (!in_array($dbms, $supported)) {
+    echo "First argument must be one of: 'mongodb', 'mariadb'";
+    return;
+}
 
+$database = null;
 
-// MariaDB
-// $dbHost = 'mariadb';
-// $dbPort = '3306';
-// $dbUser = 'root';
-// $dbPass = 'password';
+if ($dbms === 'mongodb') {
+    $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+    $client = new Client('mongodb://mongo/',
+        [
+            'username' => 'root',
+            'password' => 'example',
+        ],
+        $options
+    );
 
-// $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
-//     PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-//     PDO::ATTR_TIMEOUT => 3, // Seconds
-//     PDO::ATTR_PERSISTENT => true,
-//     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-//     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-// ]);
+    $cache = new Cache(new NoCache());
 
-// $redis = new Redis();
-// $redis->connect('redis', 6379);
-// $redis->flushAll();
-// $cache = new Cache(new RedisAdapter($redis));
+    $database = new Database(new MongoDB($client), $cache);
+}
 
-// $database = new Database(new MariaDB($pdo), $cache);
-// $database->setNamespace('myapp_60afd9a009280');
+if ($dbms === 'mariadb') {
+    $dbHost = 'mariadb';
+    $dbPort = '3306';
+    $dbUser = 'root';
+    $dbPass = 'password';
+
+    $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+        PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+        PDO::ATTR_TIMEOUT => 3, // Seconds
+        PDO::ATTR_PERSISTENT => true,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+
+    $cache = new Cache(new NoCache());
+
+    $database = new Database(new MariaDB($pdo), $cache);
+}
+
+$database->setNamespace($loadedDB);
+
 
 // Create index
 echo "Creating indexes\n";
@@ -66,7 +78,7 @@ echo "Completed in " . $time . "s\n";
 echo "For query: [created.greater(1262322000), genre.equal('travel')]\n"; # Jan 1, 2010
 
 $start = microtime(true);
-$success = $database->createIndex('articles', 'published', Database::INDEX_KEY, ['created', 'genre'], [], [Database::ORDER_DESC, Database::ORDER_DESC]);
+$success = $database->createIndex('articles', 'createdGenre', Database::INDEX_KEY, ['created', 'genre'], [], [Database::ORDER_DESC, Database::ORDER_DESC]);
 $time = microtime(true) - $start;
 echo "Completed in " . $time . "s\n";
 

--- a/bin/tasks/index.php
+++ b/bin/tasks/index.php
@@ -1,0 +1,86 @@
+<?php
+
+require_once '/usr/src/code/vendor/autoload.php';
+
+use Faker\Factory;
+use MongoDB\Client;
+use Utopia\Cache\Cache;
+use Utopia\Cache\Adapter\Redis as RedisAdapter;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+use Utopia\Database\Adapter\MongoDB;
+use Utopia\Database\Adapter\MariaDB;
+use Utopia\Database\Validator\Authorization;
+
+// mongodb
+$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+$client = new Client('mongodb://mongo/',
+    [
+        'username' => 'root',
+        'password' => 'example',
+    ],
+    $options
+);
+
+$redis = new Redis();
+$redis->connect('redis', 6379);
+$redis->flushAll();
+$cache = new Cache(new RedisAdapter($redis));
+
+$database = new Database(new MongoDB($client), $cache);
+$database->setNamespace('myapp_60afec3d936a0');
+
+
+// MariaDB
+// $dbHost = 'mariadb';
+// $dbPort = '3306';
+// $dbUser = 'root';
+// $dbPass = 'password';
+
+// $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+//     PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+//     PDO::ATTR_TIMEOUT => 3, // Seconds
+//     PDO::ATTR_PERSISTENT => true,
+//     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+//     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+// ]);
+
+// $redis = new Redis();
+// $redis->connect('redis', 6379);
+// $redis->flushAll();
+// $cache = new Cache(new RedisAdapter($redis));
+
+// $database = new Database(new MariaDB($pdo), $cache);
+// $database->setNamespace('myapp_60afd9a009280');
+
+// Create index
+echo "Creating indexes\n";
+
+echo "For query: text.search('Alice')\n";
+$start = microtime(true);
+$success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
+$time = microtime(true) - $start;
+echo "Completed in " . $time . "s\n";
+
+echo "For query: [created.greater(1262322000), genre.equal('travel')]\n"; # Jan 1, 2010
+
+$start = microtime(true);
+$success = $database->createIndex('articles', 'published', Database::INDEX_KEY, ['created', 'genre'], [], [Database::ORDER_DESC, Database::ORDER_DESC]);
+$time = microtime(true) - $start;
+echo "Completed in " . $time . "s\n";
+
+echo "For query: genre.equal('fashion', 'finance', 'sports')\n";
+
+$start = microtime(true);
+$success = $database->createIndex('articles', 'genre', Database::INDEX_KEY, ['genre'], [], [Database::ORDER_ASC]);
+$time = microtime(true) - $start;
+echo "Completed in " . $time . "s\n";
+
+echo "For query: views.greater(100000)\n";
+
+$start = microtime(true);
+$success = $database->createIndex('articles', 'views', Database::INDEX_KEY, ['views'], [], [Database::ORDER_DESC]);
+$time = microtime(true) - $start;
+echo "Completed in " . $time . "s\n";
+

--- a/bin/tasks/index.php
+++ b/bin/tasks/index.php
@@ -71,29 +71,24 @@ if ($dbms === 'mariadb') {
 
 $database->setNamespace($loadedDB);
 
-
-// Create index
 echo "Creating indexes\n";
 
-echo "For query: text.search('Alice')\n";
-$start = microtime(true);
-$success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
-$time = microtime(true) - $start;
-echo "Completed in " . $time . "s\n";
 
 echo "For query: [created.greater(1262322000), genre.equal('travel')]\n"; # Jan 1, 2010
 
 $start = microtime(true);
 $success = $database->createIndex('articles', 'createdGenre', Database::INDEX_KEY, ['created', 'genre'], [], [Database::ORDER_DESC, Database::ORDER_DESC]);
 $time = microtime(true) - $start;
-echo "Completed in " . $time . "s\n";
+echo "Completed in " . $time . "s\n\n";
+
 
 echo "For query: genre.equal('fashion', 'finance', 'sports')\n";
 
 $start = microtime(true);
 $success = $database->createIndex('articles', 'genre', Database::INDEX_KEY, ['genre'], [], [Database::ORDER_ASC]);
 $time = microtime(true) - $start;
-echo "Completed in " . $time . "s\n";
+echo "Completed in " . $time . "s\n\n";
+
 
 echo "For query: views.greater(100000)\n";
 
@@ -102,3 +97,9 @@ $success = $database->createIndex('articles', 'views', Database::INDEX_KEY, ['vi
 $time = microtime(true) - $start;
 echo "Completed in " . $time . "s\n";
 
+
+echo "For query: text.search('Alice')\n";
+$start = microtime(true);
+$success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
+$time = microtime(true) - $start;
+echo "Completed in " . $time . "s\n\n";

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -11,29 +11,51 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Database\Adapter\MongoDB;
+use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 use MongoDB\Client;
 
 // Constants
-$limit = 1000000;
+$limit = 250000;
 
-// DB options
-$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
-$client = new Client('mongodb://mongo/',
-    [
-        'username' => 'root',
-        'password' => 'example',
-    ],
-    $options
-);
+// Mongodb
+// $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+// $client = new Client('mongodb://mongo/',
+//     [
+//         'username' => 'root',
+//         'password' => 'example',
+//     ],
+//     $options
+// );
 
-// init database
+// $redis = new Redis();
+// $redis->connect('redis', 6379);
+// $redis->flushAll();
+// $cache = new Cache(new RedisAdapter($redis));
+
+// $database = new Database(new MongoDB($client), $cache);
+// $database->setNamespace('myapp_'.uniqid());
+
+// MariaDB
+$dbHost = 'mariadb';
+$dbPort = '3306';
+$dbUser = 'root';
+$dbPass = 'password';
+
+$pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+    PDO::ATTR_TIMEOUT => 3, // Seconds
+    PDO::ATTR_PERSISTENT => true,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+
 $redis = new Redis();
 $redis->connect('redis', 6379);
 $redis->flushAll();
 $cache = new Cache(new RedisAdapter($redis));
 
-$database = new Database(new MongoDB($client), $cache);
+$database = new Database(new MariaDB($pdo), $cache);
 $database->setNamespace('myapp_'.uniqid());
 
 // Outline collection schema

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -32,7 +32,7 @@ Co\run(function() use (&$start) {
     , 128);
 
     // Constants
-    $limit = 80000;
+    $limit = 150000;
 
     // Mongodb
     // $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
@@ -72,6 +72,7 @@ Co\run(function() use (&$start) {
 
     $database = new Database(new MariaDB($pdo), $cache);
     $database->setNamespace('myapp_'.$uniqid);
+    echo 'Database created: myapp_'.$uniqid;
 
 
     // Outline collection schema
@@ -91,27 +92,31 @@ Co\run(function() use (&$start) {
     $start = microtime(true);
     echo 'Filling database with ' . $limit . " documents";
 
-    for ($i=0; $i < $limit; $i++) {
+    if ($limit <= 1000) {
+        echo "Please insert > 1000 documents";
+        return;
+    }
+
+    for ($i=0; $i < $limit/1000; $i++) {
         go(function() use ($pool, $faker, $uniqid, $cache) {
             $pdo = $pool->get();
 
             $database = new Database(new MariaDB($pdo), $cache);
             $database->setNamespace('myapp_'.$uniqid);
 
-            $database->createDocument('articles', new Document([
-                // Five random users out of 10,000 get read access
-                '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
-                // Three random users out of 10,000 get write access
-                '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
-                'author' => $faker->name(),
-                'created' => $faker->unixTime(),
-                'text' => $faker->realTextBetween(1000, 4000),
-                'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
-                'views' => $faker->randomNumber(6, false)
-            ]));
-            // if ($i % 5000 === 0) {
-            //     echo '.';
-            // }
+            for ($i=0; $i < 1000; $i++) {
+                $database->createDocument('articles', new Document([
+                    // Five random users out of 10,000 get read access
+                    '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+                    // Three random users out of 10,000 get write access
+                    '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+                    'author' => $faker->name(),
+                    'created' => $faker->unixTime(),
+                    'text' => $faker->realTextBetween(1000, 4000),
+                    'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
+                    'views' => $faker->randomNumber(6, false)
+                ]));
+            }
 
             $pool->put($pdo);
             $database = null;

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -65,29 +65,29 @@ for ($i=0; $i < $limit; $i++) {
 $time = microtime(true) - $start;
 echo "\nCompleted in " . $time . "s\n";
 
-// Create fulltext index
-echo "Creating index";
+// // Create fulltext index
+// echo "Creating index";
 
-$start = microtime(true);
-$success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
-$time = microtime(true) - $start;
+// $start = microtime(true);
+// $success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
+// $time = microtime(true) - $start;
 
-echo "\nCompleted in " . $time . "s\n";
+// echo "\nCompleted in " . $time . "s\n";
 
-// Query documents
-echo "Querying\n";
+// // Query documents
+// echo "Querying\n";
 
-echo "Changing role to 'user4567'\n";
-Authorization::setRole('user4567');
+// echo "Changing role to 'user4567'\n";
+// Authorization::setRole('user4567');
 
-echo "Running query: text.search('time')\n";
+// echo "Running query: text.search('time')\n";
 
-$start = microtime(true);
-$documents = $database->find('articles', [
-    new Query('text', Query::TYPE_SEARCH, ['time']),
-]);
-$time = microtime(true) - $start;
+// $start = microtime(true);
+// $documents = $database->find('articles', [
+//     new Query('text', Query::TYPE_SEARCH, ['time']),
+// ]);
+// $time = microtime(true) - $start;
 
-echo "Found " . count($documents) . " results";
-echo "\nCompleted in " . $time . "s\n";
+// echo "Found " . count($documents) . " results";
+// echo "\nCompleted in " . $time . "s\n";
 

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -19,44 +19,44 @@ use MongoDB\Client;
 $limit = 250000;
 
 // Mongodb
-// $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
-// $client = new Client('mongodb://mongo/',
-//     [
-//         'username' => 'root',
-//         'password' => 'example',
-//     ],
-//     $options
-// );
-
-// $redis = new Redis();
-// $redis->connect('redis', 6379);
-// $redis->flushAll();
-// $cache = new Cache(new RedisAdapter($redis));
-
-// $database = new Database(new MongoDB($client), $cache);
-// $database->setNamespace('myapp_'.uniqid());
-
-// MariaDB
-$dbHost = 'mariadb';
-$dbPort = '3306';
-$dbUser = 'root';
-$dbPass = 'password';
-
-$pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
-    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-    PDO::ATTR_TIMEOUT => 3, // Seconds
-    PDO::ATTR_PERSISTENT => true,
-    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-]);
+$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+$client = new Client('mongodb://mongo/',
+    [
+        'username' => 'root',
+        'password' => 'example',
+    ],
+    $options
+);
 
 $redis = new Redis();
 $redis->connect('redis', 6379);
 $redis->flushAll();
 $cache = new Cache(new RedisAdapter($redis));
 
-$database = new Database(new MariaDB($pdo), $cache);
+$database = new Database(new MongoDB($client), $cache);
 $database->setNamespace('myapp_'.uniqid());
+
+// MariaDB
+// $dbHost = 'mariadb';
+// $dbPort = '3306';
+// $dbUser = 'root';
+// $dbPass = 'password';
+
+// $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+//     PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+//     PDO::ATTR_TIMEOUT => 3, // Seconds
+//     PDO::ATTR_PERSISTENT => true,
+//     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+//     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+// ]);
+
+// $redis = new Redis();
+// $redis->connect('redis', 6379);
+// $redis->flushAll();
+// $cache = new Cache(new RedisAdapter($redis));
+
+// $database = new Database(new MariaDB($pdo), $cache);
+// $database->setNamespace('myapp_'.uniqid());
 
 // Outline collection schema
 $database->create();
@@ -90,30 +90,4 @@ for ($i=0; $i < $limit; $i++) {
 }
 $time = microtime(true) - $start;
 echo "\nCompleted in " . $time . "s\n";
-
-// // Create fulltext index
-// echo "Creating index";
-
-// $start = microtime(true);
-// $success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
-// $time = microtime(true) - $start;
-
-// echo "\nCompleted in " . $time . "s\n";
-
-// // Query documents
-// echo "Querying\n";
-
-// echo "Changing role to 'user4567'\n";
-// Authorization::setRole('user4567');
-
-// echo "Running query: text.search('time')\n";
-
-// $start = microtime(true);
-// $documents = $database->find('articles', [
-//     new Query('text', Query::TYPE_SEARCH, ['time']),
-// ]);
-// $time = microtime(true) - $start;
-
-// echo "Found " . count($documents) . " results";
-// echo "\nCompleted in " . $time . "s\n";
 

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -15,7 +15,7 @@ use Utopia\Database\Validator\Authorization;
 use MongoDB\Client;
 
 // Constants
-$limit = 35000;
+$limit = 1000000;
 
 // DB options
 $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
@@ -47,11 +47,11 @@ $database->createAttribute('articles', 'text', Database::VAR_STRING, 5000, true)
 $faker = Factory::create();
 
 $start = microtime(true);
-echo 'Filling databases';
+echo 'Filling database with ' . $limit . " documents";
 for ($i=0; $i < $limit; $i++) {
     $database->createDocument('articles', new Document([
         // Five random users out of 10,000 get read access
-        '$read' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+        '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
         // Three random users out of 10,000 get write access
         '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
         'author' => $faker->name(),
@@ -77,21 +77,14 @@ echo "\nCompleted in " . $time . "s\n";
 // Query documents
 echo "Querying\n";
 
-$start = microtime(true);
-$documents = $database->find('articles', [
-    new Query('text', Query::TYPE_SEARCH, ['rich and famous']),
-]);
-$time = microtime(true) - $start;
-
-echo "Found " . count($documents) . " results";
-echo "\nCompleted in " . $time . "s\n";
-
-echo "Changing role\n";
+echo "Changing role to 'user4567'\n";
 Authorization::setRole('user4567');
 
+echo "Running query: text.search('time')\n";
+
 $start = microtime(true);
 $documents = $database->find('articles', [
-    new Query('text', Query::TYPE_SEARCH, ['rich and famous']),
+    new Query('text', Query::TYPE_SEARCH, ['time']),
 ]);
 $time = microtime(true) - $start;
 

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -1,0 +1,60 @@
+<?php
+
+require_once '/usr/src/code/vendor/autoload.php';
+
+use Faker\Factory;
+// use Redis;
+// use MongoDB\Client;
+use Utopia\Cache\Cache;
+use Utopia\Cache\Adapter\Redis as RedisAdapter;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Adapter\MongoDB;
+
+// Constants
+$limit = 50000;
+
+// DB options
+$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+$client = new Client('mongodb://mongo/',
+    [
+        'username' => 'root',
+        'password' => 'example',
+    ],
+    $options
+);
+
+// init database
+$redis = new Redis();
+$redis->connect('redis', 6379);
+$redis->flushAll();
+$cache = new Cache(new RedisAdapter($redis));
+
+$database = new Database(new MongoDB($client), $cache);
+$database->setNamespace('myapp_'.uniqid());
+
+// Outline collection schema
+$database->create();
+$database->createCollection('authors');
+$database->createAttribute('authors', 'name', Database::VAR_STRING, 256, true);
+$database->createAttribute('authors', 'address', Database::VAR_STRING, 512, true);
+
+
+// Fill DB
+$faker = Factory::create();
+
+
+
+
+$start = microtime(true);
+echo 'Filling databases';
+for ($i=0; $i < 50000; $i++) {
+    $database->createDocument('authors', new Document([
+        '$read' => ['*'],
+        '$write' => ['*'],
+        'name' => $faker->name(),
+        'address' => $faker->address()
+    ]));
+}
+$end = microtime(true);
+echo 'Completed in ' . ($end - $start) . 's';

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -15,18 +15,18 @@ use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 
-$fill = $argv[1];
+$dbms = $argv[1];
 $limit = $argv[2];
 
 // Implemented databases
-switch ($fill) {
-    case 'mongodb':
-        break;
-    case 'mariadb':
-        break;
-    default:
-        echo "First argument must be one of ".implode(', ', $dbs);
-        return;
+$supported = [
+    'mongodb',
+    'mariadb'
+];
+
+if (!in_array($dbms, $supported)) {
+    echo "First argument must be one of: 'mongodb', 'mariadb'";
+    return;
 }
 
 function createSchema($database) {
@@ -56,7 +56,7 @@ function addArticle($database, $faker) {
 $start = null;
 
 // MariaDB
-if ($argv[1]=== 'mariadb') {
+if ($dbms === 'mariadb') {
     Swoole\Runtime::enableCoroutine();
     Co\run(function() use (&$start, $limit) {
 
@@ -125,7 +125,7 @@ if ($argv[1]=== 'mariadb') {
 }
 
 // MongoDB
-if ($argv[1] === 'mongodb') {
+if ($dbms === 'mongodb') {
     $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
     $client = new Client('mongodb://mongo/',
         [

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -7,7 +7,7 @@ use MongoDB\Client;
 use Swoole\Database\PDOConfig;
 use Swoole\Database\PDOPool;
 use Utopia\Cache\Cache;
-use Utopia\Cache\Adapter\None as NoAdapter;
+use Utopia\Cache\Adapter\None as NoCache;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
@@ -84,7 +84,7 @@ if ($argv[1]=== 'mariadb') {
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
         ]);
 
-        $cache = new Cache(new NoAdapter());
+        $cache = new Cache(new NoCache());
 
         $uniqid = \uniqid();
 
@@ -135,13 +135,13 @@ if ($argv[1] === 'mongodb') {
         $options
     );
 
-    $redis = new Redis();
-    $redis->connect('redis', 6379);
-    $redis->flushAll();
-    $cache = new Cache(new RedisAdapter($redis));
+    $uniqid = \uniqid();
+
+    $cache = new Cache(new NoCache());
 
     $database = new Database(new MongoDB($client), $cache);
-    $database->setNamespace('myapp_'.uniqid());
+    $database->setNamespace('myapp_'.$uniqid);
+    echo 'Database created: myapp_'.$uniqid."\n";
 
     // Outline collection schema
     createSchema($database);

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -25,7 +25,7 @@ Co\run(function() use (&$start) {
             ->withHost('mariadb')
             ->withPort(3306)
             // ->withUnixSocket('/tmp/mysql.sock')
-            ->withDbName('myapp_60afd845470c2')
+            ->withDbName('mysql') // db required just to get started
             ->withCharset('utf8mb4')
             ->withUsername('root')
             ->withPassword('password')

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -15,7 +15,7 @@ use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 
-$dbms = $argv[1];
+$adapter = $argv[1];
 $limit = $argv[2];
 
 // Implemented databases
@@ -24,7 +24,7 @@ $supported = [
     'mariadb'
 ];
 
-if (!in_array($dbms, $supported)) {
+if (!in_array($adapter, $supported)) {
     echo "First argument must be one of: 'mongodb', 'mariadb'";
     return;
 }
@@ -56,7 +56,7 @@ function addArticle($database, $faker) {
 $start = null;
 
 // MariaDB
-if ($dbms === 'mariadb') {
+if ($adapter === 'mariadb') {
     Swoole\Runtime::enableCoroutine();
     Co\run(function() use (&$start, $limit) {
 
@@ -125,7 +125,7 @@ if ($dbms === 'mariadb') {
 }
 
 // MongoDB
-if ($dbms === 'mongodb') {
+if ($adapter === 'mongodb') {
     $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
     $client = new Client('mongodb://mongo/',
         [

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -18,14 +18,14 @@ use Utopia\Database\Validator\Authorization;
 Swoole\Runtime::enableCoroutine();
 
 $start = null;
-Co\run(function() use ($start) {
+Co\run(function() use (&$start) {
 
     $pool = new PDOPool(
         (new PDOConfig())
             ->withHost('mariadb')
             ->withPort(3306)
             // ->withUnixSocket('/tmp/mysql.sock')
-            ->withDbName('myapp_60b0e48f63005')
+            ->withDbName('myapp_60afd845470c2')
             ->withCharset('utf8mb4')
             ->withUsername('root')
             ->withPassword('password')

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -64,6 +64,8 @@ $database->createCollection('articles');
 $database->createAttribute('articles', 'author', Database::VAR_STRING, 256, true);
 $database->createAttribute('articles', 'created', Database::VAR_INTEGER, 0, true);
 $database->createAttribute('articles', 'text', Database::VAR_STRING, 5000, true);
+$database->createAttribute('articles', 'genre', Database::VAR_STRING, 256, true);
+$database->createAttribute('articles', 'views', Database::VAR_INTEGER, 0, true);
 
 // Fill DB
 $faker = Factory::create();
@@ -79,6 +81,8 @@ for ($i=0; $i < $limit; $i++) {
         'author' => $faker->name(),
         'created' => $faker->unixTime(),
         'text' => $faker->realTextBetween(1000, 4000),
+        'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
+        'views' => $faker->randomNumber(6, false)
     ]));
     if ($i % 5000 === 0) {
         echo '.';

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -15,67 +15,21 @@ use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 
-Swoole\Runtime::enableCoroutine();
+$fill = $argv[1];
+$limit = $argv[2];
 
-$start = null;
-Co\run(function() use (&$start) {
+// Implemented databases
+switch ($fill) {
+    case 'mongodb':
+        break;
+    case 'mariadb':
+        break;
+    default:
+        echo "First argument must be one of ".implode(', ', $dbs);
+        return;
+}
 
-    $pool = new PDOPool(
-        (new PDOConfig())
-            ->withHost('mariadb')
-            ->withPort(3306)
-            // ->withUnixSocket('/tmp/mysql.sock')
-            ->withDbName('mysql') // db required just to get started
-            ->withCharset('utf8mb4')
-            ->withUsername('root')
-            ->withPassword('password')
-    , 128);
-
-    // Constants
-    $limit = 150000;
-
-    // Mongodb
-    // $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
-    // $client = new Client('mongodb://mongo/',
-    //     [
-    //         'username' => 'root',
-    //         'password' => 'example',
-    //     ],
-    //     $options
-    // );
-
-    // $redis = new Redis();
-    // $redis->connect('redis', 6379);
-    // $redis->flushAll();
-    // $cache = new Cache(new RedisAdapter($redis));
-
-    // $database = new Database(new MongoDB($client), $cache);
-    // $database->setNamespace('myapp_'.uniqid());
-
-    // MariaDB
-    $dbHost = 'mariadb';
-    $dbPort = '3306';
-    $dbUser = 'root';
-    $dbPass = 'password';
-
-    $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
-        PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-        PDO::ATTR_TIMEOUT => 3, // Seconds
-        PDO::ATTR_PERSISTENT => true,
-        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-    ]);
-
-    $cache = new Cache(new NoAdapter());
-
-    $uniqid = \uniqid();
-
-    $database = new Database(new MariaDB($pdo), $cache);
-    $database->setNamespace('myapp_'.$uniqid);
-    echo 'Database created: myapp_'.$uniqid;
-
-
-    // Outline collection schema
+function createSchema($database) {
     $database->create();
     $database->createCollection('articles');
     $database->createAttribute('articles', 'author', Database::VAR_STRING, 256, true);
@@ -83,47 +37,124 @@ Co\run(function() use (&$start) {
     $database->createAttribute('articles', 'text', Database::VAR_STRING, 5000, true);
     $database->createAttribute('articles', 'genre', Database::VAR_STRING, 256, true);
     $database->createAttribute('articles', 'views', Database::VAR_INTEGER, 0, true);
+}
 
-    $database = null;
+function addArticle($database, $faker) {
+    $database->createDocument('articles', new Document([
+        // Five random users out of 10,000 get read access
+        '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+        // Three random users out of 10,000 get write access
+        '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+        'author' => $faker->name(),
+        'created' => $faker->unixTime(),
+        'text' => $faker->realTextBetween(1000, 4000),
+        'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
+        'views' => $faker->randomNumber(6, false)
+    ]));
+}
+
+$start = null;
+
+// MariaDB
+if ($argv[1]=== 'mariadb') {
+    Swoole\Runtime::enableCoroutine();
+    Co\run(function() use (&$start, $limit) {
+
+        $pool = new PDOPool(
+            (new PDOConfig())
+                ->withHost('mariadb')
+                ->withPort(3306)
+                // ->withUnixSocket('/tmp/mysql.sock')
+                ->withDbName('mysql') // db required just to get started
+                ->withCharset('utf8mb4')
+                ->withUsername('root')
+                ->withPassword('password')
+        , 128);
+
+        $dbHost = 'mariadb';
+        $dbPort = '3306';
+        $dbUser = 'root';
+        $dbPass = 'password';
+
+        $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+            PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+            PDO::ATTR_TIMEOUT => 3, // Seconds
+            PDO::ATTR_PERSISTENT => true,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]);
+
+        $cache = new Cache(new NoAdapter());
+
+        $uniqid = \uniqid();
+
+        $database = new Database(new MariaDB($pdo), $cache);
+        $database->setNamespace('myapp_'.$uniqid);
+        echo 'Database created: myapp_'.$uniqid."\n";
+
+        // Outline collection schema
+        createSchema($database);
+        $database = null; // Unsetting to reclaim connection
+
+        // Init Faker
+        $faker = Factory::create();
+
+        $start = microtime(true);
+        echo 'Filling database with ' . $limit . " documents";
+
+        // A coroutine is assigned per 1000 documents
+        for ($i=0; $i < $limit/1000; $i++) {
+            go(function() use ($pool, $faker, $uniqid, $cache) {
+                $pdo = $pool->get();
+
+                $database = new Database(new MariaDB($pdo), $cache);
+                $database->setNamespace('myapp_'.$uniqid);
+
+                // Each coroutine loads 1000 documents
+                for ($i=0; $i < 1000; $i++) {
+                    addArticle($database, $faker);
+                }
+
+                // Reclaim resources
+                $pool->put($pdo);
+                $database = null;
+            });
+        }
+
+    });
+}
+
+// MongoDB
+if ($argv[1] === 'mongodb') {
+    $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+    $client = new Client('mongodb://mongo/',
+        [
+            'username' => 'root',
+            'password' => 'example',
+        ],
+        $options
+    );
+
+    $redis = new Redis();
+    $redis->connect('redis', 6379);
+    $redis->flushAll();
+    $cache = new Cache(new RedisAdapter($redis));
+
+    $database = new Database(new MongoDB($client), $cache);
+    $database->setNamespace('myapp_'.uniqid());
+
+    // Outline collection schema
+    createSchema($database);
 
     // Fill DB
     $faker = Factory::create();
 
     $start = microtime(true);
     echo 'Filling database with ' . $limit . " documents";
-
-    if ($limit <= 1000) {
-        echo "Please insert > 1000 documents";
-        return;
+    for ($i=0; $i < $limit; $i++) {
+        addArticle($database, $faker);
     }
-
-    for ($i=0; $i < $limit/1000; $i++) {
-        go(function() use ($pool, $faker, $uniqid, $cache) {
-            $pdo = $pool->get();
-
-            $database = new Database(new MariaDB($pdo), $cache);
-            $database->setNamespace('myapp_'.$uniqid);
-
-            for ($i=0; $i < 1000; $i++) {
-                $database->createDocument('articles', new Document([
-                    // Five random users out of 10,000 get read access
-                    '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
-                    // Three random users out of 10,000 get write access
-                    '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
-                    'author' => $faker->name(),
-                    'created' => $faker->unixTime(),
-                    'text' => $faker->realTextBetween(1000, 4000),
-                    'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
-                    'views' => $faker->randomNumber(6, false)
-                ]));
-            }
-
-            $pool->put($pdo);
-            $database = null;
-        });
-    }
-
-});
+}
 
 $time = microtime(true) - $start;
 echo "\nCompleted in " . $time . "s\n";

--- a/bin/tasks/load.php
+++ b/bin/tasks/load.php
@@ -3,91 +3,122 @@
 require_once '/usr/src/code/vendor/autoload.php';
 
 use Faker\Factory;
-// use Redis;
-// use MongoDB\Client;
+use MongoDB\Client;
+use Swoole\Database\PDOConfig;
+use Swoole\Database\PDOPool;
 use Utopia\Cache\Cache;
-use Utopia\Cache\Adapter\Redis as RedisAdapter;
+use Utopia\Cache\Adapter\None as NoAdapter;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
-use MongoDB\Client;
 
-// Constants
-$limit = 250000;
+Swoole\Runtime::enableCoroutine();
 
-// Mongodb
-$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
-$client = new Client('mongodb://mongo/',
-    [
-        'username' => 'root',
-        'password' => 'example',
-    ],
-    $options
-);
+$start = null;
+Co\run(function() use ($start) {
 
-$redis = new Redis();
-$redis->connect('redis', 6379);
-$redis->flushAll();
-$cache = new Cache(new RedisAdapter($redis));
+    $pool = new PDOPool(
+        (new PDOConfig())
+            ->withHost('mariadb')
+            ->withPort(3306)
+            // ->withUnixSocket('/tmp/mysql.sock')
+            ->withDbName('myapp_60b0e48f63005')
+            ->withCharset('utf8mb4')
+            ->withUsername('root')
+            ->withPassword('password')
+    , 128);
 
-$database = new Database(new MongoDB($client), $cache);
-$database->setNamespace('myapp_'.uniqid());
+    // Constants
+    $limit = 80000;
 
-// MariaDB
-// $dbHost = 'mariadb';
-// $dbPort = '3306';
-// $dbUser = 'root';
-// $dbPass = 'password';
+    // Mongodb
+    // $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+    // $client = new Client('mongodb://mongo/',
+    //     [
+    //         'username' => 'root',
+    //         'password' => 'example',
+    //     ],
+    //     $options
+    // );
 
-// $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
-//     PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-//     PDO::ATTR_TIMEOUT => 3, // Seconds
-//     PDO::ATTR_PERSISTENT => true,
-//     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-//     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-// ]);
+    // $redis = new Redis();
+    // $redis->connect('redis', 6379);
+    // $redis->flushAll();
+    // $cache = new Cache(new RedisAdapter($redis));
 
-// $redis = new Redis();
-// $redis->connect('redis', 6379);
-// $redis->flushAll();
-// $cache = new Cache(new RedisAdapter($redis));
+    // $database = new Database(new MongoDB($client), $cache);
+    // $database->setNamespace('myapp_'.uniqid());
 
-// $database = new Database(new MariaDB($pdo), $cache);
-// $database->setNamespace('myapp_'.uniqid());
+    // MariaDB
+    $dbHost = 'mariadb';
+    $dbPort = '3306';
+    $dbUser = 'root';
+    $dbPass = 'password';
 
-// Outline collection schema
-$database->create();
-$database->createCollection('articles');
-$database->createAttribute('articles', 'author', Database::VAR_STRING, 256, true);
-$database->createAttribute('articles', 'created', Database::VAR_INTEGER, 0, true);
-$database->createAttribute('articles', 'text', Database::VAR_STRING, 5000, true);
-$database->createAttribute('articles', 'genre', Database::VAR_STRING, 256, true);
-$database->createAttribute('articles', 'views', Database::VAR_INTEGER, 0, true);
+    $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+        PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+        PDO::ATTR_TIMEOUT => 3, // Seconds
+        PDO::ATTR_PERSISTENT => true,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
 
-// Fill DB
-$faker = Factory::create();
+    $cache = new Cache(new NoAdapter());
 
-$start = microtime(true);
-echo 'Filling database with ' . $limit . " documents";
-for ($i=0; $i < $limit; $i++) {
-    $database->createDocument('articles', new Document([
-        // Five random users out of 10,000 get read access
-        '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
-        // Three random users out of 10,000 get write access
-        '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
-        'author' => $faker->name(),
-        'created' => $faker->unixTime(),
-        'text' => $faker->realTextBetween(1000, 4000),
-        'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
-        'views' => $faker->randomNumber(6, false)
-    ]));
-    if ($i % 5000 === 0) {
-        echo '.';
+    $uniqid = \uniqid();
+
+    $database = new Database(new MariaDB($pdo), $cache);
+    $database->setNamespace('myapp_'.$uniqid);
+
+
+    // Outline collection schema
+    $database->create();
+    $database->createCollection('articles');
+    $database->createAttribute('articles', 'author', Database::VAR_STRING, 256, true);
+    $database->createAttribute('articles', 'created', Database::VAR_INTEGER, 0, true);
+    $database->createAttribute('articles', 'text', Database::VAR_STRING, 5000, true);
+    $database->createAttribute('articles', 'genre', Database::VAR_STRING, 256, true);
+    $database->createAttribute('articles', 'views', Database::VAR_INTEGER, 0, true);
+
+    $database = null;
+
+    // Fill DB
+    $faker = Factory::create();
+
+    $start = microtime(true);
+    echo 'Filling database with ' . $limit . " documents";
+
+    for ($i=0; $i < $limit; $i++) {
+        go(function() use ($pool, $faker, $uniqid, $cache) {
+            $pdo = $pool->get();
+
+            $database = new Database(new MariaDB($pdo), $cache);
+            $database->setNamespace('myapp_'.$uniqid);
+
+            $database->createDocument('articles', new Document([
+                // Five random users out of 10,000 get read access
+                '$read' => [$faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+                // Three random users out of 10,000 get write access
+                '$write' => ['*', $faker->numerify('user####'), $faker->numerify('user####'), $faker->numerify('user####')],
+                'author' => $faker->name(),
+                'created' => $faker->unixTime(),
+                'text' => $faker->realTextBetween(1000, 4000),
+                'genre' => $faker->randomElement(['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance']),
+                'views' => $faker->randomNumber(6, false)
+            ]));
+            // if ($i % 5000 === 0) {
+            //     echo '.';
+            // }
+
+            $pool->put($pdo);
+            $database = null;
+        });
     }
-}
+
+});
+
 $time = microtime(true) - $start;
 echo "\nCompleted in " . $time . "s\n";
-

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -17,7 +17,6 @@ use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Validator\Numeric;
 use Utopia\Validator\Text;
-
 $cli
     ->task('query')
     ->desc('Query mock data')
@@ -104,12 +103,12 @@ $cli
             'results' => runQueries($database, $limit)
         ];
 
-        if (!file_exists('results')) {
-            mkdir('results', 0777, true);
+        if (!file_exists('bin/view/results')) {
+            mkdir('bin/view/results', 0777, true);
         }
 
         $time = time();
-        $f = fopen("results/{$adapter}_{$name}_{$limit}_{$time}.json", 'w');
+        $f = fopen("bin/view/results/{$adapter}_{$name}_{$limit}_{$time}.json", 'w');
         fwrite($f, json_encode($report));
         fclose($f);
     });

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -15,9 +15,6 @@ use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 use MongoDB\Client;
 
-// Constants
-$limit = 1000000;
-
 // mongodb
 $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
 $client = new Client('mongodb://mongo/',
@@ -75,29 +72,78 @@ $database->setNamespace('myapp_60ad4d52a7c01');
 // echo "\nCompleted in " . $time . "s\n";
 
 // Query documents
-echo "Querying\n";
 
-echo "Changing role to 'user4869'\n";
-Authorization::setRole('user4869');
 
-echo "Running query: text.search('Alice')\n";
+function runQueries($database, $limit = 25) {
+    echo "Running query: text.search('Alice')\n";
 
-$start = microtime(true);
-$documents = $database->find('articles', [
-    new Query('text', Query::TYPE_SEARCH, ['Alice']),
-], 25);
-$time = microtime(true) - $start;
+    $start = microtime(true);
+    $documents = $database->find('articles', [
+        new Query('text', Query::TYPE_SEARCH, ['Alice']),
+    ], $limit);
+    $time = microtime(true) - $start;
 
-echo "Found " . count($documents) . " results";
-echo "\nCompleted in " . $time . "s\n";
+    echo "Found " . count($documents) . " results";
+    echo "\nCompleted in " . $time . "s\n";
 
-echo "Running query: created.greater('1262322000')\n"; # Jan 1, 2010
+    echo "Running query: created.greater('1262322000')\n"; # Jan 1, 2010
 
-$start = microtime(true);
-$documents = $database->find('articles', [
-    new Query('created', Query::TYPE_GREATER, [1262322000]),
-], 25);
-$time = microtime(true) - $start;
+    $start = microtime(true);
+    $documents = $database->find('articles', [
+        new Query('created', Query::TYPE_GREATER, [1262322000]),
+    ], $limit);
+    $time = microtime(true) - $start;
 
-echo "Found " . count($documents) . " results";
-echo "\nCompleted in " . $time . "s\n";
+    echo "Found " . count($documents) . " results";
+    echo "\nCompleted in " . $time . "s\n";
+    sleep(1);
+}
+
+$faker = Factory::create();
+
+$user = $faker->numerify('user####');
+echo "Changing role to '" . $user . "'\n";
+Authorization::setRole($user);
+
+runQueries($database);
+
+$count = 100;
+echo "Randomly generating " . $count . " roles\n";
+
+
+for ($i=0; $i < $count; $i++) {
+    Authorization::setRole($faker->numerify('user####'));
+}
+echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+runQueries($database);
+
+$count = 400;
+echo "Randomly generating an additional " . $count . " roles\n";
+
+for ($i=0; $i < $count; $i++) {
+    Authorization::setRole($faker->numerify('user####'));
+}
+
+echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+runQueries($database);
+
+$count = 500;
+echo "Randomly generating an additional " . $count . " roles\n";
+
+for ($i=0; $i < $count; $i++) {
+    Authorization::setRole($faker->numerify('user####'));
+}
+
+echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+runQueries($database);
+
+$count = 1000;
+echo "Randomly generating an additional " . $count . " roles\n";
+
+for ($i=0; $i < $count; $i++) {
+    Authorization::setRole($faker->numerify('user####'));
+}
+
+echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+runQueries($database);
+

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -31,7 +31,7 @@ $redis->flushAll();
 $cache = new Cache(new RedisAdapter($redis));
 
 $database = new Database(new MongoDB($client), $cache);
-$database->setNamespace('myapp_60ad4d52a7c01');
+$database->setNamespace('myapp_60afec3d936a0');
 
 
 // MariaDB
@@ -53,8 +53,11 @@ $database->setNamespace('myapp_60ad4d52a7c01');
 // $redis->flushAll();
 // $cache = new Cache(new RedisAdapter($redis));
 
+// /**
+//  * @var Database
+//  */
 // $database = new Database(new MariaDB($pdo), $cache);
-// $database->setNamespace('myapp_60ae724abe58b');
+// $database->setNamespace('myapp_60afd9a009280');
 
 // Query documents
 
@@ -62,25 +65,59 @@ $database->setNamespace('myapp_60ad4d52a7c01');
 function runQueries($database, $limit = 25) {
     echo "Running query: text.search('Alice')\n";
 
+    /**
+     * @var Document[]
+     */
+    $documents = null;
+
     $start = microtime(true);
     $documents = $database->find('articles', [
         new Query('text', Query::TYPE_SEARCH, ['Alice']),
+        // new Query('author', Query::TYPE_SEARCH, ['Alice']),
     ], $limit);
     $time = microtime(true) - $start;
 
     echo "Found " . count($documents) . " results";
     echo "\nCompleted in " . $time . "s\n";
 
-    echo "Running query: created.greater('1262322000')\n"; # Jan 1, 2010
+
+    echo "Running query: [created.greater(1262322000), genre.equal('travel')]\n"; # Jan 1, 2010
 
     $start = microtime(true);
     $documents = $database->find('articles', [
         new Query('created', Query::TYPE_GREATER, [1262322000]),
+        new Query('genre', Query::TYPE_EQUAL, ['travel']),
     ], $limit);
     $time = microtime(true) - $start;
 
     echo "Found " . count($documents) . " results";
     echo "\nCompleted in " . $time . "s\n";
+
+
+    echo "Running query: genre.equal('fashion', 'finance', 'sports')\n";
+
+    $start = microtime(true);
+    $documents = $database->find('articles', [
+        new Query('genre', Query::TYPE_EQUAL, ['fashion', 'finance', 'sports']),
+    ], $limit);
+    $time = microtime(true) - $start;
+
+    echo "Found " . count($documents) . " results";
+    echo "\nCompleted in " . $time . "s\n";
+
+
+    echo "Running query: views.greater(100000)\n";
+
+    $start = microtime(true);
+    $documents = $database->find('articles', [
+        new Query('views', Query::TYPE_GREATER, [100000]),
+    ], $limit);
+    $time = microtime(true) - $start;
+
+    echo "Found " . count($documents) . " results";
+    echo "\nCompleted in " . $time . "s\n";
+
+
     sleep(1);
 }
 

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -36,18 +36,26 @@ $cache = new Cache(new RedisAdapter($redis));
 $database = new Database(new MongoDB($client), $cache);
 $database->setNamespace('myapp_60ad50d614c60');
 
+echo "Creating index";
+
+$start = microtime(true);
+$success = $database->createIndex('articles', 'published', Database::INDEX_KEY, ['created'], [], [Database::ORDER_DESC]);
+$time = microtime(true) - $start;
+
+echo "\nCompleted in " . $time . "s\n";
+
 // Query documents
 echo "Querying\n";
 
-echo "Changing role to 'user4567'\n";
-Authorization::setRole('user4567');
+echo "Changing role to 'user4869'\n";
+Authorization::setRole('user4869');
 
-echo "Running query: text.search('time')\n";
+echo "Running query: text.search('into the woods')\n";
 
 $start = microtime(true);
 $documents = $database->find('articles', [
-    // new Query('text', Query::TYPE_SEARCH, ['time']),
-]);
+    new Query('text', Query::TYPE_SEARCH, ['cheshire cat']), # Wed May 26 2010 00:52:00 GMT+0000
+], 1000);
 $time = microtime(true) - $start;
 
 echo "Found " . count($documents) . " results";

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -117,19 +117,19 @@ function runQueries($database, $limit) {
     $results = [];
     // Recent travel blogs
     $query = ["created.greater(1262322000)", "genre.equal('travel')"];
-    $results[] = runQuery($query, $database, $limit, $results);
+    $results[] = runQuery($query, $database, $limit);
 
     // Favorite genres
     $query = ["genre.equal('fashion, 'finance', 'sports')"];
-    $results[] = runQuery($query, $database, $limit, $results);
+    $results[] = runQuery($query, $database, $limit);
 
     // Popular posts
     $query = ["views.greater(100000)"];
-    $results[] = runQuery($query, $database, $limit, $results);
+    $results[] = runQuery($query, $database, $limit);
 
     // Fulltext search
     $query = ["text.search('Alice')"];
-    $results[] = runQuery($query, $database, $limit, $results);
+    $results[] = runQuery($query, $database, $limit);
 
     return $results;
 }
@@ -141,7 +141,7 @@ function addRoles($faker, $count) {
     return count(Authorization::getRoles());
 }
 
-function runQuery($query, $database, $limit, $results) {
+function runQuery($query, $database, $limit) {
     Console::log('Running query: ['.implode(', ', $query).']');
     $query = array_map(function($q) {
         return Query::parse($q);
@@ -151,10 +151,5 @@ function runQuery($query, $database, $limit, $results) {
     $documents = $database->find('articles', $query, $limit);
     $time = microtime(true) - $start;
     Console::success("{$time} s");
-    $results = [
-        'query' => $query,
-        'time' => $time,
-        'limit' => $limit,
-    ];
-    return $results;
+    return $time;
 }

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -15,6 +15,7 @@ use Utopia\Database\Validator\Authorization;
 
 $dbms = $argv[1];
 $loadedDB = $argv[2];
+$limit = $argv[3];
 
 // Implemented databases
 $supported = [
@@ -31,6 +32,11 @@ if (!in_array($dbms, $supported)) {
 if (!$loadedDB) {
     echo "Second argument is the name of a filled database";
     return;
+}
+
+if (!isset($limit)) {
+    echo "Using default limit of 25";
+    $limit = 25;
 }
 
 $database = null;
@@ -71,7 +77,7 @@ if ($dbms === 'mariadb') {
 
 $database->setNamespace($loadedDB);
 
-function runQueries($database, $limit = 25) {
+function runQueries($database, $limit) {
     /**
      * @var Document[]
      */
@@ -88,8 +94,8 @@ function runQueries($database, $limit = 25) {
     ], $limit);
     $time = microtime(true) - $start;
 
-    echo "Found " . count($documents) . " results";
-    echo "\nCompleted in " . $time . "s\n";
+    echo "Found " . count($documents) . " results\n";
+    echo $time." s\n";
 
 
     // Favorite genres
@@ -101,8 +107,8 @@ function runQueries($database, $limit = 25) {
     ], $limit);
     $time = microtime(true) - $start;
 
-    echo "Found " . count($documents) . " results";
-    echo "\nCompleted in " . $time . "s\n";
+    echo "Found " . count($documents) . " results\n";
+    echo $time." s\n";
 
 
     // Popular posts
@@ -138,44 +144,44 @@ $user = $faker->numerify('user####');
 echo "Changing role to '" . $user . "'\n";
 Authorization::setRole($user);
 
-runQueries($database);
+runQueries($database, $limit);
 
+// add another $count roles
 $count = 100;
-echo "Randomly generating " . $count . " roles\n";
 
 for ($i=0; $i < $count; $i++) {
     Authorization::setRole($faker->numerify('user####'));
 }
 echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
-runQueries($database);
+runQueries($database, $limit);
 
+// add another $count roles
 $count = 400;
-echo "Randomly generating an additional " . $count . " roles\n";
 
 for ($i=0; $i < $count; $i++) {
     Authorization::setRole($faker->numerify('user####'));
 }
 
 echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
-runQueries($database);
+runQueries($database, $limit);
 
+// add another $count roles
 $count = 500;
-echo "Randomly generating an additional " . $count . " roles\n";
 
 for ($i=0; $i < $count; $i++) {
     Authorization::setRole($faker->numerify('user####'));
 }
 
 echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
-runQueries($database);
+runQueries($database, $limit);
 
+// add another $count roles
 $count = 1000;
-echo "Randomly generating an additional " . $count . " roles\n";
 
 for ($i=0; $i < $count; $i++) {
     Authorization::setRole($faker->numerify('user####'));
 }
 
 echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
-runQueries($database);
+runQueries($database, $limit);
 

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -85,67 +85,37 @@ $cli
     });
 
 function runQueries($database, $limit) {
-    /**
-     * @var Document[]
-     */
-    $documents = null;
-
     // Recent travel blogs
-    echo "Running query: [created.greater(1262322000), genre.equal('travel')]\n"; # Jan 1, 2010
-
-    $start = microtime(true);
-    $documents = $database->find('articles', [
-        new Query('created', Query::TYPE_GREATER, [1262322000]),
-        new Query('genre', Query::TYPE_EQUAL, ['travel']),
-    ], $limit);
-    $time = microtime(true) - $start;
-
-    echo "Found " . count($documents) . " results\n";
-    echo $time." s\n";
-
+    $query = ["created.greater(1262322000)", "genre.equal('travel')"];
+    runQuery($query, $database, $limit);
 
     // Favorite genres
-    echo "Running query: genre.equal('fashion', 'finance', 'sports')\n";
-
-    $start = microtime(true);
-    $documents = $database->find('articles', [
-        new Query('genre', Query::TYPE_EQUAL, ['fashion', 'finance', 'sports']),
-    ], $limit);
-    $time = microtime(true) - $start;
-
-    echo "Found " . count($documents) . " results\n";
-    echo $time." s\n";
-
+    $query = ["genre.equal('fashion, 'finance', 'sports')"];
+    runQuery($query, $database, $limit);
 
     // Popular posts
-    echo "Running query: views.greater(100000)\n";
+    $query = ["views.greater(100000)"];
+    runQuery($query, $database, $limit);
 
-    $start = microtime(true);
-    $documents = $database->find('articles', [
-        new Query('views', Query::TYPE_GREATER, [100000]),
-    ], $limit);
-    $time = microtime(true) - $start;
-
-    echo "Found " . count($documents) . " results";
-    echo "\nCompleted in " . $time . "s\n";
-
-
-    // Fulltext Search
-    echo "Running query: text.search('Alice')\n";
-
-    $start = microtime(true);
-    $documents = $database->find('articles', [
-        new Query('text', Query::TYPE_SEARCH, ['Alice']),
-        // new Query('author', Query::TYPE_SEARCH, ['Alice']),
-    ], $limit);
-    $time = microtime(true) - $start;
-
-    echo "Found " . count($documents) . " results";
-    echo "\nCompleted in " . $time . "s\n";
+    // Fulltext search
+    $query = ["text.search('Alice')"];
+    runQuery($query, $database, $limit);
 }
 
 function addRoles($faker, $count) {
     for ($i=0; $i < $count; $i++) {
         Authorization::setRole($faker->numerify('user####'));
     }
+}
+
+function runQuery($query, $database, $limit) {
+    Console::log('Running query: ['.implode(', ', $query).']');
+    $query = array_map(function($q) {
+        return Query::parse($q);
+    }, $query);
+
+    $start = microtime(true);
+    $documents = $database->find('articles', $query, $limit);
+    $time = microtime(true) - $start;
+    Console::success("{$time} s");
 }

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -56,21 +56,6 @@ $database->setNamespace('myapp_60ad4d52a7c01');
 // $database = new Database(new MariaDB($pdo), $cache);
 // $database->setNamespace('myapp_60ae724abe58b');
 
-// Create index
-// echo "Creating indexes";
-
-// $start = microtime(true);
-// $success = $database->createIndex('articles', 'fulltextsearch', Database::INDEX_FULLTEXT, ['text']);
-// $time = microtime(true) - $start;
-
-// echo "\nCompleted in " . $time . "s\n";
-
-// $start = microtime(true);
-// $success = $database->createIndex('articles', 'published', Database::INDEX_KEY, ['created'], [], [Database::ORDER_DESC]);
-// $time = microtime(true) - $start;
-
-// echo "\nCompleted in " . $time . "s\n";
-
 // Query documents
 
 

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -1,0 +1,55 @@
+<?php
+
+require_once '/usr/src/code/vendor/autoload.php';
+
+use Faker\Factory;
+// use Redis;
+// use MongoDB\Client;
+use Utopia\Cache\Cache;
+use Utopia\Cache\Adapter\Redis as RedisAdapter;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+use Utopia\Database\Adapter\MongoDB;
+use Utopia\Database\Validator\Authorization;
+use MongoDB\Client;
+
+// Constants
+$limit = 1000000;
+
+// DB options
+$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+$client = new Client('mongodb://mongo/',
+    [
+        'username' => 'root',
+        'password' => 'example',
+    ],
+    $options
+);
+
+// init database
+$redis = new Redis();
+$redis->connect('redis', 6379);
+$redis->flushAll();
+$cache = new Cache(new RedisAdapter($redis));
+
+$database = new Database(new MongoDB($client), $cache);
+$database->setNamespace('myapp_60ad50d614c60');
+
+// Query documents
+echo "Querying\n";
+
+echo "Changing role to 'user4567'\n";
+Authorization::setRole('user4567');
+
+echo "Running query: text.search('time')\n";
+
+$start = microtime(true);
+$documents = $database->find('articles', [
+    // new Query('text', Query::TYPE_SEARCH, ['time']),
+]);
+$time = microtime(true) - $start;
+
+echo "Found " . count($documents) . " results";
+echo "\nCompleted in " . $time . "s\n";
+

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -4,7 +4,7 @@ require_once '/usr/src/code/vendor/autoload.php';
 
 use Faker\Factory;
 // use Redis;
-// use MongoDB\Client;
+use MongoDB\Client;
 use Utopia\Cache\Cache;
 use Utopia\Cache\Adapter\Redis as RedisAdapter;
 use Utopia\Database\Database;
@@ -13,51 +13,50 @@ use Utopia\Database\Query;
 use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
-use MongoDB\Client;
 
 // mongodb
-$options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
-$client = new Client('mongodb://mongo/',
-    [
-        'username' => 'root',
-        'password' => 'example',
-    ],
-    $options
-);
-
-$redis = new Redis();
-$redis->connect('redis', 6379);
-$redis->flushAll();
-$cache = new Cache(new RedisAdapter($redis));
-
-$database = new Database(new MongoDB($client), $cache);
-$database->setNamespace('myapp_60afec3d936a0');
-
-
-// MariaDB
-// $dbHost = 'mariadb';
-// $dbPort = '3306';
-// $dbUser = 'root';
-// $dbPass = 'password';
-
-// $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
-//     PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
-//     PDO::ATTR_TIMEOUT => 3, // Seconds
-//     PDO::ATTR_PERSISTENT => true,
-//     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-//     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-// ]);
+// $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
+// $client = new Client('mongodb://mongo/',
+//     [
+//         'username' => 'root',
+//         'password' => 'example',
+//     ],
+//     $options
+// );
 
 // $redis = new Redis();
 // $redis->connect('redis', 6379);
 // $redis->flushAll();
 // $cache = new Cache(new RedisAdapter($redis));
 
-// /**
-//  * @var Database
-//  */
-// $database = new Database(new MariaDB($pdo), $cache);
-// $database->setNamespace('myapp_60afd9a009280');
+// $database = new Database(new MongoDB($client), $cache);
+// $database->setNamespace('myapp_60afec3d936a0');
+
+
+// MariaDB
+$dbHost = 'mariadb';
+$dbPort = '3306';
+$dbUser = 'root';
+$dbPass = 'password';
+
+$pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+    PDO::ATTR_TIMEOUT => 3, // Seconds
+    PDO::ATTR_PERSISTENT => true,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+]);
+
+$redis = new Redis();
+$redis->connect('redis', 6379);
+$redis->flushAll();
+$cache = new Cache(new RedisAdapter($redis));
+
+/**
+ * @var Database
+ */
+$database = new Database(new MariaDB($pdo), $cache);
+$database->setNamespace('myapp_60b0108cf2fbe');
 
 // Query documents
 
@@ -72,7 +71,7 @@ function runQueries($database, $limit = 25) {
 
     $start = microtime(true);
     $documents = $database->find('articles', [
-        new Query('text', Query::TYPE_SEARCH, ['Alice']),
+        // new Query('text', Query::TYPE_SEARCH, ['Alice']),
         // new Query('author', Query::TYPE_SEARCH, ['Alice']),
     ], $limit);
     $time = microtime(true) - $start;

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -57,6 +57,23 @@ $cli
                 $database = new Database(new MariaDB($pdo), new Cache(new NoCache()));
                 break;
 
+            case 'mysql':
+                $dbHost = 'mysql';
+                $dbPort = '3307';
+                $dbUser = 'root';
+                $dbPass = 'password';
+
+                $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
+                    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                    PDO::ATTR_TIMEOUT => 3, // Seconds
+                    PDO::ATTR_PERSISTENT => true,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                ]);
+
+                $database = new Database(new MariaDB($pdo), new Cache(new NoCache()));
+                break;
+
             default:
                 Console::error('Adapter not supported');
                 return;

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -13,8 +13,8 @@ use Utopia\Database\Adapter\MongoDB;
 use Utopia\Database\Adapter\MariaDB;
 use Utopia\Database\Validator\Authorization;
 
-$dbms = $argv[1];
-$loadedDB = $argv[2];
+$adapter = $argv[1];
+$collection = $argv[2];
 $limit = $argv[3];
 
 // Implemented databases
@@ -24,12 +24,12 @@ $supported = [
 ];
 
 // Check input
-if (!in_array($dbms, $supported)) {
+if (!in_array($adapter, $supported)) {
     echo "First argument must be one of: 'mongodb', 'mariadb'";
     return;
 }
 
-if (!$loadedDB) {
+if (!$collection) {
     echo "Second argument is the name of a filled database";
     return;
 }
@@ -41,7 +41,7 @@ if (!isset($limit)) {
 
 $database = null;
 
-if ($dbms === 'mongodb') {
+if ($adapter === 'mongodb') {
     $options = ["typeMap" => ['root' => 'array', 'document' => 'array', 'array' => 'array']];
     $client = new Client('mongodb://mongo/',
         [
@@ -56,7 +56,7 @@ if ($dbms === 'mongodb') {
     $database = new Database(new MongoDB($client), $cache);
 }
 
-if ($dbms === 'mariadb') {
+if ($adapter === 'mariadb') {
     $dbHost = 'mariadb';
     $dbPort = '3306';
     $dbUser = 'root';
@@ -75,7 +75,7 @@ if ($dbms === 'mariadb') {
     $database = new Database(new MariaDB($pdo), $cache);
 }
 
-$database->setNamespace($loadedDB);
+$database->setNamespace($collection);
 
 function runQueries($database, $limit) {
     /**

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -67,55 +67,21 @@ $cli
 
         $database->setNamespace($name);
 
-
         $faker = Factory::create();
-
-        $user = $faker->numerify('user####');
-        echo "Changing role to '" . $user . "'\n";
-        Authorization::setRole($user);
-
+        addRoles($faker, 1);
         runQueries($database, $limit);
 
-        // add another $count roles
-        $count = 100;
-
-        for ($i=0; $i < $count; $i++) {
-            Authorization::setRole($faker->numerify('user####'));
-        }
-        echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+        addRoles($faker, 100);
         runQueries($database, $limit);
 
-        // add another $count roles
-        $count = 400;
-
-        for ($i=0; $i < $count; $i++) {
-            Authorization::setRole($faker->numerify('user####'));
-        }
-
-        echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+        addRoles($faker, 400);
         runQueries($database, $limit);
 
-        // add another $count roles
-        $count = 500;
-
-        for ($i=0; $i < $count; $i++) {
-            Authorization::setRole($faker->numerify('user####'));
-        }
-
-        echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+        addRoles($faker, 500);
         runQueries($database, $limit);
 
-        // add another $count roles
-        $count = 1000;
-
-        for ($i=0; $i < $count; $i++) {
-            Authorization::setRole($faker->numerify('user####'));
-        }
-
-        echo "\nWith " . count(Authorization::getRoles()) . " roles: \n";
+        addRoles($faker, 1000);
         runQueries($database, $limit);
-
-
     });
 
 function runQueries($database, $limit) {
@@ -123,7 +89,6 @@ function runQueries($database, $limit) {
      * @var Document[]
      */
     $documents = null;
-
 
     // Recent travel blogs
     echo "Running query: [created.greater(1262322000), genre.equal('travel')]\n"; # Jan 1, 2010
@@ -179,3 +144,8 @@ function runQueries($database, $limit) {
     echo "\nCompleted in " . $time . "s\n";
 }
 
+function addRoles($faker, $count) {
+    for ($i=0; $i < $count; $i++) {
+        Authorization::setRole($faker->numerify('user####'));
+    }
+}

--- a/bin/tasks/query.php
+++ b/bin/tasks/query.php
@@ -68,19 +68,25 @@ $cli
         $database->setNamespace($name);
 
         $faker = Factory::create();
+
         addRoles($faker, 1);
+        Console::info("\n".count(Authorization::getRoles())." roles:");
         runQueries($database, $limit);
 
         addRoles($faker, 100);
+        Console::info("\n".count(Authorization::getRoles())." roles:");
         runQueries($database, $limit);
 
         addRoles($faker, 400);
+        Console::info("\n".count(Authorization::getRoles())." roles:");
         runQueries($database, $limit);
 
         addRoles($faker, 500);
+        Console::info("\n".count(Authorization::getRoles())." roles:");
         runQueries($database, $limit);
 
         addRoles($faker, 1000);
+        Console::info("\n".count(Authorization::getRoles())." roles:");
         runQueries($database, $limit);
     });
 

--- a/bin/view/index.php
+++ b/bin/view/index.php
@@ -20,17 +20,21 @@
     <div id="datatables" class="datatables">
         <table v-for="n in 4" :key="n">
             <tr>
-                <th colspan="5">{{ queries[n-1] }}</th>
+                <!-- v-for is base 1 index  -->
+                <th colspan="6">{{ queries[n-1] }}</th>
             </tr>
             <tr>
+                <th></th> 
                 <th>1 role</th>
                 <th>100 roles</th>
                 <th>500 roles</th>
                 <th>1000 roles</th>
                 <th>2000 roles</th>
             </tr>
-            <tr v-for="result in results" :key="result.name">
-                <td v-for="set in result.data">{{ set.results[n-1].toFixed(4) }}</td>
+            <tr v-for="(result, index) in results" :key="result.name" v-bind:style="{ backgroundColor: colors[index].table }">
+                <!-- grab just the timestamp from result.name -->
+                <td> {{ result.name.split("_")[3] }}</td>
+                <td v-for="set in result.data">{{ set.results[n-1].toFixed(4) }} s</td>
             </tr>
         </table>
     </div>
@@ -55,20 +59,39 @@ console.log(results)
 
 const colors = [
     {
-        line: "rgb(0, 184, 148)",
-        fill: "rgba(0, 184, 148, 0.2)"
+        line: "rgba(0, 184, 148, 1.0)",
+        fill: "rgba(0, 184, 148, 0.2)",
+        table: "rgba(0, 184, 148, 0.4)",
     },
     {
-        line: "rgb(214, 48, 49)",
-        fill: "rgba(214, 48, 49, 0.2)"
+        line: "rgba(214, 48, 49, 1.0)",
+        fill: "rgba(214, 48, 49, 0.2)",
+        table: "rgba(214, 48, 49, 0.4)",
     },
     {
-        line: "rgb(9, 132, 227)",
-        fill: "rgba(9, 132, 227, 0.2)"
+        line: "rgba(9, 132, 227, 1.0)",
+        fill: "rgba(9, 132, 227, 0.2)",
+        table: "rgba(9, 132, 227, 0.4)",
     },
     {
-        line: "rgb(0, 206, 201)",
-        fill: "rgba(0, 206, 201, 0.2)"
+        line: "rgba(95, 39, 205, 1.0)",
+        fill: "rgba(95, 39, 205, 0.2)",
+        table: "rgba(95, 39, 205, 0.4)",
+    },
+    {
+        line: "rgba(34, 47, 62, 1.0)",
+        fill: "rgba(34, 47, 62, 0.2)",
+        table: "rgba(34, 47, 62, 0.4)",
+    },
+    {
+        line: "rgba(243, 104, 224, 1.0)",
+        fill: "rgba(243, 104, 224, 0.2)",
+        table: "rgba(243, 104, 224, 0.4)"
+    },
+    {
+        line: "rgba(255, 159, 67, 1.0)",
+        fill: "rgba(255, 159, 67, 0.2)",
+        table: "rgba(255, 159, 67, 0.4)",
     },
 ];
 
@@ -77,7 +100,7 @@ let datasets = [];
 for (i=0; i < results.length; i++) {
     datasets[i] = {
         label: results[i].name,
-        data: results[i].data[1].results,
+        data: results[i].data[0].results,
         fill: true,
         backgroundColor: colors[i].fill,
         borderColor: colors[i].line,
@@ -121,8 +144,9 @@ const myChart = new Chart(
 const datatables = {
     data() {
         return {
-        results: results,
-        queries: ['created.greater(), genre.equal()', 'genre.equal(OR)', 'views.greater()', 'text.search()']
+            results: results,
+            queries: chartData.labels,
+            colors: colors
         }
     }
 }
@@ -136,19 +160,23 @@ table {
     margin: 1em;
 }
 
+table td {
+    width: 110px;
+    text-align: center;
+}
+
 .chartcontainer {
-    width: 75vw;
-    height: 65vh;
+    width: 650px;
+    height: 550px;
     margin: auto;
 }
 
 .datatables {
     display: flex;
     flex-flow: row wrap;
+    justify-content: center;
     padding-left: 2em;
     padding-right: 2em;
-    margin-left: auto;
-    margin-right: auto;
 }
 </style>
 

--- a/bin/view/index.php
+++ b/bin/view/index.php
@@ -7,16 +7,49 @@
     <title>utopia-php/database</title>
     <meta name="description" content="utopia-php/database">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://unpkg.com/vue@next"></script>
 
 </head>
 
 <body>
 
-<div class="canvascontainer">
-    <canvas id="myChart"></canvas>
-</div>
+    <div class="chartcontainer">
+        <canvas id="radarchart"></canvas>
+    </div>
+
+    <div id="datatables">
+    <table>
+        <tr>{{ results[0].name }}</tr>
+        <tr>
+            <td v-for="r in results[0].data" :key="r.roles">{{ r.results }}</td>
+        </tr>
+    </table>
+    <br>
+    <table>
+        <tr>{{ results[1].name }}</tr>
+        <tr>
+            <td v-for="r in results[1].data" :key="r.roles">{{ r.results }}</td>
+        </tr>
+    </table>
+    </div>
 
 <script>
+
+const results = <?php
+    $directory = './results';
+    $scanned_directory = array_diff(scandir($directory), array('..', '.'));
+
+    $results = [];
+    foreach ($scanned_directory as $path) {
+        $results[] = [
+            'name' => $path,
+            'data' => json_decode(file_get_contents("{$directory}/{$path}"), true)
+        ];
+    }
+    echo json_encode($results);
+?>
+
+console.log(results)
 
 const colors = [
     {
@@ -37,26 +70,8 @@ const colors = [
     },
 ];
 
-let results = <?php
-
-    $directory = './results';
-    $scanned_directory = array_diff(scandir($directory), array('..', '.'));
-    // $files = '["' . implode('", "', $scanned_directory) . '"]';
-
-    $results = [];
-    foreach ($scanned_directory as $path) {
-        $results[] = [
-            'name' => $path,
-            'data' => json_decode(file_get_contents("{$directory}/{$path}"), true)
-        ];
-    }
-    echo json_encode($results);
-?>
-
-console.log(results);
-
+// Radar chart
 let datasets = [];
-
 for (i=0; i < results.length; i++) {
     datasets[i] = {
         label: results[i].name,
@@ -71,7 +86,7 @@ for (i=0; i < results.length; i++) {
     }
 }
 
-const data = {
+const chartData = {
     labels: [
         'created.greater(), genre.equal()',
         'genre.equal(OR)',
@@ -83,7 +98,7 @@ const data = {
 
 const config = {
   type: 'radar',
-  data: data,
+  data: chartData,
   options: {
     elements: {
       line: {
@@ -95,15 +110,26 @@ const config = {
   },
 };
 
-var myChart = new Chart(
-    document.getElementById('myChart'),
+const myChart = new Chart(
+    document.getElementById('radarchart'),
     config
 );
+
+// datatables with vue
+const datatables = {
+    data() {
+        return {
+            results: results
+        }
+    }
+}
+
+Vue.createApp(datatables).mount('#datatables')
 
 </script>
 
 <style>
-.canvascontainer {
+.chartcontainer {
     width: 75vw;
     height: 75vh;
     margin: auto;

--- a/bin/view/index.php
+++ b/bin/view/index.php
@@ -17,20 +17,22 @@
         <canvas id="radarchart"></canvas>
     </div>
 
-    <div id="datatables">
-    <table>
-        <tr>{{ results[0].name }}</tr>
-        <tr>
-            <td v-for="r in results[0].data" :key="r.roles">{{ r.results }}</td>
-        </tr>
-    </table>
-    <br>
-    <table>
-        <tr>{{ results[1].name }}</tr>
-        <tr>
-            <td v-for="r in results[1].data" :key="r.roles">{{ r.results }}</td>
-        </tr>
-    </table>
+    <div id="datatables" class="datatables">
+        <table v-for="n in 4" :key="n">
+            <tr>
+                <th colspan="5">{{ queries[n-1] }}</th>
+            </tr>
+            <tr>
+                <th>1 role</th>
+                <th>100 roles</th>
+                <th>500 roles</th>
+                <th>1000 roles</th>
+                <th>2000 roles</th>
+            </tr>
+            <tr v-for="result in results" :key="result.name">
+                <td v-for="set in result.data">{{ set.results[n-1].toFixed(4) }}</td>
+            </tr>
+        </table>
     </div>
 
 <script>
@@ -119,7 +121,8 @@ const myChart = new Chart(
 const datatables = {
     data() {
         return {
-            results: results
+        results: results,
+        queries: ['created.greater(), genre.equal()', 'genre.equal(OR)', 'views.greater()', 'text.search()']
         }
     }
 }
@@ -129,10 +132,23 @@ Vue.createApp(datatables).mount('#datatables')
 </script>
 
 <style>
+table {
+    margin: 1em;
+}
+
 .chartcontainer {
     width: 75vw;
-    height: 75vh;
+    height: 65vh;
     margin: auto;
+}
+
+.datatables {
+    display: flex;
+    flex-flow: row wrap;
+    padding-left: 2em;
+    padding-right: 2em;
+    margin-left: auto;
+    margin-right: auto;
 }
 </style>
 

--- a/bin/view/index.php
+++ b/bin/view/index.php
@@ -1,0 +1,114 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+
+    <title>utopia-php/database</title>
+    <meta name="description" content="utopia-php/database">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+</head>
+
+<body>
+
+<div class="canvascontainer">
+    <canvas id="myChart"></canvas>
+</div>
+
+<script>
+
+const colors = [
+    {
+        line: "rgb(0, 184, 148)",
+        fill: "rgba(0, 184, 148, 0.2)"
+    },
+    {
+        line: "rgb(214, 48, 49)",
+        fill: "rgba(214, 48, 49, 0.2)"
+    },
+    {
+        line: "rgb(9, 132, 227)",
+        fill: "rgba(9, 132, 227, 0.2)"
+    },
+    {
+        line: "rgb(0, 206, 201)",
+        fill: "rgba(0, 206, 201, 0.2)"
+    },
+];
+
+let results = <?php
+
+    $directory = './results';
+    $scanned_directory = array_diff(scandir($directory), array('..', '.'));
+    // $files = '["' . implode('", "', $scanned_directory) . '"]';
+
+    $results = [];
+    foreach ($scanned_directory as $path) {
+        $results[] = [
+            'name' => $path,
+            'data' => json_decode(file_get_contents("{$directory}/{$path}"), true)
+        ];
+    }
+    echo json_encode($results);
+?>
+
+console.log(results);
+
+let datasets = [];
+
+for (i=0; i < results.length; i++) {
+    datasets[i] = {
+        label: results[i].name,
+        data: results[i].data[1].results,
+        fill: true,
+        backgroundColor: colors[i].fill,
+        borderColor: colors[i].line,
+        pointBackgroundColor: colors[i].line,
+        pointBorderColor: '#fff',
+        pointHoverBackgroundColor: '#fff',
+        pointHoverBorderColor: colors[i].line
+    }
+}
+
+const data = {
+    labels: [
+        'created.greater(), genre.equal()',
+        'genre.equal(OR)',
+        'views.greater()',
+        'text.search()',
+    ],
+    datasets: datasets,
+};
+
+const config = {
+  type: 'radar',
+  data: data,
+  options: {
+    elements: {
+      line: {
+        borderWidth: 2
+      }
+    },
+    responsive: true,
+    maintainAspectRatio: false
+  },
+};
+
+var myChart = new Chart(
+    document.getElementById('myChart'),
+    config
+);
+
+</script>
+
+<style>
+.canvascontainer {
+    width: 75vw;
+    height: 75vh;
+    margin: auto;
+}
+</style>
+
+</body>
+</html>

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",
-        "vimeo/psalm": "4.0.1"
+        "vimeo/psalm": "4.0.1",
+        "fakerphp/faker": "^1.14"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.4",
         "vimeo/psalm": "4.0.1",
-        "fakerphp/faker": "^1.14"
+        "fakerphp/faker": "^1.14",
+        "utopia-php/cli": "^0.11.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd2546d5cd02cf55391c4a5cd4768bd0",
+    "content-hash": "f3ca342a461f5f2e8439faa15e0b4db8",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -805,6 +805,71 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.14.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "ed22aee8d17c7b396f74a58b1e7fefa4f90d5ef1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/ed22aee8d17c7b396f74a58b1e7fefa4f90d5ef1",
+                "reference": "ed22aee8d17c7b396f74a58b1e7fefa4f90d5ef1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/container": "^1.0",
+                "symfony/deprecation-contracts": "^2.2"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "ext-intl": "*",
+                "symfony/phpunit-bridge": "^4.4 || ^5.2"
+            },
+            "suggest": {
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v1.15-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v.1.14.1"
+            },
+            "time": "2021-03-30T06:27:33+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -3040,6 +3105,73 @@
                 }
             ],
             "time": "2021-03-28T09:42:18+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3ca342a461f5f2e8439faa15e0b4db8",
+    "content-hash": "eb73de2debe0da378e395d7dcb714a3a",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -3787,6 +3787,59 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "utopia-php/cli",
+            "version": "0.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/utopia-php/cli.git",
+                "reference": "c7a6908a8dbe9234b8b2c954e5487d34cb079af6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/utopia-php/cli/zipball/c7a6908a8dbe9234b8b2c954e5487d34cb079af6",
+                "reference": "c7a6908a8dbe9234b8b2c954e5487d34cb079af6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "utopia-php/framework": "0.*.*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "vimeo/psalm": "4.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Utopia\\CLI\\": "src/CLI"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eldad Fux",
+                    "email": "eldad@appwrite.io"
+                }
+            ],
+            "description": "A simple CLI library to manage command line applications",
+            "keywords": [
+                "cli",
+                "command line",
+                "framework",
+                "php",
+                "upf",
+                "utopia"
+            ],
+            "support": {
+                "issues": "https://github.com/utopia-php/cli/issues",
+                "source": "https://github.com/utopia-php/cli/tree/0.11.0"
+            },
+            "time": "2021-04-16T15:16:08+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: password
+
   cockroach:
     image: cockroachdb/cockroach:v20.2.0
     container_name: utopia-cockroach
@@ -73,21 +74,6 @@ services:
     container_name: utopia-redis
     networks:
       - database
-
-  ##############################################
-  ##            FOR DEVELOPMENT               ##
-  ##############################################
-
-  # mongo-gui:
-  #   container_name: "mongo-gui"
-  #   image: ugleiton/mongo-gui
-  #   restart: always
-  #   ports:
-  #     - "4321:4321"
-  #   environment:
-  #     - MONGO_URL=mongodb://root:example@mongo:27017
-  #   networks:
-  #     - database
 
 networks:
   database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - database
     volumes:
       - ./:/usr/src/code
+    ports:
+      - "8708:8708"
 
   postgres:
     image: postgres:13

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: password
-
   cockroach:
     image: cockroachdb/cockroach:v20.2.0
     container_name: utopia-cockroach
@@ -74,6 +73,21 @@ services:
     container_name: utopia-redis
     networks:
       - database
+
+  ##############################################
+  ##            FOR DEVELOPMENT               ##
+  ##############################################
+
+  # mongo-gui:
+  #   container_name: "mongo-gui"
+  #   image: ugleiton/mongo-gui
+  #   restart: always
+  #   ports:
+  #     - "4321:4321"
+  #   environment:
+  #     - MONGO_URL=mongodb://root:example@mongo:27017
+  #   networks:
+  #     - database
 
 networks:
   database:

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -26,7 +26,7 @@ class MariaDB extends Adapter
      *
      * @param PDO $pdo
      */
-    public function __construct(PDO $pdo)
+    public function __construct($pdo)
     {
         $this->pdo = $pdo;
     }


### PR DESCRIPTION
Three commands have been added to `bin/` to fill, index, and query the DB to test changes:

- `bin/load` invokes `bin/tasks/load.php`
- `bin/index` invokes `bin/tasks/index.php`
- `bin/query` invokes `bin/tasks/query.php`

To test your DB changes under load:

**=> Load the database**

```bash
docker-compose exec tests bin/load --adapter=[adapter] --limit=[limit] [--name=[name]]

# [adapter]: either 'mongodb' or 'mariadb', no quotes
# [limit]: integer of total documents to generate
# [name]: (optional) name for new database
```

**=> Create indexes**

```bash
docker-compose exec tests bin/index --adapter=[adapter] --name=[name]

# [adapter]: either 'mongodb' or 'mariadb', no quotes
# [name]: name of filled database by bin/load
```

**=> Run Query Suite**

```bash
docker-compose exec tests bin/query --adapter=[adapter] --limit=[limit] --name=[name]

# [adapter]: either 'mongodb' or 'mariadb', no quotes
# [limit]: integer of query limit (default 25)
# [name]: name of filled database by bin/load
```