### PR TITLE
Refactor - Adjust permissions query for performance

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -530,7 +530,8 @@ class MariaDB extends Adapter
 
         $permissions = (Authorization::$status) ? "INNER JOIN {$this->getNamespace()}.{$name}_permissions as table_permissions
             ON table_main._uid = table_permissions._uid
-            AND table_permissions._action = 'read' AND table_permissions._role IN (".implode(',', $roles).")" : ''; // Disable join when no authorization required
+            AND table_permissions._action = 'read'" : ''; // Disable join when no authorization required
+        $permissions2 = (Authorization::$status) ? " AND table_permissions._role IN (".implode(',', $roles).")" : ''; // Disable join when no authorization required
 
         foreach($queries as $i => $query) {
             $conditions = [];
@@ -546,6 +547,7 @@ class MariaDB extends Adapter
         $stmt = $this->getPDO()->prepare("SELECT table_main.* FROM {$this->getNamespace()}.{$name} table_main
             {$permissions}
             WHERE ".implode(' AND ', $where)."
+            {$permissions2}
             GROUP BY table_main._uid 
             {$order}
             LIMIT :offset, :limit;
@@ -603,7 +605,8 @@ class MariaDB extends Adapter
 
         $permissions = (Authorization::$status) ? "INNER JOIN {$this->getNamespace()}.{$name}_permissions as table_permissions
             ON table_main._uid = table_permissions._uid
-            AND table_permissions._action = 'read' AND table_permissions._role IN (".implode(',', $roles).")" : ''; // Disable join when no authorization required
+            AND table_permissions._action = 'read'" : ''; // Disable join when no authorization required
+        $permissions2 = (Authorization::$status) ? " AND table_permissions._role IN (".implode(',', $roles).")" : ''; // Disable join when no authorization required
 
         foreach($queries as $i => $query) {
             $conditions = [];
@@ -617,6 +620,7 @@ class MariaDB extends Adapter
         $stmt = $this->getPDO()->prepare("SELECT COUNT(1) as sum FROM (SELECT 1 FROM {$this->getNamespace()}.{$name} table_main
             {$permissions}
             WHERE ".implode(' AND ', $where)."
+            {$permissions2}
             GROUP BY table_main._uid 
             {$limit}) table_count
         ");


### PR DESCRIPTION
Moving the individual permissions IN query to the WHERE clause (from the JOIN) increases query performance at scale on certain indexes.

Results for 250k documents, limit 25:

| ~500 roles                                           | Before (s)          | After (s)              |
|------------------------------------------------------|-----------------|--------------------|
| text.search('Alice')                                 | 10.322902917862 | 10.365649223328    |
| [created.greater(1262322000), genre.equal('travel')] | 1.6036841869354 | 1.6573619842529    |
| genre.equal('fashion', 'finance', 'sports')          | 1.8061821460724 | 0.0035700798034668* |
| views.greater(100000)                                | 2.4185400009155 | 2.3989799022675    |

| ~1000 roles                                          | Before (s)          | After (s)              |
|------------------------------------------------------|-----------------|--------------------|
| text.search('Alice')                                 | 11.500841140747 | 11.508894205093    |
| [created.greater(1262322000), genre.equal('travel')] | 3.0463140010834 | 3.0712490081787    |
| genre.equal('fashion', 'finance', 'sports')          | 3.5477650165558 | 0.0035550594329834* |
| views.greater(100000)                                | 4.8037049770355 | 4.8732569217682    |

| ~2000 roles                                          | Before (s)          | After (s)              |
|------------------------------------------------------|-----------------|--------------------|
| text.search('Alice')                                 | 13.602020978928 | 13.609866857529    |
| [created.greater(1262322000), genre.equal('travel')] | 5.7006130218506 | 5.3941948413849    |
| genre.equal('fashion', 'finance', 'sports')          | 6.7950260639191 | 0.0059249401092529* |
| views.greater(100000)                                | 9.1683850288391 | 8.6509971618652    |

* I ran both sets of queries a few times to see if this result was just cached, but the difference is that big after several repetitions.

