### PR TITLE
Feat - Attribute default values

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -331,13 +331,14 @@ class Database
      * @param string $type
      * @param int $size utf8mb4 chars length
      * @param bool $required
+     * @param array|bool|callable|int|float|object|resource|string|null $default
      * @param bool $signed
      * @param bool $array
      * @param array $filters
      * 
      * @return bool
      */
-    public function createAttribute(string $collection, string $id, string $type, int $size, bool $required, bool $signed = true, bool $array = false, array $filters = []): bool
+    public function createAttribute(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, array $filters = []): bool
     {
         $collection = $this->getCollection($collection);
 
@@ -346,6 +347,7 @@ class Database
             'type' => $type,
             'size' => $size,
             'required' => $required,
+            'default' => $default,
             'signed' => $signed,
             'array' => $array,
             'filters' => $filters,
@@ -374,6 +376,10 @@ class Database
             default:
                 throw new Exception('Unknown attribute type: '.$type);
                 break;
+        }
+
+        if (!\is_null($default) && $type !== \gettype($default)) {
+            throw new Exception('Default value ' . $default . ' does not match given type ' . $type);
         }
 
         return $this->adapter->createAttribute($collection->getId(), $id, $type, $size, $signed, $array);
@@ -416,13 +422,14 @@ class Database
      * @param string $type
      * @param int $size utf8mb4 chars length
      * @param bool $required
+     * @param array|bool|callable|int|float|object|resource|string|null $default
      * @param bool $signed
      * @param bool $array
      * @param array $filters
      * 
      * @return bool
      */
-    public function addAttributeInQueue(string $collection, string $id, string $type, int $size, bool $required, bool $signed = true, bool $array = false, array $filters = []): bool
+    public function addAttributeInQueue(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, array $filters = []): bool
     {
         $collection = $this->getCollection($collection);
 
@@ -431,6 +438,7 @@ class Database
             'type' => $type,
             'size' => $size,
             'required' => $required,
+            'default' => $default,
             'signed' => $signed,
             'array' => $array,
             'filters' => $filters,

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -757,7 +757,9 @@ class Database
          * Find all attributes with default values
          * @var Document[]
          */
-        $defaults = array_filter($collection->getAttributes()['attributes'], function ($attribute) {
+        $attributes = $collection->getAttributes()['attributes'];
+
+        $defaults = array_filter($attributes, function ($attribute) {
             return (!\is_null($attribute->getAttribute('default')));
         });
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -713,6 +713,20 @@ class Database
 
         $collection = $this->getCollection($collection);
 
+        /**
+         * @var Document[]
+         */
+        $defaults = array_filter($collection->getAttributes()['attributes'], function ($attribute) {
+            return (!\is_null($attribute->getAttribute('default')));
+        });
+
+        foreach ($defaults as $default) {
+            // TODO@kodumbeats default values for arrays?
+            if ($default->getAttribute('array') === false) {
+                $document->setAttribute($default->getId(), $default->getAttribute('default'));
+            }
+        }
+
         $document
             ->setAttribute('$id', empty($document->getId()) ? $this->getId(): $document->getId())
             ->setAttribute('$collection', $collection->getId())

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -750,7 +750,7 @@ class Database
         $attributes = $collection->getAttributes()['attributes'];
 
         $defaults = array_filter($attributes, function ($attribute) {
-            return (!\is_null($attribute->getAttribute('default')));
+            return (isset($attribute['default'])) ? $attribute['default'] : false;
         });
 
         // Since required params cannot have a default value,

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -307,6 +307,35 @@ abstract class Base extends TestCase
         return $document;
     }
 
+    public function testCreateDocumentDefaults()
+    {
+        static::getDatabase()->createCollection('defaults');
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'string', Database::VAR_STRING, 128, false, 'default'));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'integer', Database::VAR_INTEGER, 0, false, 1));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'float', Database::VAR_FLOAT, 0, false, 1.5));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'boolean', Database::VAR_BOOLEAN, 0, false, true));
+        // TODO@kodumbeats default values for arrays?
+        // $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'colors', Database::VAR_STRING, 32, true, 'red', true, true));
+
+        $document = static::getDatabase()->createDocument('defaults', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+        ]));
+
+        $this->assertNotEmpty(true, $document->getId());
+
+        $this->assertIsString($document->getAttribute('string'));
+        $this->assertEquals('default', $document->getAttribute('string'));
+        $this->assertIsInt($document->getAttribute('integer'));
+        $this->assertEquals(1, $document->getAttribute('integer'));
+        $this->assertIsFloat($document->getAttribute('float'));
+        $this->assertEquals(1.5, $document->getAttribute('float'));
+
+        // cleanup collection
+        static::getDatabase()->deleteCollection('defaults');
+    }
+
     /**
      * @depends testCreateDocument
      */

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -68,13 +68,38 @@ abstract class Base extends TestCase
         $this->assertCount(7, $collection->getAttribute('attributes'));
 
         // Array
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_list', Database::VAR_STRING, 128, true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_list', Database::VAR_INTEGER, 0, true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_list', Database::VAR_FLOAT, 0, true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_list', Database::VAR_BOOLEAN, 0, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_list', Database::VAR_STRING, 128, true, 'string', true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_list', Database::VAR_INTEGER, 0, true, 0, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_list', Database::VAR_FLOAT, 0, true, 0.1, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_list', Database::VAR_BOOLEAN, 0, true, false, true, true));
 
         $collection = static::getDatabase()->getCollection('attributes');
         $this->assertCount(11, $collection->getAttribute('attributes'));
+
+        // Default values
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_default', Database::VAR_STRING, 256, 'test'));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_default', Database::VAR_INTEGER, 0, 1));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_default', Database::VAR_FLOAT, 0, true, 1.5));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_default', Database::VAR_BOOLEAN, 0, true, false));
+
+        // Type of provided default value does not match
+        // Testing for failure
+        $this->expectException(\Exception::class);
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'string_bad_default', Database::VAR_STRING, 256, true, 1));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'string_bad_default', Database::VAR_STRING, 256, true, 1.5));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'string_bad_default', Database::VAR_STRING, 256, true, false));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'integer_bad_default', Database::VAR_INTEGER, 0, true, "one"));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'integer_bad_default', Database::VAR_INTEGER, 0, true, 1.5));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'integer_bad_default', Database::VAR_INTEGER, 0, true, false));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'float_bad_default', Database::VAR_FLOAT, 0, true, 1));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'float_bad_default', Database::VAR_FLOAT, 0, true, "one"));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'float_bad_default', Database::VAR_FLOAT, 0, true, false));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'boolean_bad_default', Database::VAR_BOOLEAN, 0, true, 1));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'boolean_bad_default', Database::VAR_BOOLEAN, 0, true, "true"));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'boolean_bad_default', Database::VAR_BOOLEAN, 0, true, 1.5));
+
+        $collection = static::getDatabase()->getCollection('attributes');
+        $this->assertCount(15, $collection->getAttribute('attributes'));
 
         // Delete
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string1'));
@@ -86,13 +111,22 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'boolean'));
 
         $collection = static::getDatabase()->getCollection('attributes');
-        $this->assertCount(4, $collection->getAttribute('attributes'));
+        $this->assertCount(8, $collection->getAttribute('attributes'));
 
         // Delete Array
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string_list'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'integer_list'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'float_list'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'boolean_list'));
+
+        $collection = static::getDatabase()->getCollection('attributes');
+        $this->assertCount(4, $collection->getAttribute('attributes'));
+
+        // Delete default
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_default', Database::VAR_STRING, 256, 'test'));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_default', Database::VAR_INTEGER, 0, 1));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_default', Database::VAR_FLOAT, 0, true, 1.5));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_default', Database::VAR_BOOLEAN, 0, true, false));
 
         $collection = static::getDatabase()->getCollection('attributes');
         $this->assertCount(0, $collection->getAttribute('attributes'));
@@ -214,8 +248,8 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'integer', Database::VAR_INTEGER, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'float', Database::VAR_FLOAT, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'boolean', Database::VAR_BOOLEAN, 0, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'colors', Database::VAR_STRING, 32, true, true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'empty', Database::VAR_STRING, 32, false, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'colors', Database::VAR_STRING, 32, true, '', true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'empty', Database::VAR_STRING, 32, false, '', true, true));
 
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$read' => ['role:all', 'user1', 'user2'],
@@ -320,7 +354,7 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'year', Database::VAR_INTEGER, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'price', Database::VAR_FLOAT, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'active', Database::VAR_BOOLEAN, 0, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'generes', Database::VAR_STRING, 32, true, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'generes', Database::VAR_STRING, 32, true, '', true, true));
 
         static::getDatabase()->createDocument('movies', new Document([
             '$read' => ['role:all', 'user1', 'user2'],

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -324,8 +324,6 @@ abstract class Base extends TestCase
 
         $this->assertNotEmpty(true, $document->getId());
 
-        var_dump($document);
-
         $this->assertIsString($document->getAttribute('string'));
         $this->assertEquals('default', $document->getAttribute('string'));
         $this->assertIsInt($document->getAttribute('integer'));

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -315,8 +315,7 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'integer', Database::VAR_INTEGER, 0, false, 1));
         $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'float', Database::VAR_FLOAT, 0, false, 1.5));
         $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'boolean', Database::VAR_BOOLEAN, 0, false, true));
-        // TODO@kodumbeats default values for arrays?
-        // $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'colors', Database::VAR_STRING, 32, true, 'red', true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('defaults', 'colors', Database::VAR_STRING, 32, false, ['red', 'green', 'blue'], true, true));
 
         $document = static::getDatabase()->createDocument('defaults', new Document([
             '$read' => ['role:all'],
@@ -325,12 +324,19 @@ abstract class Base extends TestCase
 
         $this->assertNotEmpty(true, $document->getId());
 
+        var_dump($document);
+
         $this->assertIsString($document->getAttribute('string'));
         $this->assertEquals('default', $document->getAttribute('string'));
         $this->assertIsInt($document->getAttribute('integer'));
         $this->assertEquals(1, $document->getAttribute('integer'));
         $this->assertIsFloat($document->getAttribute('float'));
         $this->assertEquals(1.5, $document->getAttribute('float'));
+        $this->assertIsArray($document->getAttribute('colors'));
+        $this->assertCount(3, $document->getAttribute('colors'));
+        $this->assertEquals('red', $document->getAttribute('colors')[0]);
+        $this->assertEquals('green', $document->getAttribute('colors')[1]);
+        $this->assertEquals('blue', $document->getAttribute('colors')[2]);
 
         // cleanup collection
         static::getDatabase()->deleteCollection('defaults');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -277,8 +277,8 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'integer', Database::VAR_INTEGER, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'float', Database::VAR_FLOAT, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'boolean', Database::VAR_BOOLEAN, 0, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'colors', Database::VAR_STRING, 32, true, '', true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'empty', Database::VAR_STRING, 32, false, '', true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'colors', Database::VAR_STRING, 32, true, null, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'empty', Database::VAR_STRING, 32, false, null, true, true));
 
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$read' => ['role:all', 'user1', 'user2'],
@@ -418,7 +418,7 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'year', Database::VAR_INTEGER, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'price', Database::VAR_FLOAT, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'active', Database::VAR_BOOLEAN, 0, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'generes', Database::VAR_STRING, 32, true, '', true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('movies', 'generes', Database::VAR_STRING, 32, true, null, true, true));
 
         static::getDatabase()->createDocument('movies', new Document([
             '$read' => ['role:all', 'user1', 'user2'],

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -68,19 +68,19 @@ abstract class Base extends TestCase
         $this->assertCount(7, $collection->getAttribute('attributes'));
 
         // Array
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_list', Database::VAR_STRING, 128, true, 'string', true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_list', Database::VAR_INTEGER, 0, true, 0, true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_list', Database::VAR_FLOAT, 0, true, 0.1, true, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_list', Database::VAR_BOOLEAN, 0, true, false, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_list', Database::VAR_STRING, 128, true, null, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_list', Database::VAR_INTEGER, 0, true, null, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_list', Database::VAR_FLOAT, 0, true, null, true, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_list', Database::VAR_BOOLEAN, 0, true, null, true, true));
 
         $collection = static::getDatabase()->getCollection('attributes');
         $this->assertCount(11, $collection->getAttribute('attributes'));
 
         // Default values
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_default', Database::VAR_STRING, 256, 'test'));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_default', Database::VAR_INTEGER, 0, 1));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_default', Database::VAR_FLOAT, 0, true, 1.5));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_default', Database::VAR_BOOLEAN, 0, true, false));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_default', Database::VAR_STRING, 256, false, 'test'));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer_default', Database::VAR_INTEGER, 0, false, 1));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float_default', Database::VAR_FLOAT, 0, false, 1.5));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_default', Database::VAR_BOOLEAN, 0, false, false));
 
         $collection = static::getDatabase()->getCollection('attributes');
         $this->assertCount(15, $collection->getAttribute('attributes'));


### PR DESCRIPTION
This PR introduces a default value when creating an attribute. An exception is thrown if the type of default value does not match the type of attribute, as the database would be unaware of the mismatched type until a document is created.

**Testing**

Unit tests have been added to test for valid and invalid default values.