### PR TITLE
Feat - Expand Permissions validator

### DIFF
--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -88,8 +88,8 @@ class Permissions extends Validator
              * Substring after ":" $value must not be empty and satisty requirements per $type
              */
 
-            $type = \substr($role, 0, \strpos($role, ':'));
-            $value = \substr($role, \strpos($role, ':') + 1);
+            $type = \substr($role, 0, $pos);
+            $value = \substr($role, $pos + 1);
 
             if (strlen($value) === 0) {
                 $this->message = 'Permission role value must not be empty';

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -110,7 +110,7 @@ class Permissions extends Validator
                     // user:$id and member:$id must be valid Keys
                     $key = new Key();
                     if (!$key->isValid($value)) {
-                        $this->message = 'Permission role must contain a valid $id: ' . $key->getDescription();
+                        $this->message = '[role:$id] $id must be a valid key: ' . $key->getDescription();
 
                         return false;
                     }
@@ -124,7 +124,7 @@ class Permissions extends Validator
 
                     // if no team role is given and and $id is not valid
                     if ($pos === false && !$key->isValid($value)) {
-                        $this->message = 'Permission role must contain a valid $id: ' . $key->getDescription();
+                        $this->message = '[role:$id] $id must be a valid key: ' . $key->getDescription();
 
                         return false;
                     }

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -159,7 +159,7 @@ class Permissions extends Validator
 
                         // $teamId and $teamRole must both be valid Keys
                         if (!$key->isValid($teamId) || !$key->isValid($teamRole)) {
-                            $this->message = 'Permission role for team must contain valid teamID and role: ' . $key->getDescription();
+                            $this->message = '[team:$teamId/$role] $teamID and $role must be valid keys: ' . $key->getDescription();
 
                             return false;
                         }

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -12,6 +12,16 @@ class Permissions extends Validator
     protected $message = 'Permissions Error';
 
     /**
+     * @var string[]
+     */
+    protected $permissions = [
+        'member',
+        'role',
+        'team',
+        'user',
+    ];
+
+    /**
      * Get Description.
      *
      * Returns validator description
@@ -35,13 +45,34 @@ class Permissions extends Validator
     public function isValid($roles)
     {
         if(!is_array($roles)) {
-            $this->message = 'Permissions roles must be an array of strings';
+            $this->message = 'Permissions roles must be an array of strings.';
             return false;
         }
 
         foreach ($roles as $role) {
             if (!\is_string($role)) {
                 $this->message = 'Permissions role must be of type string.';
+
+                return false;
+            }
+
+            if ($role === '*') {
+                $this->message = 'Wildcard permission "*" deprecated. Use "role:all" instead.';
+
+                return false;
+            }
+
+            $pos = \strpos($role, ':');
+            // Should only contain a single ":" char
+            if ($pos === false || $pos !== \strrpos($role, ':')) {
+                $this->message = 'Permission role must contain one and only one \':\' character: ' . $role;
+
+                return false;
+            }
+
+            // Substring before ":" must be a known permission
+            if (!\in_array(\substr($role, 0, \strpos($role, ":")), $this->permissions)) {
+                $this->message = 'Permission role must begin with one of: ' . \implode(", ", $this->permissions);
 
                 return false;
             }

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -98,9 +98,6 @@ class Permissions extends Validator
             }
 
             switch ($type) {
-                case 'team':
-                    // Team:[role] can have any string as role
-                    break;
                 case 'role':
                     // role:$value must be in list of $roles
                     if (!\in_array($value, $this->roles)) {
@@ -108,9 +105,10 @@ class Permissions extends Validator
                         return false;
                     }
                     break;
+                case 'team':
                 case 'user':
                 case 'member':
-                    // member:[memberId] and user:[userId] must be valid keys
+                    // every valid $value must be a valid Key
                     $key = new Key();
                     if (!$key->isValid($value)) {
                         $this->message = $key->getDescription();

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -65,13 +65,13 @@ class Permissions extends Validator
             $pos = \strpos($role, ':');
             // Should only contain a single ":" char
             if ($pos === false || $pos !== \strrpos($role, ':')) {
-                $this->message = 'Permission role must contain one and only one \':\' character: ' . $role;
+                $this->message = 'Permission role must contain one and only one ":" character: ' . $role;
 
                 return false;
             }
 
             // Substring before ":" must be a known permission
-            if (!\in_array(\substr($role, 0, \strpos($role, ":")), $this->permissions)) {
+            if (!\in_array(\substr($role, 0, \strpos($role, ':')), $this->permissions)) {
                 $this->message = 'Permission role must begin with one of: ' . \implode(", ", $this->permissions);
 
                 return false;

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -138,7 +138,7 @@ class Permissions extends Validator
 
                     // if a "/" is found, ensure is unique and both substrings are valid
                     if ($pos > 0) {
-                        // Split into format {$teamId}:{$teamRole}
+                        // Split into format {$teamId}/{$teamRole}
                         $teamId = \substr($value, 0, $pos);
                         $teamRole = \substr($value, $pos + 1);
 

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -62,16 +62,20 @@ class Permissions extends Validator
                 return false;
             }
 
-            $pos = \strpos($role, ':');
             // Should only contain a single ":" char
+            $pos = \strpos($role, ':');
+
             if ($pos === false || $pos !== \strrpos($role, ':')) {
-                $this->message = 'Permission role must contain one and only one ":" character: ' . $role;
+                $this->message = 'Permission roles must contain one and only one ":" character.';
 
                 return false;
             }
 
-            // Substring before ":" must be a known permission
-            if (!\in_array(\substr($role, 0, \strpos($role, ':')), $this->permissions)) {
+            // Substring before ":" must be a known permission type
+            $type = \substr($role, 0, \strpos($role, ':'));
+            $value = \substr($role, \strpos($role, ':') + 1);
+
+            if (!\in_array($type, $this->permissions)) {
                 $this->message = 'Permission role must begin with one of: ' . \implode(", ", $this->permissions);
 
                 return false;

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -110,7 +110,7 @@ class Permissions extends Validator
                     // user:$id and member:$id must be valid Keys
                     $key = new Key();
                     if (!$key->isValid($value)) {
-                        $this->message = $key->getDescription();
+                        $this->message = 'Permission role must contain a valid $id: ' . $key->getDescription();
 
                         return false;
                     }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -44,4 +44,26 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid('sting'), false);
         
     }
+
+    public function testInvalidPermissions()
+    {
+        $object = new Permissions();
+
+        // Must be array of strings
+        $this->assertEquals($object->isValid('role:all'), false);
+        $this->assertEquals($object->getDescription(), 'Permissions roles must be an array of strings.');
+        $this->assertEquals($object->isValid(false), false);
+        $this->assertEquals($object->getDescription(), 'Permissions roles must be an array of strings.');
+        $this->assertEquals($object->isValid(1.5), false);
+        $this->assertEquals($object->getDescription(), 'Permissions roles must be an array of strings.');
+
+        // Permissions role must be of type string
+        $this->assertEquals($object->isValid([0]), false);
+        $this->assertEquals($object->getDescription(), 'Permissions role must be of type string.');
+        $this->assertEquals($object->isValid([false]), false);
+        $this->assertEquals($object->getDescription(), 'Permissions role must be of type string.');
+        $this->assertEquals($object->isValid([['a']]), false);
+        $this->assertEquals($object->getDescription(), 'Permissions role must be of type string.');
+
+    }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -30,14 +30,17 @@ class PermissionsTest extends TestCase
         ]);
         
         $this->assertEquals($object->isValid($document->getRead()), true);
+        $this->assertEquals($object->isValid($document->getWrite()), true);
         
         $document = new Document([
             '$id' => uniqid(),
             '$collection' => uniqid(),
             '$read' => ['user:123', 'team:123'],
+            '$read' => ['member:123'],
         ]);
         
         $this->assertEquals($object->isValid($document->getRead()), true);
+        $this->assertEquals($object->isValid($document->getWrite()), true);
         $this->assertEquals($object->isValid('sting'), false);
         
     }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -58,12 +58,33 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->getDescription(), 'Permissions roles must be an array of strings.');
 
         // Permissions role must be of type string
-        $this->assertEquals($object->isValid([0]), false);
+        $this->assertEquals($object->isValid([0, 1.5]), false);
         $this->assertEquals($object->getDescription(), 'Permissions role must be of type string.');
-        $this->assertEquals($object->isValid([false]), false);
+        $this->assertEquals($object->isValid([false, []]), false);
         $this->assertEquals($object->getDescription(), 'Permissions role must be of type string.');
         $this->assertEquals($object->isValid([['a']]), false);
         $this->assertEquals($object->getDescription(), 'Permissions role must be of type string.');
 
+        // Wildcard character deprecated
+        $this->assertEquals($object->isValid(['*']), false);
+        $this->assertEquals($object->getDescription(), 'Wildcard permission "*" deprecated. Use "role:all" instead.');
+
+        // Only contains a single ':'
+        $this->assertEquals($object->isValid(['user1234']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one \':\' character: user1234');
+        $this->assertEquals($object->isValid(['user::1234']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one \':\' character: user::1234');
+        $this->assertEquals($object->isValid(['user:123:4']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one \':\' character: user:123:4');
+
+        // Permission role must begin with one of: member, role, team, user
+        $this->assertEquals($object->isValid(['memmber:1234']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');
+        $this->assertEquals($object->isValid(['rol:1234']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');
+        $this->assertEquals($object->isValid(['tteam:1234']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');
+        $this->assertEquals($object->isValid(['userr:1234']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -96,7 +96,7 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['role:memer']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles must be one of: all, guest, member');
 
-        // member:[memberId] and user:[userId] must be valid keys
+        // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
@@ -106,7 +106,7 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['user:12&4']), false);
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
-        $this->assertEquals($object->isValid(['user:ab(124']), false);
+        $this->assertEquals($object->isValid(['team:ab(124']), false);
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // Shorter than 32 chars

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // Shorter than 32 chars
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddd']), true);
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddde']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
@@ -126,7 +126,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertEquals($object->isValid(['team:_abcd']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['team:abcd/']), false);
         $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
         $this->assertEquals($object->isValid(['team:/abcd']), false);

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -71,11 +71,11 @@ class PermissionsTest extends TestCase
 
         // Only contains a single ':'
         $this->assertEquals($object->isValid(['user1234']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one ":" character: user1234');
+        $this->assertEquals($object->getDescription(), 'Permission roles must contain one and only one ":" character.');
         $this->assertEquals($object->isValid(['user::1234']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one ":" character: user::1234');
+        $this->assertEquals($object->getDescription(), 'Permission roles must contain one and only one ":" character.');
         $this->assertEquals($object->isValid(['user:123:4']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one ":" character: user:123:4');
+        $this->assertEquals($object->getDescription(), 'Permission roles must contain one and only one ":" character.');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -136,8 +136,8 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
         $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role for team must contain valid teamID and role: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role for team must contain valid teamID and role: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -36,7 +36,7 @@ class PermissionsTest extends TestCase
             '$id' => uniqid(),
             '$collection' => uniqid(),
             '$read' => ['user:123', 'team:123'],
-            '$read' => ['member:123'],
+            '$read' => ['member:123', 'team:123/edit'],
         ]);
         
         $this->assertEquals($object->isValid($document->getRead()), true);
@@ -106,7 +106,7 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['user:12&4']), false);
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
-        $this->assertEquals($object->isValid(['team:ab(124']), false);
+        $this->assertEquals($object->isValid(['member:ab(124']), false);
         $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // Shorter than 32 chars
@@ -123,5 +123,21 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');
         $this->assertEquals($object->isValid(['userr:1234']), false);
         $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');
+
+        // Team permission
+        $this->assertEquals($object->isValid(['team:_abcd']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->isValid(['team:abcd/']), false);
+        $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
+        $this->assertEquals($object->isValid(['team:/abcd']), false);
+        $this->assertEquals($object->getDescription(), 'Team ID must not be empty.');
+        $this->assertEquals($object->isValid(['team:abcd//efgh']), false);
+        $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
+        $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
+        $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
+        $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role for team must contain valid teamID and role: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role for team must contain valid teamID and role: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -71,11 +71,11 @@ class PermissionsTest extends TestCase
 
         // Only contains a single ':'
         $this->assertEquals($object->isValid(['user1234']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one \':\' character: user1234');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one ":" character: user1234');
         $this->assertEquals($object->isValid(['user::1234']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one \':\' character: user::1234');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one ":" character: user::1234');
         $this->assertEquals($object->isValid(['user:123:4']), false);
-        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one \':\' character: user:123:4');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain one and only one ":" character: user:123:4');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // Shorter than 32 chars
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddd']), true);
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddde']), false);
-        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), 'Permission role must contain a valid $id: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -77,6 +77,43 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['user:123:4']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles must contain one and only one ":" character.');
 
+        // Split role into format {$type}:{$value}
+        // Permission must have value
+        $this->assertEquals($object->isValid(['member:']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role value must not be empty');
+        $this->assertEquals($object->isValid(['role:']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role value must not be empty');
+        $this->assertEquals($object->isValid(['team:']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role value must not be empty');
+        $this->assertEquals($object->isValid(['user:']), false);
+        $this->assertEquals($object->getDescription(), 'Permission role value must not be empty');
+
+        // Permission role:$value must be one of: all, guest, member
+        $this->assertEquals($object->isValid(['role:alll']), false);
+        $this->assertEquals($object->getDescription(), 'Permission roles must be one of: all, guest, member');
+        $this->assertEquals($object->isValid(['role:gguest']), false);
+        $this->assertEquals($object->getDescription(), 'Permission roles must be one of: all, guest, member');
+        $this->assertEquals($object->isValid(['role:memer']), false);
+        $this->assertEquals($object->getDescription(), 'Permission roles must be one of: all, guest, member');
+
+        // member:[memberId] and user:[userId] must be valid keys
+        // No leading underscores
+        $this->assertEquals($object->isValid(['member:_1234']), false);
+        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+
+        // No special characters
+        $this->assertEquals($object->isValid(['member:12$4']), false);
+        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->isValid(['user:12&4']), false);
+        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->isValid(['user:ab(124']), false);
+        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+
+        // Shorter than 32 chars
+        $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddd']), true);
+        $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddde']), false);
+        $this->assertEquals($object->getDescription(), 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
         $this->assertEquals($object->getDescription(), 'Permission role must begin with one of: member, role, team, user');


### PR DESCRIPTION

This PR expands the permissions validator to check the format of the permission strings. Since the removal of the wildcard char `*`, a "role" satisfies the following simple schema:
- Can be expressed in the format `{$type}:{$value}` with only a single colon separating the permission type from its value
- `$type` must be one of `['member', 'role', 'user', 'team']`
- `$value` must not be empty
- `$value` must satisfy the Key validator for `user` and `member`
- `$value` must be one of `['all', 'guest', 'member']` when `$type = 'role'`
- Since `team:[teamId]/[role]` can have any string for role, no validation needed

### Test plan
Unit tests included