### PR TITLE
Feat - Harmonize UID with Key validator

### DIFF
--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -42,7 +42,7 @@ class Key extends Validator
             return false;
         }
         
-        if (\preg_match('/[^A-Za-z0-9\-\_]/', $value)) {
+        if (\preg_match('/[^A-Za-z0-9\_]/', $value)) {
             return false;
         }
 

--- a/src/Database/Validator/UID.php
+++ b/src/Database/Validator/UID.php
@@ -2,9 +2,9 @@
 
 namespace Utopia\Database\Validator;
 
-use Utopia\Validator;
+use Utopia\Database\Validator\Key;
 
-class UID extends Validator
+class UID extends Key
 {
     /**
      * Get Description.
@@ -15,56 +15,6 @@ class UID extends Validator
      */
     public function getDescription()
     {
-        return 'Invalid UID format';
-    }
-
-    /**
-     * Is valid.
-     *
-     * Returns true if valid or false if not.
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    public function isValid($value)
-    {
-        if ($value === 0) { // TODO Deprecate confition when we get the chance.
-            return true;
-        }
-
-        if (!is_string($value)) {
-            return false;
-        }
-        
-        if (mb_strlen($value) > 32) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Is array
-     *
-     * Function will return true if object is array.
-     *
-     * @return bool
-     */
-    public function isArray(): bool
-    {
-        return false;
-    }
-
-    /**
-     * Get Type
-     *
-     * Returns validator type.
-     *
-     * @return string
-     */
-    public function getType(): string
-    {
-        return self::TYPE_STRING;
+        return 'UID must contain only alphanumeric chars or non-leading underscore, shorter than 32 chars';
     }
 }

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -23,20 +23,29 @@ class KeyTest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals(false, $this->object->isValid('dasda asdasd'));
-        $this->assertEquals(true, $this->object->isValid('asdasdasdas'));
-        $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
-        $this->assertEquals(false, $this->object->isValid('asd"asdasdas'));
-        $this->assertEquals(false, $this->object->isValid('asd\'asdasdas'));
-        $this->assertEquals(false, $this->object->isValid('as$$5dasdasdas'));
+        // Must be strings
         $this->assertEquals(false, $this->object->isValid(false));
         $this->assertEquals(false, $this->object->isValid(null));
-        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscribers'));
-        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscriber'));
-        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribe'));
-        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscrib'));
-
+        $this->assertEquals(false, $this->object->isValid(['value']));
+        $this->assertEquals(false, $this->object->isValid(0));
+        $this->assertEquals(false, $this->object->isValid(1.5));
+        $this->assertEquals(true, $this->object->isValid('asdas7as9as'));
         $this->assertEquals(true, $this->object->isValid('5f058a8925807'));
+
+        // No leading underscore
+        $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
+        $this->assertEquals(true, $this->object->isValid('a_sdasdasdas'));
+
+        // No Special characters
+        $this->assertEquals(false, $this->object->isValid('dasda asdasd'));
+        $this->assertEquals(false, $this->object->isValid('asd"asd6sdas'));
+        $this->assertEquals(false, $this->object->isValid('asd\'as0asdas'));
+        $this->assertEquals(false, $this->object->isValid('as$$5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as-5dasdasdas'));
+
+        // At most 32 chars
+        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribe'));
+        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscribers'));
         $this->assertEquals(true, $this->object->isValid('5f058a89258075f058a89258075f058t'));
         $this->assertEquals(false, $this->object->isValid('5f058a89258075f058a89258075f058tx'));
     }

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -23,18 +23,18 @@ class KeyTest extends TestCase
 
     public function testValues()
     {
-        $this->assertEquals($this->object->isValid('dasda asdasd'), false);
-        $this->assertEquals($this->object->isValid('asdasdasdas'), true);
-        $this->assertEquals($this->object->isValid('_asdasdasdas'), false);
-        $this->assertEquals($this->object->isValid('asd"asdasdas'), false);
-        $this->assertEquals($this->object->isValid('asd\'asdasdas'), false);
-        $this->assertEquals($this->object->isValid('as$$5dasdasdas'), false);
-        $this->assertEquals($this->object->isValid(false), false);
-        $this->assertEquals($this->object->isValid(null), false);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscribers'), false);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscriber'), false);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscribe'), true);
-        $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscrib'), true);
+        $this->assertEquals(false, $this->object->isValid('dasda asdasd'));
+        $this->assertEquals(true, $this->object->isValid('asdasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('asd"asdasdas'));
+        $this->assertEquals(false, $this->object->isValid('asd\'asdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as$$5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid(false));
+        $this->assertEquals(false, $this->object->isValid(null));
+        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscribers'));
+        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscriber'));
+        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribe'));
+        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscrib'));
 
         $this->assertEquals(true, $this->object->isValid('5f058a8925807'));
         $this->assertEquals(true, $this->object->isValid('5f058a89258075f058a89258075f058t'));

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -35,5 +35,9 @@ class KeyTest extends TestCase
         $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscriber'), false);
         $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscribe'), true);
         $this->assertEquals($this->object->isValid('socialAccountForYoutubeSubscrib'), true);
+
+        $this->assertEquals(true, $this->object->isValid('5f058a8925807'));
+        $this->assertEquals(true, $this->object->isValid('5f058a89258075f058a89258075f058t'));
+        $this->assertEquals(false, $this->object->isValid('5f058a89258075f058a89258075f058tx'));
     }
 }

--- a/tests/Database/Validator/UIDTest.php
+++ b/tests/Database/Validator/UIDTest.php
@@ -2,29 +2,8 @@
 
 namespace Utopia\Tests\Validator;
 
-use Utopia\Database\Validator\UID;
-use PHPUnit\Framework\TestCase;
+use Utopia\Database\Validator\Key;
 
-class UIDTest extends TestCase
+class UIDTest extends KeyTest
 {
-    /**
-     * @var UID
-     */
-    protected $object = null;
-
-    public function setUp(): void
-    {
-        $this->object = new UID();
-    }
-
-    public function tearDown(): void
-    {
-    }
-
-    public function testValues()
-    {
-        $this->assertEquals($this->object->isValid('5f058a8925807'), true);
-        $this->assertEquals($this->object->isValid('5f058a89258075f058a89258075f058t'), true);
-        $this->assertEquals($this->object->isValid('5f058a89258075f058a89258075f058tx'), false);
-    }
 }


### PR DESCRIPTION
This PR harmonizes the UID and Key validators. Keys and UIDs must both satisfy the following:

- Must be string
- Must be alphanumeric + underscore "_"
- No leading underscore
- Maximum of 32 chars

**Tests**
Harmonized the tests as well, refactoring the expected value to first `assert` param and restructured for clarity.