### PR TITLE
Allow for creation of collection with complete schema

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -119,10 +119,12 @@ abstract class Adapter
      * Create Collection
      * 
      * @param string $name
+     * @param Document[] $attributes (optional)
+     * @param Document[] $indexes (optional)
      * 
      * @return bool
      */
-    abstract public function createCollection(string $name): bool;
+    abstract public function createCollection(string $name, array $attributes = [], array $indexes = []): bool;
 
     /**
      * Delete Collection

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -95,14 +95,14 @@ class MariaDB extends Adapter
     /**
      * Create Collection
      * 
-     * @param string $id
+     * @param string $name
      * @param Document[] $attributes (optional)
      * @param Document[] $indexes (optional)
      * @return bool
      */
-    public function createCollection(string $id, array $attributes = [], array $indexes = []): bool
+    public function createCollection(string $name, array $attributes = [], array $indexes = []): bool
     {
-        $id = $this->filter($id);
+        $id = $this->filter($name);
 
         if (!empty($attributes) || !empty($indexes)) {
             foreach ($attributes as &$attribute) {
@@ -123,7 +123,7 @@ class MariaDB extends Adapter
                 $indexAttributes = $index->getAttribute('attributes');
                 foreach ($indexAttributes as $key => &$attribute) {
                     $indexLength = $index->getAttribute('lengths')[$key] ?? '';
-                    $indexLength = (empty($length)) ? '' : '('.(int)$length.')';
+                    $indexLength = (empty($indexLength)) ? '' : '('.(int)$indexLength.')';
                     $indexOrder = $index->getAttribute('orders')[$key] ?? '';
                     $indexAttribute = $this->filter($attribute);
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -726,6 +726,35 @@ class MariaDB extends Adapter
     }
 
     /**
+     * Get SQL Index Type
+     * 
+     * @param string $type
+     * 
+     * @return string
+     */
+    protected function getSQLIndexType(string $type): string
+    {
+        switch ($type) {
+            case Database::INDEX_KEY:
+            case Database::INDEX_ARRAY:
+                return 'INDEX';
+            break;
+            
+            case Database::INDEX_UNIQUE:
+                return 'UNIQUE INDEX';
+            break;
+            
+            case Database::INDEX_FULLTEXT:
+                return 'FULLTEXT INDEX';
+            break;
+            
+            default:
+                throw new Exception('Unknown Index Type:' . $type);
+            break;
+        }
+    }
+
+    /**
      * Get SQL Index
      * 
      * @param string $collection

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -97,9 +97,11 @@ class MariaDB extends Adapter
      * Create Collection
      * 
      * @param string $id
+     * @param Document[] $attributes (optional)
+     * @param Document[] $indexes (optional)
      * @return bool
      */
-    public function createCollection(string $id): bool
+    public function createCollection(string $id, array $attributes = [], array $indexes = []): bool
     {
         $id = $this->filter($id);
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -30,7 +30,6 @@ class MariaDB extends Adapter
     {
         $this->pdo = $pdo;
     }
-    
     /**
      * Create Database
      * 
@@ -143,7 +142,7 @@ class MariaDB extends Adapter
                 ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
                     `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                     `_uid` CHAR(255) NOT NULL,
-                    `_read` TEXT NOT NULL,
+                    `_read` " . $this->getTypeForReadPermission() . " NOT NULL,
                     `_write` TEXT NOT NULL,
                     " . \implode(' ', $attributes) . "
                     PRIMARY KEY (`_id`),
@@ -157,7 +156,7 @@ class MariaDB extends Adapter
                 ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
                     `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                     `_uid` CHAR(255) NOT NULL,
-                    `_read` TEXT NOT NULL,
+                    `_read` " . $this->getTypeForReadPermission() . " NOT NULL,
                     `_write` TEXT NOT NULL,
                     PRIMARY KEY (`_id`),
                     UNIQUE KEY `_index1` (`_uid`)
@@ -165,7 +164,7 @@ class MariaDB extends Adapter
                 ->execute();
         }
 
-        return $this->createIndex($id, '_index2', Database::INDEX_FULLTEXT, ['_read'], [], []);
+        return $this->createIndex($id, '_index2', $this->getIndexTypeForReadPermission(), ['_read'], [], []);
     }
 
     /**
@@ -657,6 +656,26 @@ class MariaDB extends Adapter
     public function getSupportForCasting(): bool
     {
         return false;
+    }
+
+    /**
+     * Returns the attribute type for read permissions
+     *
+     * @return string
+     */
+    public function getTypeForReadPermission(): string
+    {
+        return "TEXT";
+    }
+
+    /**
+     * Returns the index type for read permissions
+     *
+     * @return string
+     */
+    public function getIndexTypeForReadPermission(): string
+    {
+        return Database::INDEX_FULLTEXT;
     }
 
     /**

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -663,7 +663,7 @@ class MariaDB extends Adapter
      *
      * @return string
      */
-    public function getTypeForReadPermission(): string
+    protected function getTypeForReadPermission(): string
     {
         return "TEXT";
     }
@@ -673,7 +673,7 @@ class MariaDB extends Adapter
      *
      * @return string
      */
-    public function getIndexTypeForReadPermission(): string
+    protected function getIndexTypeForReadPermission(): string
     {
         return Database::INDEX_FULLTEXT;
     }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -105,7 +105,7 @@ class MariaDB extends Adapter
     {
         $id = $this->filter($id);
 
-        if (!\empty($attributes) || !\empty($indexes)) {
+        if (!empty($attributes) || !empty($indexes)) {
             foreach ($attributes as &$attribute) {
                 $attrId = $attribute->getId();
                 $attrType = $this->getSQLType($attribute->getAttribute('type'), $attribute->getAttribute('size'), $attribute->getAttribute('signed'));
@@ -114,12 +114,12 @@ class MariaDB extends Adapter
                     $attrType = 'LONGTEXT';
                 }
 
-                $attribute = "`{$attrId}` {$attrType},"
+                $attribute = "`{$attrId}` {$attrType}, ";
             }
 
             foreach ($indexes as &$index) {
                 $indexId = $this->filter($index->getId()); 
-                $indexType = $this->getSQLIndexType($attribute->getAttribute('type'));
+                $indexType = $this->getSQLIndexType($index->getAttribute('type'));
 
                 $indexAttributes = $index->getAttribute('attributes');
                 foreach ($indexAttributes as $key => &$attribute) {

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -98,18 +98,19 @@ class MongoDB extends Adapter
     {
         $id = $this->filter($name);
 
-        if ($this->getDatabase()->createCollection($id)) {
+        $database = $this->getDatabase();
+
+        // Returns an array/object with the result document
+        if (empty($database->createCollection($id))) {
             return false;
         }
 
-        /**
-         * @var MongoCollection
-         */
-        $collection = $this->getDatabase()->selectCollection($id);
+        $collection = $database->$id;
 
         // Mongo creates an index for _id; index _read,_write by default
-        $read = $this->createIndex($id, '_read_permissions', Database::INDEX_KEY, ['_read'], [], [Database::ORDER_DESC]);
-        $write = $this->createIndex($id, '_write_permissions', Database::INDEX_KEY, ['_write'], [], [Database::ORDER_DESC]);
+        // Returns the name of the created index as a string.
+        $read = $collection->createIndex(['_read' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_read_permissions']);
+        $write = $collection->createIndex(['_write' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_write_permissions']);
 
         if (!$read || !$write) {
             return false;

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -89,9 +89,11 @@ class MongoDB extends Adapter
      * Create Collection
      * 
      * @param string $id
+     * @param Document[] $attributes (optional)
+     * @param Document[] $indexes (optional)
      * @return bool
      */
-    public function createCollection(string $id): bool
+    public function createCollection(string $id, array $attributes = [], array $indexes = []): bool
     {
         $id = $this->filter($id);
 

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -19,18 +19,105 @@ class MySQL extends MariaDB
     {
         $id = $this->filter($id);
 
-        $this->getPDO()
-            ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
-                `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-                `_uid` CHAR(255) NOT NULL,
-                `_read` JSON NOT NULL,
-                `_write` TEXT NOT NULL,
-                PRIMARY KEY (`_id`),
-                UNIQUE KEY `_index1` (`_uid`)
-              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
-            ->execute();
+        if (!empty($attributes) || !empty($indexes)) {
+            foreach ($attributes as &$attribute) {
+                $attrId = $attribute->getId();
+                $attrType = $this->getSQLType($attribute->getAttribute('type'), $attribute->getAttribute('size'), $attribute->getAttribute('signed'));
+
+                if($attribute->getAttribute('array')) {
+                    $attrType = 'LONGTEXT';
+                }
+
+                $attribute = "`{$attrId}` {$attrType},";
+            }
+
+            foreach ($indexes as &$index) {
+                $indexId = $this->filter($index->getId()); 
+                $indexType = $this->getSQLIndexType($index->getAttribute('type'));
+
+                $indexAttributes = $index->getAttribute('attributes');
+                foreach ($indexAttributes as $key => &$attribute) {
+                    $indexLength = $index->getAttribute('lengths')[$key] ?? '';
+                    $indexLength = (empty($length)) ? '' : '('.(int)$length.')';
+                    $indexOrder = $index->getAttribute('orders')[$key] ?? '';
+                    $indexAttribute = $this->filter($attribute);
+
+                    if ($indexType === Database::INDEX_FULLTEXT) {
+                        $indexOrder = '';
+                    }
+
+                    $attribute = "`{$indexAttribute}`{$indexLength} {$indexOrder}";
+                }
+
+                $index = "{$indexType} `{$indexId}` (" . \implode(", ", $indexAttributes) . " ),";
+
+            }
+
+            $this->getPDO()
+                ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
+                    `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+                    `_uid` CHAR(255) NOT NULL,
+                    `_read` JSON NOT NULL,
+                    `_write` TEXT NOT NULL,
+                    " . \implode(' ', $attributes) . "
+                    PRIMARY KEY (`_id`),
+                    " . \implode(' ', $indexes) . "
+                    UNIQUE KEY `_index1` (`_uid`)
+                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
+                ->execute();
+
+        } else {
+            $this->getPDO()
+                ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
+                    `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+                    `_uid` CHAR(255) NOT NULL,
+                    `_read` JSON NOT NULL,
+                    `_write` TEXT NOT NULL,
+                    PRIMARY KEY (`_id`),
+                    UNIQUE KEY `_index1` (`_uid`)
+                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
+                ->execute();
+        }
 
         return $this->createIndex($id, '_index2', Database::INDEX_ARRAY, ['_read'], [], []);
+    }
+
+    /**
+     * Get SQL Index Type
+     * 
+     * @param string $type
+     * 
+     * @return string
+     */
+    protected function getSQLIndexType(string $type): string
+    {
+        switch ($type) {
+            case Database::INDEX_KEY:
+                $type = 'INDEX';
+            break;
+
+            case Database::INDEX_ARRAY:
+                $type = 'INDEX';
+
+                foreach ($attributes as $key => &$value) {
+                    $value = '(CAST('.$value.' AS char(255) ARRAY))';
+                }
+            break;
+            
+            case Database::INDEX_UNIQUE:
+                $type = 'UNIQUE INDEX';
+            break;
+            
+            case Database::INDEX_FULLTEXT:
+                $type = 'FULLTEXT INDEX';
+            break;
+            
+            default:
+                throw new Exception('Unknown Index Type:' . $type);
+            break;
+        }
+
+        return $type;
     }
 
     /**

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -8,78 +8,23 @@ use Utopia\Database\Database;
 class MySQL extends MariaDB
 {
     /**
-     * Create Collection
-     * 
-     * @param string $id
-     * @param Document[] $attributes (optional)
-     * @param Document[] $indexes (optional)
-     * @return bool
+     * Returns the attribute type for read permissions
+     *
+     * @return string
      */
-    public function createCollection(string $id, array $attributes = [], array $indexes = []): bool
+    public function getTypeForReadPermission(): string
     {
-        $id = $this->filter($id);
+        return "JSON";
+    }
 
-        if (!empty($attributes) || !empty($indexes)) {
-            foreach ($attributes as &$attribute) {
-                $attrId = $attribute->getId();
-                $attrType = $this->getSQLType($attribute->getAttribute('type'), $attribute->getAttribute('size'), $attribute->getAttribute('signed'));
-
-                if($attribute->getAttribute('array')) {
-                    $attrType = 'LONGTEXT';
-                }
-
-                $attribute = "`{$attrId}` {$attrType},";
-            }
-
-            foreach ($indexes as &$index) {
-                $indexId = $this->filter($index->getId()); 
-                $indexType = $this->getSQLIndexType($index->getAttribute('type'));
-
-                $indexAttributes = $index->getAttribute('attributes');
-                foreach ($indexAttributes as $key => &$attribute) {
-                    $indexLength = $index->getAttribute('lengths')[$key] ?? '';
-                    $indexLength = (empty($length)) ? '' : '('.(int)$length.')';
-                    $indexOrder = $index->getAttribute('orders')[$key] ?? '';
-                    $indexAttribute = $this->filter($attribute);
-
-                    if ($indexType === Database::INDEX_FULLTEXT) {
-                        $indexOrder = '';
-                    }
-
-                    $attribute = "`{$indexAttribute}`{$indexLength} {$indexOrder}";
-                }
-
-                $index = "{$indexType} `{$indexId}` (" . \implode(", ", $indexAttributes) . " ),";
-
-            }
-
-            $this->getPDO()
-                ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
-                    `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-                    `_uid` CHAR(255) NOT NULL,
-                    `_read` JSON NOT NULL,
-                    `_write` TEXT NOT NULL,
-                    " . \implode(' ', $attributes) . "
-                    PRIMARY KEY (`_id`),
-                    " . \implode(' ', $indexes) . "
-                    UNIQUE KEY `_index1` (`_uid`)
-                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
-                ->execute();
-
-        } else {
-            $this->getPDO()
-                ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
-                    `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
-                    `_uid` CHAR(255) NOT NULL,
-                    `_read` JSON NOT NULL,
-                    `_write` TEXT NOT NULL,
-                    PRIMARY KEY (`_id`),
-                    UNIQUE KEY `_index1` (`_uid`)
-                  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
-                ->execute();
-        }
-
-        return $this->createIndex($id, '_index2', Database::INDEX_ARRAY, ['_read'], [], []);
+    /**
+     * Returns the index type for read permissions
+     *
+     * @return string
+     */
+    public function getIndexTypeForReadPermission(): string
+    {
+        return Database::INDEX_ARRAY;
     }
 
     /**

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -11,9 +11,11 @@ class MySQL extends MariaDB
      * Create Collection
      * 
      * @param string $id
+     * @param Document[] $attributes (optional)
+     * @param Document[] $indexes (optional)
      * @return bool
      */
-    public function createCollection(string $id): bool
+    public function createCollection(string $id, array $attributes = [], array $indexes = []): bool
     {
         $id = $this->filter($id);
 

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -12,7 +12,7 @@ class MySQL extends MariaDB
      *
      * @return string
      */
-    public function getTypeForReadPermission(): string
+    protected function getTypeForReadPermission(): string
     {
         return "JSON";
     }
@@ -22,7 +22,7 @@ class MySQL extends MariaDB
      *
      * @return string
      */
-    public function getIndexTypeForReadPermission(): string
+    protected function getIndexTypeForReadPermission(): string
     {
         return Database::INDEX_ARRAY;
     }

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -43,10 +43,6 @@ class MySQL extends MariaDB
 
             case Database::INDEX_ARRAY:
                 $type = 'INDEX';
-
-                foreach ($attributes as $key => &$value) {
-                    $value = '(CAST('.$value.' AS char(255) ARRAY))';
-                }
             break;
             
             case Database::INDEX_UNIQUE:

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -254,12 +254,14 @@ class Database
      * Create Collection
      * 
      * @param string $id
+     * @param Document[] $attributes (optional)
+     * @param Document[] $indexes (optional)
      * 
      * @return Document
      */
-    public function createCollection(string $id): Document
+    public function createCollection(string $id, array $attributes = [], array $indexes = []): Document
     {
-        $this->adapter->createCollection($id);
+        $this->adapter->createCollection($id, $attributes, $indexes);
 
         if($id === self::COLLECTIONS) {
             return new Document($this->collection);
@@ -270,8 +272,8 @@ class Database
             '$read' => ['role:all'],
             '$write' => ['role:all'],
             'name' => $id,
-            'attributes' => [],
-            'indexes' => [],
+            'attributes' => $attributes,
+            'indexes' => $indexes,
             'attributesInQueue' => [],
             'indexesInQueue' => [],
         ]));

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -206,6 +206,88 @@ abstract class Base extends TestCase
         static::getDatabase()->deleteCollection('indexesInQueue');
     }
 
+    public function testCreateCollectionWithSchema()
+    {
+        $attributes = [
+            new Document([
+                '$id' => 'attribute1',
+                'type' => Database::VAR_STRING,
+                'size' => 256,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+            new Document([
+                '$id' => 'attribute2',
+                'type' => Database::VAR_INTEGER,
+                'size' => 0,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+            new Document([
+                '$id' => 'attribute3',
+                'type' => Database::VAR_BOOLEAN,
+                'size' => 0,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+        ];
+
+        $indexes = [
+            new Document([
+                '$id' => 'index1',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute1'],
+                'lengths' => [256],
+                'orders' => ['ASC'],
+            ]),
+            new Document([
+                '$id' => 'index2',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute2'],
+                'lengths' => [],
+                'orders' => ['DESC'],
+            ]),
+            new Document([
+                '$id' => 'index3',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute3', 'attribute2'],
+                'lengths' => [],
+                'orders' => ['DESC', 'ASC'],
+            ]),
+        ];
+
+        $collection = static::getDatabase()->createCollection('withSchema', $attributes, $indexes);
+
+        $this->assertEquals(false, $collection->isEmpty());
+        $this->assertEquals('withSchema', $collection->getId());
+
+        $this->assertIsArray($collection->getAttribute('attributes'));
+        $this->assertCount(3, $collection->getAttribute('attributes'));
+        $this->assertEquals('attribute1', $collection->getAttribute('attributes')[0]['$id']);
+        $this->assertEquals(Database::VAR_STRING, $collection->getAttribute('attributes')[0]['type']);
+        $this->assertEquals('attribute2', $collection->getAttribute('attributes')[1]['$id']);
+        $this->assertEquals(Database::VAR_INTEGER, $collection->getAttribute('attributes')[1]['type']);
+        $this->assertEquals('attribute3', $collection->getAttribute('attributes')[2]['$id']);
+        $this->assertEquals(Database::VAR_BOOLEAN, $collection->getAttribute('attributes')[2]['type']);
+
+        $this->assertIsArray($collection->getAttribute('indexes'));
+        $this->assertCount(3, $collection->getAttribute('indexes'));
+        $this->assertEquals('index1', $collection->getAttribute('indexes')[0]['$id']);
+        $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[0]['type']);
+        $this->assertEquals('index2', $collection->getAttribute('indexes')[1]['$id']);
+        $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[1]['type']);
+        $this->assertEquals('index3', $collection->getAttribute('indexes')[2]['$id']);
+        $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[2]['type']);
+
+        static::getDatabase()->deleteCollection('withSchema');
+    }
+
     public function testCreateDocument()
     {
         static::getDatabase()->createCollection('documents');


### PR DESCRIPTION
Creating collections with many attributes (for example, on startup of Appwrite, for testing) can be slow, so this PR adds additional params to `createCollection` to generate a complete collection with one call:
```php
abstract public function createCollection(string $name, array $attributes = [], array $indexes = []): bool;
```

**Testing**
Additional unit tests will be added to validate functionality.
<details>
<summary>Screenshots of index creation from tests</summary>

![mariadbcollectionwithschema](https://user-images.githubusercontent.com/9708641/123980932-ede9b800-d98f-11eb-810a-7f84ba25c394.png)

![defaultschemainmongo](https://user-images.githubusercontent.com/9708641/123980940-f04c1200-d98f-11eb-9124-303ff1846486.png)

</details>

