### PR TITLE
Fetch should return only assoc array, not PDO::FETCH_BOTH (default)

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -63,7 +63,7 @@ class MariaDB extends Adapter
 
         $stmt->execute();
         
-        $document = $stmt->fetch();
+        $document = $stmt->fetch(PDO::FETCH_ASSOC);
 
         return (($document['SCHEMA_NAME'] ?? '') == $name);
     }
@@ -254,7 +254,7 @@ class MariaDB extends Adapter
 
         $stmt->execute();
 
-        $document = $stmt->fetch();
+        $document = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if(empty($document)) {
             return new Document([]);
@@ -479,7 +479,7 @@ class MariaDB extends Adapter
         $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
         $stmt->execute();
 
-        $results = $stmt->fetchAll();
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
         foreach ($results as &$value) {
             $value['$id'] = $value['_uid'];
@@ -543,7 +543,7 @@ class MariaDB extends Adapter
 
         $stmt->execute();
 
-        $result = $stmt->fetch();
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
         return $result['sum'] ?? 0;
     }


### PR DESCRIPTION
By default, `PDO->fetch()` is configured to the default mode:
>  PDO::FETCH_BOTH (default): returns an array indexed by both column name and 0-indexed column number as returned in your result set

This causes problems on `getDocument()` calls, as the returned document fails structure validation (with the additional indexed array data in the return structure). This PR changes the default mode in the MariaDB/MySQL adapters to return the assoc array we want.