### PR TITLE
Feat - Index limits

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -285,6 +285,21 @@ abstract class Adapter
     abstract public function getSupportForFulltextIndex(): bool;
 
     /**
+     * Get current index count.
+     * 
+     * @param string $collection collectionID
+     * @return int
+     */
+    abstract public function getIndexCount(string $collection): int;
+
+    /**
+     * Get maximum index limit.
+     * 
+     * @return int
+     */
+    abstract public function getIndexLimit(): int;
+
+    /**
      * Does the adapter handle casting?
      * 
      * @return bool

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -285,12 +285,12 @@ abstract class Adapter
     abstract public function getSupportForFulltextIndex(): bool;
 
     /**
-     * Get current index count.
+     * Get current index count from collection document
      * 
-     * @param string $collection collectionID
+     * @param Document $collection
      * @return int
      */
-    abstract public function getIndexCount(string $collection): int;
+    abstract public function getIndexCount(Document $collection): int;
 
     /**
      * Get maximum index limit.

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -164,6 +164,7 @@ class MariaDB extends Adapter
                 ->execute();
         }
 
+        // Update $this->getIndexCount when adding another default index
         return $this->createIndex($id, '_index2', $this->getIndexTypeForReadPermission(), ['_read'], [], []);
     }
 
@@ -651,24 +652,23 @@ class MariaDB extends Adapter
     }
 
     /**
-     * Get current index count.
+     * Get current index count from collection document
      * 
-     * @param string $collection collectionID
+     * @param Document $collection
      * @return int
      */
-    public function getIndexCount(string $collection): int
+    public function getIndexCount(Document $collection): int
     {
-        $name = $this->filter($collection);
+        $indexes = $collection->getAttribute('indexes') ?? [];
+        $indexesInQueue = $collection->getAttribute('indexesInQueue') ?? [];
 
-        $stmt = $this->getPDO()->prepare("SHOW KEYS FROM {$this->getNamespace()}.{$name}");
-
-        $stmt->execute();
-
-        return \count($stmt->fetchAll(PDO::FETCH_ASSOC));
+        // +3 ==> hardcoded number of default indexes from createCollection
+        return \count($indexes) + \count($indexesInQueue) + 3;
     }
 
     /**
      * Get maximum index limit.
+     * https://mariadb.com/kb/en/innodb-limitations/#limitations-on-schema
      * 
      * @return int
      */

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -660,7 +660,7 @@ class MariaDB extends Adapter
     public function getIndexCount(string $collection): int
     {
         $name = $this->filter($collection);
-        
+
         $stmt = $this->getPDO()->prepare("SHOW KEYS FROM {$this->getNamespace()}.{$name}");
 
         $stmt->execute();

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -318,6 +318,7 @@ class MariaDB extends Adapter
 
         $stmt->execute();
 
+        /** @var array $document */
         $document = $stmt->fetch(PDO::FETCH_ASSOC);
 
         if(empty($document)) {
@@ -607,6 +608,7 @@ class MariaDB extends Adapter
 
         $stmt->execute();
 
+        /** @var array $result */
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
         return $result['sum'] ?? 0;

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -9,7 +9,6 @@ use Utopia\Database\Adapter;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
-use Utopia\Database\Exception\IndexLimit;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -7,7 +7,6 @@ use Utopia\Database\Adapter;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
-use Utopia\Database\Exception\IndexLimit;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 use MongoDB\Client as MongoClient;
@@ -278,13 +277,8 @@ class MongoDB extends Adapter
                     return false;
             }
         }
-        try{
-            $success = $collection->createIndex($indexes, $options);
-        } catch (\MongoDB\Driver\Exception\CommandException $e) {
-            throw new IndexLimit('Index limit reached. Cannot create new index.');
-        }
 
-        return (!!$success);
+        return (!!$collection->createIndex($indexes, $options));
     }
 
     /**
@@ -684,6 +678,30 @@ class MongoDB extends Adapter
     public function getSupportForFulltextIndex(): bool
     {
         return true;
+    }
+
+    /**
+     * Get current index count.
+     * 
+     * @param string $collection collectionID
+     * @return int
+     */
+    public function getIndexCount(string $collection): int
+    {
+        $name = $this->filter($collection);
+        $indexes = $this->getDatabase()->$name->listIndexes();
+
+        return \iterator_count($indexes);
+    }
+
+    /**
+     * Get maximum index limit.
+     * 
+     * @return int
+     */
+    public function getIndexLimit(): int
+    {
+        return 64;
     }
 
     /**

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -7,6 +7,7 @@ use Utopia\Database\Adapter;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Duplicate;
+use Utopia\Database\Exception\IndexLimit;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 use MongoDB\Client as MongoClient;
@@ -277,8 +278,13 @@ class MongoDB extends Adapter
                     return false;
             }
         }
+        try{
+            $success = $collection->createIndex($indexes, $options);
+        } catch (\MongoDB\Driver\Exception\CommandException $e) {
+            throw new IndexLimit('Index limit reached. Cannot create new index.');
+        }
 
-        return (!!$collection->createIndex($indexes, $options));
+        return (!!$success);
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -528,6 +528,10 @@ class Database
 
         $collection = $this->getCollection($collection);
 
+        if ($this->adapter->getIndexCount($collection) >= $this->adapter->getIndexLimit()) {
+            throw new IndexLimitException('Index limit reached. Cannot create new index.');
+        }
+
         $collection->setAttribute('indexes', new Document([
             '$id' => $id,
             'type' => $type,
@@ -562,10 +566,6 @@ class Database
             default:
                 throw new Exception('Unknown index type: '.$type);
                 break;
-        }
-
-        if ($this->adapter->getIndexCount($collection->getId()) >= $this->adapter->getIndexLimit()) {
-            throw new IndexLimitException('Index limit reached. Cannot create new index.');
         }
 
         return $this->adapter->createIndex($collection->getId(), $id, $type, $attributes, $lengths, $orders);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6,6 +6,7 @@ use Exception;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Structure;
 use Utopia\Database\Exception\Authorization as AuthorizationException;
+use Utopia\Database\Exception\IndexLimit as IndexLimitException;
 use Utopia\Database\Exception\Structure as StructureException;
 use Utopia\Cache\Cache;
 
@@ -561,6 +562,10 @@ class Database
             default:
                 throw new Exception('Unknown index type: '.$type);
                 break;
+        }
+
+        if ($this->adapter->getIndexCount($collection->getId()) >= $this->adapter->getIndexLimit()) {
+            throw new IndexLimitException('Index limit reached. Cannot create new index.');
         }
 
         return $this->adapter->createIndex($collection->getId(), $id, $type, $attributes, $lengths, $orders);

--- a/src/Database/Exception/IndexLimit.php
+++ b/src/Database/Exception/IndexLimit.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Utopia\Database\Exception;
+
+class IndexLimit extends \Exception
+{
+}

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1144,6 +1144,22 @@ abstract class Base extends TestCase
         return $document;
     }
 
+    public function testExceptionIndexLimit()
+    {
+        static::getDatabase()->createCollection('exceptionLimit');
+
+        // add unique attributes for indexing
+        for ($i=0; $i < 64; $i++) {
+            $this->assertEquals(true, static::getDatabase()->createAttribute('exceptionLimit', "test{$i}", Database::VAR_STRING, 256, true));
+        }
+
+        // testing for indexLimit = 64
+        $this->expectException(\Utopia\Database\Exception\IndexLimit::class);
+        for ($i=0; $i < 64; $i++) {
+            $this->assertEquals(true, static::getDatabase()->createIndex('exceptionLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [256]));
+        }
+    }
+
     /**
      * @depends testGetDocument
      */

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1150,13 +1150,13 @@ abstract class Base extends TestCase
 
         // add unique attributes for indexing
         for ($i=0; $i < 64; $i++) {
-            $this->assertEquals(true, static::getDatabase()->createAttribute('exceptionLimit', "test{$i}", Database::VAR_STRING, 256, true));
+            $this->assertEquals(true, static::getDatabase()->createAttribute('exceptionLimit', "test{$i}", Database::VAR_STRING, 16, true));
         }
 
         // testing for indexLimit = 64
         $this->expectException(\Utopia\Database\Exception\IndexLimit::class);
         for ($i=0; $i < 64; $i++) {
-            $this->assertEquals(true, static::getDatabase()->createIndex('exceptionLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [256]));
+            $this->assertEquals(true, static::getDatabase()->createIndex('exceptionLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
         }
     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -8,6 +8,7 @@ use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Authorization as ExceptionAuthorization;
 use Utopia\Database\Exception\Duplicate;
+use Utopia\Database\Exception\IndexLimit as IndexLimitException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 
@@ -1154,10 +1155,13 @@ abstract class Base extends TestCase
         }
 
         // testing for indexLimit = 64
-        $this->expectException(\Utopia\Database\Exception\IndexLimit::class);
-        for ($i=0; $i < 64; $i++) {
+        // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
+        // Add up to the limit, then check if the next index throws IndexLimitException
+        for ($i=0; $i < 61; $i++) {
             $this->assertEquals(true, static::getDatabase()->createIndex('exceptionLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
         }
+        $this->expectException(IndexLimitException::class);
+        $this->assertEquals(false, static::getDatabase()->createIndex('exceptionLimit', "index62", Database::INDEX_KEY, ["test62"], [16]));
     }
 
     /**


### PR DESCRIPTION
Each database has a maximum number of indexes per collection/table. This PR adds a new exception IndexLimit (not sure on the name), implemented per adapter, so these cases can be appropriately handled.

**Testing**
Additional tests have been added for these conditions.