### PR TITLE
Throw IndexLimit when adding index to queue

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -620,6 +620,10 @@ class Database
 
         $collection = $this->getCollection($collection);
 
+        if ($this->adapter->getIndexCount($collection) >= $this->adapter->getIndexLimit()) {
+            throw new IndexLimitException('Index limit reached. Cannot create new index.');
+        }
+
         $collection->setAttribute('indexesInQueue', new Document([
             '$id' => $id,
             'type' => $type,

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1162,6 +1162,27 @@ abstract class Base extends TestCase
         }
         $this->expectException(IndexLimitException::class);
         $this->assertEquals(false, static::getDatabase()->createIndex('exceptionLimit', "index62", Database::INDEX_KEY, ["test62"], [16]));
+
+        static::getDatabase()->deleteCollection('exceptionLimit');
+    }
+
+    public function testExceptionIndexLimitInQueue()
+    {
+        static::getDatabase()->createCollection('exceptionLimitInQueue');
+
+        // add unique attributes for indexing
+        for ($i=0; $i < 64; $i++) {
+            $this->assertEquals(true, static::getDatabase()->createAttribute('exceptionLimitInQueue', "test{$i}", Database::VAR_STRING, 16, true));
+        }
+
+        // testing for indexLimit = 64
+        // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
+        // Add up to the limit, then check if the next index throws IndexLimitException
+        for ($i=0; $i < 61; $i++) {
+            $this->assertEquals(true, static::getDatabase()->addIndexInQueue('exceptionLimitInQueue', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
+        }
+        $this->expectException(IndexLimitException::class);
+        $this->assertEquals(false, static::getDatabase()->addIndexInQueue('exceptionLimitInQueue', "index62", Database::INDEX_KEY, ["test62"], [16]));
     }
 
     /**


### PR DESCRIPTION
Appwrite creates indexes asynchronously, so the API calls `addIndexInQueue()` and triggers the Database worker to perform the action. 
To be able to throw/catch `IndexLimitException` meaningfully, this index check should be on both `createIndex` and `addIndexInQueue()`.