### PR TITLE
Throw exception on `create` when database already exists

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -205,8 +205,8 @@ class Database
      */
     public function create(): bool
     {
-        if (!$this->adapter->exists()) {
-            $this->adapter->create();
+        if ($this->adapter->exists()) {
+            throw new Exception('Cannot create a database that already exists');
         }
 
         /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -205,7 +205,9 @@ class Database
      */
     public function create(): bool
     {
-        $this->adapter->create();
+        if (!$this->adapter->exists()) {
+            $this->adapter->create();
+        }
 
         /**
          * Create array of attribute documents


### PR DESCRIPTION
If database already exists but the utopia required collections, attributes and indices do not; continue to create them anyway