### PR TITLE
Refactor findFirst to findOne

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -873,32 +873,24 @@ class Database
     /**
      * @param string $collection
      * @param array $queries
-     * @param int $limit
-     * @param int $offset
-     * @param array $orderAttributes
-     * @param array $orderTypes
      *
      * @return Document|bool
      */
-    public function findFirst(string $collection, array $queries = [], int $limit = 1, int $offset = 0, array $orderAttributes = [], array $orderTypes = [])
+    public function findFirst(string $collection, array $queries = [])
     {
-        $results = $this->find($collection, $queries, $limit, $offset, $orderAttributes, $orderTypes);
+        $results = $this->find($collection, $queries, /*limit*/ 1);
         return \reset($results);
     }
 
     /**
      * @param string $collection
      * @param array $queries
-     * @param int $limit
-     * @param int $offset
-     * @param array $orderAttributes
-     * @param array $orderTypes
      *
      * @return Document|false
      */
-    public function findLast(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [])
+    public function findLast(string $collection, array $queries = [])
     {
-        $results = $this->find($collection, $queries, $limit, $offset, $orderAttributes, $orderTypes);
+        $results = $this->find($collection, $queries, /*limit*/ 1);
         return \end($results);
     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -886,18 +886,6 @@ class Database
     }
 
     /**
-     * @param string $collection
-     * @param array $queries
-     *
-     * @return Document|false
-     */
-    public function findLast(string $collection, array $queries = [])
-    {
-        $results = $this->find($collection, $queries, /*limit*/ 1);
-        return \end($results);
-    }
-
-    /**
      * Count Documents
      * 
      * @param string $collection

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -880,7 +880,7 @@ class Database
      *
      * @return Document|bool
      */
-    public function findFirst(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [])
+    public function findFirst(string $collection, array $queries = [], int $limit = 1, int $offset = 0, array $orderAttributes = [], array $orderTypes = [])
     {
         $results = $this->find($collection, $queries, $limit, $offset, $orderAttributes, $orderTypes);
         return \reset($results);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -873,12 +873,15 @@ class Database
     /**
      * @param string $collection
      * @param array $queries
+     * @param int $offset
+     * @param array $orderAttributes
+     * @param array $orderTypes
      *
      * @return Document|bool
      */
-    public function findFirst(string $collection, array $queries = [])
+    public function findOne(string $collection, array $queries = [], int $offset = 0, array $orderAttributes = [], array $orderTypes = [])
     {
-        $results = $this->find($collection, $queries, /*limit*/ 1);
+        $results = $this->find($collection, $queries, /*limit*/ 1, $offset, $orderAttributes, $orderTypes);
         return \reset($results);
     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -743,24 +743,12 @@ abstract class Base extends TestCase
     /**
      * @depends testFind
      */
-    public function testFindFirst()
+    public function testFindOne()
     {
-        $document = static::getDatabase()->findFirst('movies', [], 4, 2, ['name']);
+        $document = static::getDatabase()->findOne('movies', [], 2, ['name']);
         $this->assertEquals('Frozen', $document['name']);
 
-        $document = static::getDatabase()->findFirst('movies', [], 4, 10);
-        $this->assertEquals(false, $document);
-    }
-
-    /**
-     * @depends testFind
-     */
-    public function testFindLast()
-    {
-        $document = static::getDatabase()->findLast('movies', [], 4, 2, ['name']);
-        $this->assertEquals('Work in Progress 2', $document['name']);
-
-        $document = static::getDatabase()->findLast('movies', [], 4, 10);
+        $document = static::getDatabase()->findOne('movies', [], 10);
         $this->assertEquals(false, $document);
     }
 


### PR DESCRIPTION
`Utopia\Database\Database->findFirst()` is primarily used to find a single document, and `findLast()` isn't used at all. 

This PR renames `findFirst` to `findOne` (similar to [mongo](https://docs.mongodb.com/php-library/current/reference/method/MongoDBCollection-findOne/)) and removes `findLast`.