### PR TITLE
feat(find): after document pagination

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,26 +13,26 @@ services:
     ports:
       - "8708:8708"
 
-  # postgres:
-  #   image: postgres:13
-  #   container_name: utopia-postgres
-  #   networks:
-  #     - database
-  #   ports:
-  #     - "8700:5432"
-  #   environment:
-  #     POSTGRES_USER: root
-  #     POSTGRES_PASSWORD: password
+  postgres:
+    image: postgres:13
+    container_name: utopia-postgres
+    networks:
+      - database
+    ports:
+      - "8700:5432"
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: password
 
-  # cockroach:
-  #   image: cockroachdb/cockroach:v20.2.0
-  #   container_name: utopia-cockroach
-  #   command: start-single-node --insecure --logtostderr
-  #   networks:
-  #     - database
-  #   ports:
-  #     - "8704:26257"
-  #     - "8705:8080"
+  cockroach:
+    image: cockroachdb/cockroach:v20.2.0
+    container_name: utopia-cockroach
+    command: start-single-node --insecure --logtostderr
+    networks:
+      - database
+    ports:
+      - "8704:26257"
+      - "8705:8080"
 
   mariadb:
     image: mariadb:10.5
@@ -55,21 +55,21 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
 
-  # mysql:
-  #   image: mysql:8.0.25
-  #   container_name: utopia-mysql
-  #   networks:
-  #     - database
-  #   ports:
-  #     - "8703:3307"
-  #   environment:
-  #     MYSQL_ROOT_PASSWORD: password
-  #     MYSQL_DATABASE: default
-  #     MYSQL_USER: user
-  #     MYSQL_PASSWORD: password
-  #     MYSQL_TCP_PORT: 3307
-  #   cap_add:
-  #     - SYS_NICE
+  mysql:
+    image: mysql:8.0.25
+    container_name: utopia-mysql
+    networks:
+      - database
+    ports:
+      - "8703:3307"
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: default
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_TCP_PORT: 3307
+    cap_add:
+      - SYS_NICE
 
   redis:
     image: redis:6.0-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,26 +13,26 @@ services:
     ports:
       - "8708:8708"
 
-  postgres:
-    image: postgres:13
-    container_name: utopia-postgres
-    networks:
-      - database
-    ports:
-      - "8700:5432"
-    environment:
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: password
+  # postgres:
+  #   image: postgres:13
+  #   container_name: utopia-postgres
+  #   networks:
+  #     - database
+  #   ports:
+  #     - "8700:5432"
+  #   environment:
+  #     POSTGRES_USER: root
+  #     POSTGRES_PASSWORD: password
 
-  cockroach:
-    image: cockroachdb/cockroach:v20.2.0
-    container_name: utopia-cockroach
-    command: start-single-node --insecure --logtostderr
-    networks:
-      - database
-    ports:
-      - "8704:26257"
-      - "8705:8080"
+  # cockroach:
+  #   image: cockroachdb/cockroach:v20.2.0
+  #   container_name: utopia-cockroach
+  #   command: start-single-node --insecure --logtostderr
+  #   networks:
+  #     - database
+  #   ports:
+  #     - "8704:26257"
+  #     - "8705:8080"
 
   mariadb:
     image: mariadb:10.5
@@ -55,21 +55,21 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: example
 
-  mysql:
-    image: mysql:8.0.25
-    container_name: utopia-mysql
-    networks:
-      - database
-    ports:
-      - "8703:3307"
-    environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: default
-      MYSQL_USER: user
-      MYSQL_PASSWORD: password
-      MYSQL_TCP_PORT: 3307
-    cap_add:
-      - SYS_NICE
+  # mysql:
+  #   image: mysql:8.0.25
+  #   container_name: utopia-mysql
+  #   networks:
+  #     - database
+  #   ports:
+  #     - "8703:3307"
+  #   environment:
+  #     MYSQL_ROOT_PASSWORD: password
+  #     MYSQL_DATABASE: default
+  #     MYSQL_USER: user
+  #     MYSQL_PASSWORD: password
+  #     MYSQL_TCP_PORT: 3307
+  #   cap_add:
+  #     - SYS_NICE
 
   redis:
     image: redis:6.0-alpine

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -233,6 +233,7 @@ abstract class Adapter
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
+     * @param Document|null $orderAfter
      *
      * @return Document[]
      */

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -236,8 +236,8 @@ abstract class Adapter
      *
      * @return Document[]
      */
-    abstract public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = []): array;
-    
+    abstract public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null): array;
+
     /**
      * Count Documents
      * 
@@ -319,7 +319,7 @@ abstract class Adapter
         if(\is_null($value)) {
             throw new Exception('Failed to filter key');
         }
-        
+
         return $value;
     }
 }

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -251,14 +251,6 @@ abstract class Adapter
     abstract public function count(string $collection, array $queries = [], int $max = 0): int;
 
     /**
-     * Get internal ID of a document.
-     * 
-     * @param Document $document 
-     * @return mixed 
-     */
-    abstract public function getInternalId(Document $document);
-
-    /**
      * Get max STRING limit
      * 
      * @return int

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -253,9 +253,9 @@ abstract class Adapter
      * Get internal ID of a document.
      * 
      * @param Document $document 
-     * @return int 
+     * @return mixed 
      */
-    abstract public function getInternalId(Document $document): int;
+    abstract public function getInternalId(Document $document);
 
     /**
      * Get max STRING limit

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -233,11 +233,11 @@ abstract class Adapter
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param Document|null $orderAfter
+     * @param array $orderAfter
      *
      * @return Document[]
      */
-    abstract public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null): array;
+    abstract public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], array $orderAfter = []): array;
 
     /**
      * Count Documents

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -250,6 +250,14 @@ abstract class Adapter
     abstract public function count(string $collection, array $queries = [], int $max = 0): int;
 
     /**
+     * Get internal ID of a document.
+     * 
+     * @param Document $document 
+     * @return int 
+     */
+    abstract public function getInternalId(Document $document): int;
+
+    /**
      * Get max STRING limit
      * 
      * @return int

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -532,7 +532,7 @@ class MariaDB extends Adapter
             $where[] = empty($condition) ? '' : '('.$condition.')';
         }
 
-        $order = (!empty($orders)) ? 'ORDER BY '.implode(', ', $orders) : '';
+        $order = 'ORDER BY '.implode(', ', $orders);
 
         $stmt = $this->getPDO()->prepare("SELECT table_main.* FROM {$this->getNamespace()}.{$name} table_main
             WHERE {$permissions} AND ".implode(' AND ', $where)."

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -563,10 +563,11 @@ class MariaDB extends Adapter
 
         foreach ($results as &$value) {
             $value['$id'] = $value['_uid'];
+            $value['$internalId'] = $value['_id'];
             $value['$read'] = (isset($value['_read'])) ? json_decode($value['_read'], true) : [];
             $value['$write'] = (isset($value['_write'])) ? json_decode($value['_write'], true) : [];
-            unset($value['_id']);
             unset($value['_uid']);
+            unset($value['_id']);
             unset($value['_read']);
             unset($value['_write']);
 
@@ -627,37 +628,6 @@ class MariaDB extends Adapter
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
 
         return $result['sum'] ?? 0;
-    }
-
-    /**
-     * Get internal ID for a document.
-     * 
-     * @param Document $document 
-     * @return int 
-     * @throws Exception 
-     * @throws PDOException 
-     */
-    public function getInternalId(Document $document): int
-    {
-        $name = $this->filter($document->getCollection());
-
-        $stmt = $this->getPDO()->prepare("SELECT _id FROM {$this->getNamespace()}.{$name}
-            WHERE _uid = :_uid
-            LIMIT 1;
-        ");
-
-        $stmt->bindValue(':_uid', $document->getId(), PDO::PARAM_STR);
-
-        $stmt->execute();
-
-        /** @var array $document */
-        $document = $stmt->fetch(PDO::FETCH_ASSOC);
-
-        if(empty($document)) {
-            throw new Exception("Document not found.");
-        }
-
-        return +$document['_id'];
     }
 
     /**

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -403,15 +403,16 @@ class MongoDB extends Adapter
      * Find data sets using chosen queries
      *
      * @param string $collection
-     * @param \Utopia\Database\Query[] $queries
+     * @param array $queries
      * @param int $limit
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
+     * @param array $orderAfter
      *
      * @return Document[]
      */
-    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null): array
+    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], array $orderAfter = []): array
     {
         $name = $this->filter($collection);
         $collection = $this->getDatabase()->$name;
@@ -435,14 +436,14 @@ class MongoDB extends Adapter
         if (empty($orderAttributes) && !empty($orderAfter)) {
             $filters = array_merge($filters, [
                 '_id' => [
-                    $this->getQueryOperator(Query::TYPE_GREATER) => new \MongoDB\BSON\ObjectId($orderAfter->getInternalId())
+                    $this->getQueryOperator(Query::TYPE_GREATER) => new \MongoDB\BSON\ObjectId($orderAfter['$internalId'])
                 ]
             ]);
         }
 
         if (!empty($orderAfter) && !empty($orderAttributes) && array_key_exists(0, $orderAttributes)) {
             $attribute = $orderAttributes[0];
-            if (is_null($orderAfter->getAttribute($attribute, null))) {
+            if (is_null($orderAfter[$attribute] ?? null)) {
                 throw new Exception("Order attribute '{$attribute}' is empty.");
             }
 
@@ -453,12 +454,12 @@ class MongoDB extends Adapter
                 '$or' => [
                     [
                         $attribute => [
-                            $this->getQueryOperator($orderOperator) => $orderAfter->getAttribute($attribute)
+                            $this->getQueryOperator($orderOperator) => $orderAfter[$attribute]
                         ]
                     ], [
-                        $attribute => $orderAfter->getAttribute($attribute),
+                        $attribute => $orderAfter[$attribute],
                         '_id' => [
-                            $this->getQueryOperator(Query::TYPE_GREATER) => new \MongoDB\BSON\ObjectId($orderAfter->getInternalId())
+                            $this->getQueryOperator(Query::TYPE_GREATER) => new \MongoDB\BSON\ObjectId($orderAfter['$internalId'])
                         ]
 
                     ]

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -563,7 +563,6 @@ class MongoDB extends Adapter
             $array[$to.'uid'] = $array[$from.'id'];
 
             if (array_key_exists($from.'internalId', $array)) {
-                $array[$to.'id'] = new \MongoDB\BSON\ObjectId($array[$from.'internalId']);
                 unset($array[$from.'internalId']);
             }
         }

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -563,7 +563,7 @@ class MongoDB extends Adapter
             $array[$to.'uid'] = $array[$from.'id'];
 
             if (array_key_exists($from.'internalId', $array)) {
-                unset($array[$from.'internalId']);
+                unset($array[$from.'internalId']); // remove unnecessary internal ID
             }
         }
 

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -115,7 +115,7 @@ class MongoDB extends Adapter
         $write = $collection->createIndex(['_write' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_write_permissions']);
 
 
-        if (!$read || !$write || $uid) {
+        if (!$read || !$write || !$uid) {
             return false;
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -540,7 +540,7 @@ class Database
         {
             throw new LimitException('Row width limit reached. Cannot create new attribute.');
         }
-    
+
         if($collection->getId() !== self::COLLECTIONS) {
             $this->updateDocument(self::COLLECTIONS, $collection->getId(), $collection);
         }
@@ -608,7 +608,7 @@ class Database
             'lengths' => $lengths,
             'orders' => $orders,
         ]), Document::SET_TYPE_APPEND);
-    
+
         if($collection->getId() !== self::COLLECTIONS) {
             $this->updateDocument(self::COLLECTIONS, $collection->getId(), $collection);
         }
@@ -631,7 +631,7 @@ class Database
                     throw new Exception('Fulltext index is not supported');
                 }
                 break;
-            
+
             default:
                 throw new Exception('Unknown index type: '.$type);
                 break;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -921,12 +921,22 @@ class Database
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
+     * @param string $orderAfter
      *
      * @return Document[]
      */
-    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null): array
+    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], string $orderAfter = null): array
     {
         $collection = $this->getCollection($collection);
+
+        if (!empty($orderAfter)) {
+            $orderAfter = $this->getDocument($collection->getId(), $orderAfter);
+            if ($orderAfter->isEmpty()) {
+                throw new Exception("orderAfter Document is not found.");
+            }
+            $internalId = $this->adapter->getInternalId($orderAfter);
+            $orderAfter->setInternalId($internalId);
+        }
 
         $results = $this->adapter->find($collection->getId(), $queries, $limit, $offset, $orderAttributes, $orderTypes, $orderAfter);
 
@@ -962,10 +972,11 @@ class Database
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
+     * @param string $orderAfter
      *
      * @return Document|false
      */
-    public function findLast(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null)
+    public function findLast(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], string $orderAfter = null)
     {
         $results = $this->find($collection, $queries, $limit, $offset, $orderAttributes, $orderTypes, $orderAfter);
         return \end($results);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -921,7 +921,7 @@ class Database
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param string $orderAfter
+     * @param Document|null $orderAfter
      *
      * @return Document[]
      */
@@ -932,6 +932,8 @@ class Database
         if (!empty($orderAfter) && $orderAfter->getCollection() !== $collection->getId()) {
             throw new Exception("orderAfter Document must be from the same Collection.");
         }
+
+        $orderAfter = empty($orderAfter) ? [] : $orderAfter->getArrayCopy();
 
         $results = $this->adapter->find($collection->getId(), $queries, $limit, $offset, $orderAttributes, $orderTypes, $orderAfter);
 
@@ -950,11 +952,11 @@ class Database
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param string|null $orderAfter
+     * @param Document|null $orderAfter
      * 
      * @return Document|bool
      */
-    public function findOne(string $collection, array $queries = [], int $offset = 0, array $orderAttributes = [], array $orderTypes = [], string $orderAfter = null)
+    public function findOne(string $collection, array $queries = [], int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null)
     {
         $results = $this->find($collection, $queries, /*limit*/ 1, $offset, $orderAttributes, $orderTypes, $orderAfter);
         return \reset($results);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -925,21 +925,15 @@ class Database
      *
      * @return Document[]
      */
-    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], string $orderAfter = null): array
+    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null): array
     {
         $collection = $this->getCollection($collection);
-        $orderAfterDocument = null;
 
-        if (!empty($orderAfter)) {
-            $orderAfterDocument = $this->getDocument($collection->getId(), $orderAfter);
-            if ($orderAfterDocument->isEmpty()) {
-                throw new Exception("orderAfter Document is not found.");
-            }
-            $internalId = $this->adapter->getInternalId($orderAfterDocument);
-            $orderAfterDocument->setInternalId($internalId);
+        if (!empty($orderAfter) && $orderAfter->getCollection() !== $collection->getId()) {
+            throw new Exception("orderAfter Document must be from the same Collection.");
         }
 
-        $results = $this->adapter->find($collection->getId(), $queries, $limit, $offset, $orderAttributes, $orderTypes, $orderAfterDocument);
+        $results = $this->adapter->find($collection->getId(), $queries, $limit, $offset, $orderAttributes, $orderTypes, $orderAfter);
 
         foreach ($results as &$node) {
             $node = $this->casting($collection, $node);

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -27,7 +27,7 @@ class Document extends ArrayObject
         if(isset($input['$read']) && !is_array($input['$read'])) {
             throw new Exception('$read permission must be of type array');
         }
-        
+
         if(isset($input['$write']) && !is_array($input['$write'])) {
             throw new Exception('$write permission must be of type array');
         }
@@ -55,6 +55,22 @@ class Document extends ArrayObject
     public function getId(): string
     {
         return $this->getAttribute('$id', '');
+    }
+
+    /**
+     * @return string
+     */
+    public function getInternalId(): int
+    {
+        return $this->getAttribute('$internalId', '');
+    }
+
+    /**
+     * @return string
+     */
+    public function setInternalId(int $internalId): void
+    {
+        $this->setAttribute('$internalId', $internalId);
     }
 
     /**
@@ -91,7 +107,7 @@ class Document extends ArrayObject
         $attributes = [];
 
         foreach ($this as $attribute => $value) {
-            if(array_key_exists($attribute, ['$id' => true, '$collection' => true, '$read' => true, '$write' => []])) {
+            if(array_key_exists($attribute, ['$id' => true, '$internalId' => true, '$collection' => true, '$read' => true, '$write' => []])) {
                 continue;
             }
 

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -60,15 +60,16 @@ class Document extends ArrayObject
     /**
      * @return string
      */
-    public function getInternalId(): int
+    public function getInternalId(): string
     {
         return $this->getAttribute('$internalId', '');
     }
 
     /**
-     * @return string
+     * @param mixed $internalId 
+     * @return void 
      */
-    public function setInternalId(int $internalId): void
+    public function setInternalId($internalId): void
     {
         $this->setAttribute('$internalId', $internalId);
     }

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -66,15 +66,6 @@ class Document extends ArrayObject
     }
 
     /**
-     * @param mixed $internalId 
-     * @return void 
-     */
-    public function setInternalId($internalId): void
-    {
-        $this->setAttribute('$internalId', $internalId);
-    }
-
-    /**
      * @return string
      */
     public function getCollection(): string

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -12,7 +12,7 @@ class Query
     const TYPE_GREATEREQUAL = 'greaterEqual';
     const TYPE_CONTAINS = 'contains';
     const TYPE_SEARCH = 'search';
-    
+
     /**
      * @var string
      */

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -193,7 +193,7 @@ class Structure extends Validator
 
         foreach ($structure as $key => $value) {
             if(!array_key_exists($key, $keys)) { // Check no unknown attributes are set
-                $this->message = 'Unknown attribute: "'. '"'.$key.'"';
+                $this->message = 'Unknown attribute: "'.$key.'"';
                 return false;
             }
 

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -32,6 +32,15 @@ class Structure extends Validator
             'filters' => [],
         ],
         [
+            '$id' => '$internalId',
+            'type' => Database::VAR_STRING,
+            'size' => 64,
+            'required' => false,
+            'signed' => true,
+            'array' => false,
+            'filters' => [],
+        ],
+        [
             '$id' => '$collection',
             'type' => Database::VAR_STRING,
             'size' => 64,
@@ -164,17 +173,17 @@ class Structure extends Validator
             $this->message = 'Value must be an instance of Document';
             return false;
         }
-        
+
         if (empty($document->getCollection())) {
             $this->message = 'Missing collection attribute $collection';
             return false;
         }
-        
+
         if (empty($this->collection->getId()) || Database::COLLECTIONS !== $this->collection->getCollection()) {
             $this->message = 'Collection "'.$this->collection->getCollection().'" not found';
             return false;
         }
-        
+
         $keys = [];
         $structure = $document->getArrayCopy();
         $attributes = \array_merge($this->attributes, $this->collection->getAttribute('attributes', []));

--- a/tests/Database/Adapter/MariaDBTest.php
+++ b/tests/Database/Adapter/MariaDBTest.php
@@ -40,6 +40,15 @@ class MariaDBTest extends Base
     }
 
     /**
+     * 
+     * @return int 
+     */
+    static function getUsedIndexes(): int
+    {
+        return 3;
+    }
+
+    /**
      * @return Adapter
      */
     static function getDatabase(): Database

--- a/tests/Database/Adapter/MongoDBTest.php
+++ b/tests/Database/Adapter/MongoDBTest.php
@@ -40,6 +40,15 @@ class MongoDBTest extends Base
     }
 
     /**
+     * 
+     * @return int 
+     */
+    static function getUsedIndexes(): int
+    {
+        return 4;
+    }
+
+    /**
      * @return Adapter
      */
     static function getDatabase(): Database

--- a/tests/Database/Adapter/MySQLTest.php
+++ b/tests/Database/Adapter/MySQLTest.php
@@ -40,6 +40,15 @@ class MySQLTest extends Base
     }
 
     /**
+     * 
+     * @return int 
+     */
+    static function getUsedIndexes(): int
+    {
+        return 3;
+    }
+
+    /**
      * @reture Adapter
      */
     static function getDatabase(): Database

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -740,17 +740,17 @@ abstract class Base extends TestCase
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[1]);
         $this->assertEquals(2, count($documents));
-        $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
-        $this->assertEquals('Captain Marvel', $documents[1]['name']);
+        $this->assertEquals($movies[2]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[3]['name'], $documents[1]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[3]);
         $this->assertEquals(2, count($documents));
-        $this->assertEquals('Work in Progress', $documents[0]['name']);
-        $this->assertEquals('Work in Progress 2', $documents[1]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[5]['name'], $documents[1]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[4]);
         $this->assertEquals(1, count($documents));
-        $this->assertEquals('Work in Progress 2', $documents[0]['name']);
+        $this->assertEquals($movies[5]['name'], $documents[0]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[5]);
         $this->assertEmpty(count($documents));
@@ -762,17 +762,17 @@ abstract class Base extends TestCase
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[1]);
         $this->assertEquals(2, count($documents));
-        $this->assertEquals('Frozen II', $documents[0]['name']);
-        $this->assertEquals('Captain Marvel', $documents[1]['name']);
+        $this->assertEquals($movies[2]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[3]['name'], $documents[1]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[3]);
         $this->assertEquals(2, count($documents));
-        $this->assertEquals('Frozen', $documents[0]['name']);
-        $this->assertEquals('Captain America: The First Avenger', $documents[1]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[5]['name'], $documents[1]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[3]);
         $this->assertEquals(1, count($documents));
-        $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
+        $this->assertEquals($movies[5]['name'], $documents[0]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[5]);
         $this->assertEmpty(count($documents));
@@ -785,17 +785,17 @@ abstract class Base extends TestCase
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[1]);
         $this->assertEquals(2, count($documents));
-        $this->assertEquals('Captain Marvel', $documents[0]['name']);
-        $this->assertEquals('Captain America: The First Avenger', $documents[1]['name']);
+        $this->assertEquals($movies[2]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[3]['name'], $documents[1]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[3]);
         $this->assertEquals(2, count($documents));
-        $this->assertEquals('Work in Progress', $documents[0]['name']);
-        $this->assertEquals('Work in Progress 2', $documents[1]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[5]['name'], $documents[1]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[4]);
         $this->assertEquals(1, count($documents));
-        $this->assertEquals('Work in Progress 2', $documents[0]['name']);
+        $this->assertEquals($movies[5]['name'], $documents[0]['name']);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[5]);
         $this->assertEmpty(count($documents));

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -18,7 +18,6 @@ abstract class Base extends TestCase
      * @return Adapter
      */
     abstract static protected function getDatabase(): Database;
-    abstract static function getAdapterName(): string;
 
     /**
      * @return string

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -29,6 +29,11 @@ abstract class Base extends TestCase
      */
     abstract static protected function getAdapterRowLimit(): int;
 
+    /**
+     * @return int
+     */
+    abstract static protected function getUsedIndexes(): int;
+
     public function setUp(): void
     {
         Authorization::setRole('role:all');
@@ -1325,12 +1330,13 @@ abstract class Base extends TestCase
 
         // testing for indexLimit = 64
         // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
+        // MongoDB create 4 indexes per new collection
         // Add up to the limit, then check if the next index throws IndexLimitException
-        for ($i=0; $i < 61; $i++) {
+        for ($i=0; $i < (64 - static::getUsedIndexes()); $i++) {
             $this->assertEquals(true, static::getDatabase()->createIndex('indexLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
         }
         $this->expectException(LimitException::class);
-        $this->assertEquals(false, static::getDatabase()->createIndex('indexLimit', "index62", Database::INDEX_KEY, ["test62"], [16]));
+        $this->assertEquals(false, static::getDatabase()->createIndex('indexLimit', "index64", Database::INDEX_KEY, ["test64"], [16]));
 
         static::getDatabase()->deleteCollection('indexLimit');
     }
@@ -1347,11 +1353,11 @@ abstract class Base extends TestCase
         // testing for indexLimit = 64
         // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
         // Add up to the limit, then check if the next index throws IndexLimitException
-        for ($i=0; $i < 61; $i++) {
+        for ($i=0; $i < (64 - static::getUsedIndexes()); $i++) {
             $this->assertEquals(true, static::getDatabase()->addIndexInQueue('indexLimitInQueue', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
         }
         $this->expectException(LimitException::class);
-        $this->assertEquals(false, static::getDatabase()->addIndexInQueue('indexLimitInQueue', "index62", Database::INDEX_KEY, ["test62"], [16]));
+        $this->assertEquals(false, static::getDatabase()->addIndexInQueue('indexLimitInQueue', "index61", Database::INDEX_KEY, ["test61"], [16]));
     }
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -730,21 +730,31 @@ abstract class Base extends TestCase
         /**
          * ORDER BY - After
          */
-        $movies = static::getDatabase()->find('movies', [], 25, 0, ['year'], [Database::ORDER_DESC]);
-        $movieOne = static::getDatabase()->getDocument($movies[1]->getCollection(), $movies[1]->getId(), true);
-        $movieTwo = static::getDatabase()->getDocument($movies[3]->getCollection(), $movies[3]->getId(), true);
+        $movies = static::getDatabase()->find('movies', [], 25, 0, [], []);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movieOne);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[1]->getId());
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
+        $this->assertEquals('Captain Marvel', $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[3]->getId());
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals('Work in Progress', $documents[0]['name']);
+        $this->assertEquals('Work in Progress 2', $documents[1]['name']);
+
+        $movies = static::getDatabase()->find('movies', [], 25, 0, ['year'], [Database::ORDER_DESC]);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[1]->getId());
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Frozen II', $documents[0]['name']);
         $this->assertEquals('Captain Marvel', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movieTwo);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[3]->getId());
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Frozen', $documents[0]['name']);
         $this->assertEquals('Captain America: The First Avenger', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movieTwo);
+        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[3]->getId());
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
 
@@ -752,15 +762,13 @@ abstract class Base extends TestCase
          * ORDER BY - Multiple After
          */
         $movies = static::getDatabase()->find('movies', [], 25, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC]);
-        $movieOne = static::getDatabase()->getDocument($movies[1]->getCollection(), $movies[1]->getId(), true);
-        $movieTwo = static::getDatabase()->getDocument($movies[3]->getCollection(), $movies[3]->getId(), true);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movieOne);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[1]->getId());
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Captain Marvel', $documents[0]['name']);
         $this->assertEquals('Captain America: The First Avenger', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movieTwo);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[3]->getId());
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Work in Progress', $documents[0]['name']);
         $this->assertEquals('Work in Progress 2', $documents[1]['name']);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -738,75 +738,67 @@ abstract class Base extends TestCase
          */
         $movies = static::getDatabase()->find('movies', [], 25, 0, [], []);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[1]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[1]);
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
         $this->assertEquals('Captain Marvel', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[3]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[3]);
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Work in Progress', $documents[0]['name']);
         $this->assertEquals('Work in Progress 2', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[4]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[4]);
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Work in Progress 2', $documents[0]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[5]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[5]);
         $this->assertEmpty(count($documents));
-
-        $this->expectException(Exception::class);
-        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], 'unknown');
 
         /**
          * ORDER BY - Single Attribute After
          */
         $movies = static::getDatabase()->find('movies', [], 25, 0, ['year'], [Database::ORDER_DESC]);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[1]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[1]);
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Frozen II', $documents[0]['name']);
         $this->assertEquals('Captain Marvel', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[3]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[3]);
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Frozen', $documents[0]['name']);
         $this->assertEquals('Captain America: The First Avenger', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[3]->getId());
+        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[3]);
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[5]->getId());
+        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[5]);
         $this->assertEmpty(count($documents));
 
-        $this->expectException(Exception::class);
-        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], 'unknown');
 
         /**
          * ORDER BY - Multiple After
          */
         $movies = static::getDatabase()->find('movies', [], 25, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC]);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[1]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[1]);
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Captain Marvel', $documents[0]['name']);
         $this->assertEquals('Captain America: The First Avenger', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[3]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[3]);
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Work in Progress', $documents[0]['name']);
         $this->assertEquals('Work in Progress 2', $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[4]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[4]);
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Work in Progress 2', $documents[0]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[5]->getId());
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[5]);
         $this->assertEmpty(count($documents));
-
-        $this->expectException(Exception::class);
-        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], 'unknown');
 
         /**
          * Limit

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -747,6 +747,13 @@ abstract class Base extends TestCase
         $this->assertEquals('Work in Progress', $documents[0]['name']);
         $this->assertEquals('Work in Progress 2', $documents[1]['name']);
 
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[4]->getId());
+        $this->assertEquals(1, count($documents));
+        $this->assertEquals('Work in Progress 2', $documents[0]['name']);
+
+        /**
+         * ORDER BY - Single Attribute After
+         */
         $movies = static::getDatabase()->find('movies', [], 25, 0, ['year'], [Database::ORDER_DESC]);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[1]->getId());
@@ -777,6 +784,10 @@ abstract class Base extends TestCase
         $this->assertEquals(2, count($documents));
         $this->assertEquals('Work in Progress', $documents[0]['name']);
         $this->assertEquals('Work in Progress 2', $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[4]->getId());
+        $this->assertEquals(1, count($documents));
+        $this->assertEquals('Work in Progress 2', $documents[0]['name']);
 
         /**
          * Limit

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Tests;
 
+use Exception;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Utopia\Database\Database;
@@ -751,6 +752,12 @@ abstract class Base extends TestCase
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Work in Progress 2', $documents[0]['name']);
 
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[5]->getId());
+        $this->assertEmpty(count($documents));
+
+        $this->expectException(Exception::class);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], 'unknown');
+
         /**
          * ORDER BY - Single Attribute After
          */
@@ -770,6 +777,12 @@ abstract class Base extends TestCase
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Captain America: The First Avenger', $documents[0]['name']);
 
+        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[5]->getId());
+        $this->assertEmpty(count($documents));
+
+        $this->expectException(Exception::class);
+        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], 'unknown');
+
         /**
          * ORDER BY - Multiple After
          */
@@ -788,6 +801,12 @@ abstract class Base extends TestCase
         $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[4]->getId());
         $this->assertEquals(1, count($documents));
         $this->assertEquals('Work in Progress 2', $documents[0]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[5]->getId());
+        $this->assertEmpty(count($documents));
+
+        $this->expectException(Exception::class);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], 'unknown');
 
         /**
          * Limit

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -183,9 +183,9 @@ class StructureTest extends TestCase
             'feedback' => 'team@appwrite.io',
         ])));
     }
-    
+
     public function testUnknownKeys()
-    {    
+    {
         $validator = new Structure(new Document($this->collection));
 
         $this->assertEquals(false, $validator->isValid(new Document([
@@ -200,13 +200,13 @@ class StructureTest extends TestCase
             'feedback' => 'team@appwrite.io',
         ])));
 
-        $this->assertEquals('Invalid document structure: Unknown attribute: ""titlex"', $validator->getDescription());
-    }  
-            
+        $this->assertEquals('Invalid document structure: Unknown attribute: "titlex"', $validator->getDescription());
+    }
+
     public function testValidDocument()
-    { 
+    {
         $validator = new Structure(new Document($this->collection));
-        
+
         $this->assertEquals(true, $validator->isValid(new Document([
             '$collection' => 'posts',
             'title' => 'Demo Title',


### PR DESCRIPTION
- allow queries to paginate after a specific document
- for MariaDB, we are using the internal `_id` as a subsequent value to query after a certain document while allowing to sort
- since we need the internal `_id` and every attribute and its proper datatype, a document need to be passed instead of only its Document ID

References can be found here: https://shopify.engineering/pagination-relative-cursors

For MongoDB we are using the same approach, except that we are using the native `_id` as a subsequent value.