### PR TITLE
Accept array of formats for custom structure validation

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -397,8 +397,8 @@ class Database
             throw new LimitException('Column limit reached. Cannot create new attribute.');
         }
 
-        if ($format && !Structure::hasFormat($format, $type)) {
-            throw new Exception('Format ("'.$format.'") not available for this attribute type ("'.$type.'")');
+        if ($format && !Structure::hasFormat(json_decode($format, true)['name'], $type)) {
+            throw new Exception('Format ("'.json_decode($format, true)['name'].'") not available for this attribute type ("'.$type.'")');
         }
 
         $collection->setAttribute('attributes', new Document([

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -806,14 +806,14 @@ class Database
      * 
      * @param string $collection
      * @param Document $document
-     * @param array{name: string, validator: Validator, type: string} $formats
+     * @param array{name: string, validator: Validator, type: string} $formats (optional) Array of format validators
      *
      * @return Document
      *
      * @throws AuthorizationException
      * @throws StructureException
      */
-    public function createDocument(string $collection, Document $document, array $formats): Document
+    public function createDocument(string $collection, Document $document, array $formats = []): Document
     {
         $validator = new Authorization($document, self::PERMISSION_WRITE);
 
@@ -849,13 +849,13 @@ class Database
      * @param string $collection
      * @param string $id
      * @param Document $document
-     * @param array{name: string, validator: Validator, type: string} $formats
+     * @param array{name: string, validator: Validator, type: string} $formats (optional) Array of format validators
      *
      * @return Document
      *
      * @throws Exception
      */
-    public function updateDocument(string $collection, string $id, Document $document, array $formats): Document
+    public function updateDocument(string $collection, string $id, Document $document, array $formats = []): Document
     {
         if (!$document->getId() || !$id) {
             throw new Exception('Must define $id attribute');

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -806,15 +806,13 @@ class Database
      * 
      * @param string $collection
      * @param Document $document
-     * @param array $formats (optional) Array of format validators
-     * {name: string, validator: \Utopia\Validator, type: string}
      *
      * @return Document
      *
      * @throws AuthorizationException
      * @throws StructureException
      */
-    public function createDocument(string $collection, Document $document, array $formats = []): Document
+    public function createDocument(string $collection, Document $document): Document
     {
         $validator = new Authorization($document, self::PERMISSION_WRITE);
 
@@ -831,7 +829,7 @@ class Database
 
         $document = $this->encode($collection, $document);
 
-        $validator = new Structure($collection, $formats);
+        $validator = new Structure($collection);
 
         if (!$validator->isValid($document)) {
             throw new StructureException($validator->getDescription());
@@ -849,14 +847,12 @@ class Database
      * 
      * @param string $collection
      * @param string $id
-     * @param array $formats (optional) Array of format validators
-     * {name: string, validator: \Utopia\Validator, type: string}
      *
      * @return Document
      *
      * @throws Exception
      */
-    public function updateDocument(string $collection, string $id, Document $document, array $formats = []): Document
+    public function updateDocument(string $collection, string $id, Document $document): Document
     {
         if (!$document->getId() || !$id) {
             throw new Exception('Must define $id attribute');
@@ -881,7 +877,7 @@ class Database
 
         $document = $this->encode($collection, $document);
 
-        $validator = new Structure($collection, $formats);
+        $validator = new Structure($collection);
 
         if (!$validator->isValid($document)) { // Make sure updated structure still apply collection rules (if any)
             throw new StructureException($validator->getDescription());

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -397,6 +397,10 @@ class Database
             throw new LimitException('Column limit reached. Cannot create new attribute.');
         }
 
+        if ($format && !Structure::hasFormat($format, $type)) {
+            throw new Exception('Format ("'.$format.'") not available for this attribute type ("'.$type.'")');
+        }
+
         $collection->setAttribute('attributes', new Document([
             '$id' => $id,
             'type' => $type,
@@ -525,6 +529,10 @@ class Database
             $this->adapter->getAttributeCount($collection) >= $this->adapter->getAttributeLimit())
         {
             throw new LimitException('Column limit reached. Cannot create new attribute.');
+        }
+
+        if ($format && !Structure::hasFormat($format, $type)) {
+            throw new Exception('Format ("'.$format.'") not available for this attribute type ("'.$type.'")');
         }
 
         $collection->setAttribute('attributesInQueue', new Document([

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -397,9 +397,12 @@ class Database
             throw new LimitException('Column limit reached. Cannot create new attribute.');
         }
 
-        if ($format && !Structure::hasFormat(json_decode($format, true)['name'], $type)) {
-            throw new Exception('Format ("'.json_decode($format, true)['name'].'") not available for this attribute type ("'.$type.'")');
-        }
+        if ($format) {
+            $name = \json_decode($format, true)['name'];
+            if (!Structure::hasFormat(json_decode($format, true)['name'], $type)) {
+                throw new Exception('Format ("'.$name.'") not available for this attribute type ("'.$type.'")');
+            }
+        } 
 
         $collection->setAttribute('attributes', new Document([
             '$id' => $id,
@@ -531,9 +534,12 @@ class Database
             throw new LimitException('Column limit reached. Cannot create new attribute.');
         }
 
-        if ($format && !Structure::hasFormat($format, $type)) {
-            throw new Exception('Format ("'.$format.'") not available for this attribute type ("'.$type.'")');
-        }
+        if ($format) {
+            $name = \json_decode($format, true)['name'];
+            if (!Structure::hasFormat(json_decode($format, true)['name'], $type)) {
+                throw new Exception('Format ("'.$name.'") not available for this attribute type ("'.$type.'")');
+            }
+        } 
 
         $collection->setAttribute('attributesInQueue', new Document([
             '$id' => $id,

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -806,7 +806,8 @@ class Database
      * 
      * @param string $collection
      * @param Document $document
-     * @param array{name: string, validator: Validator, type: string} $formats (optional) Array of format validators
+     * @param array $formats (optional) Array of format validators
+     * {name: string, validator: \Utopia\Validator, type: string}
      *
      * @return Document
      *
@@ -848,8 +849,8 @@ class Database
      * 
      * @param string $collection
      * @param string $id
-     * @param Document $document
-     * @param array{name: string, validator: Validator, type: string} $formats (optional) Array of format validators
+     * @param array $formats (optional) Array of format validators
+     * {name: string, validator: \Utopia\Validator, type: string}
      *
      * @return Document
      *

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -382,11 +382,12 @@ class Database
      * @param array|bool|callable|int|float|object|resource|string|null $default
      * @param bool $signed
      * @param bool $array
+     * @param string $format optional validation format of attribute
      * @param array $filters
      * 
      * @return bool
      */
-    public function createAttribute(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, array $filters = []): bool
+    public function createAttribute(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, string $format = null, array $filters = []): bool
     {
         $collection = $this->getCollection($collection);
 
@@ -404,6 +405,7 @@ class Database
             'default' => $default,
             'signed' => $signed,
             'array' => $array,
+            'format' => $format,
             'filters' => $filters,
         ]), Document::SET_TYPE_APPEND);
 
@@ -510,11 +512,12 @@ class Database
      * @param array|bool|callable|int|float|object|resource|string|null $default
      * @param bool $signed
      * @param bool $array
+     * @param string $format optional validation format of attribute
      * @param array $filters
      * 
      * @return bool
      */
-    public function addAttributeInQueue(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, array $filters = []): bool
+    public function addAttributeInQueue(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, string $format = null, array $filters = []): bool
     {
         $collection = $this->getCollection($collection);
 
@@ -532,6 +535,7 @@ class Database
             'default' => $default,
             'signed' => $signed,
             'array' => $array,
+            'format' => $format,
             'filters' => $filters,
         ]), Document::SET_TYPE_APPEND);
 
@@ -801,14 +805,15 @@ class Database
      * Create Document
      * 
      * @param string $collection
-     * @param Document $data
+     * @param Document $document
+     * @param array{name: string, validator: Validator, type: string} $formats
      *
      * @return Document
      *
      * @throws AuthorizationException
      * @throws StructureException
      */
-    public function createDocument(string $collection, Document $document): Document
+    public function createDocument(string $collection, Document $document, array $formats): Document
     {
         $validator = new Authorization($document, self::PERMISSION_WRITE);
 
@@ -825,7 +830,7 @@ class Database
 
         $document = $this->encode($collection, $document);
 
-        $validator = new Structure($collection);
+        $validator = new Structure($collection, $formats);
 
         if (!$validator->isValid($document)) {
             throw new StructureException($validator->getDescription());
@@ -844,12 +849,13 @@ class Database
      * @param string $collection
      * @param string $id
      * @param Document $document
+     * @param array{name: string, validator: Validator, type: string} $formats
      *
      * @return Document
      *
      * @throws Exception
      */
-    public function updateDocument(string $collection, string $id, Document $document): Document
+    public function updateDocument(string $collection, string $id, Document $document, array $formats): Document
     {
         if (!$document->getId() || !$id) {
             throw new Exception('Must define $id attribute');
@@ -874,7 +880,7 @@ class Database
 
         $document = $this->encode($collection, $document);
 
-        $validator = new Structure($collection);
+        $validator = new Structure($collection, $formats);
 
         if (!$validator->isValid($document)) { // Make sure updated structure still apply collection rules (if any)
             throw new StructureException($validator->getDescription());

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -73,8 +73,8 @@ class Structure extends Validator
     /**
      * Structure constructor.
      *
-     * @param Document $collection
-     * @param array{name: string, validator: Validator, type: string} $formats (optional) Array of format validators
+     * @param array $formats (optional) Array of format validators
+     * {name: string, validator: \Utopia\Validator, type: string}
      */
     public function __construct(Document $collection, array $formats = [])
     {

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -74,10 +74,15 @@ class Structure extends Validator
      * Structure constructor.
      *
      * @param Document $collection
+     * @param array{name: string, validator: Validator, type: string} $formats
      */
-    public function __construct(Document $collection)
+    public function __construct(Document $collection, array $formats = [])
     {
         $this->collection = $collection;
+
+        foreach ($formats as $format) {
+            self::addFormat($format['name'], $format['validator'], $format['type']);
+        }
     }
 
     /**
@@ -182,6 +187,7 @@ class Structure extends Validator
         foreach ($attributes as $key => $attribute) { // Check all required attributes are set
             $name = $attribute['$id'] ?? '';
             $required = $attribute['required'] ?? false;
+            $format = $attribute['format'] ?? false;
 
             $keys[$name] = $attribute; // List of allowed attributes to help find unknown ones
 
@@ -278,8 +284,6 @@ class Structure extends Validator
                     }
                 }
             }
-
-            // TODO check for length / size
         }
 
         return true;

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -107,6 +107,22 @@ class Structure extends Validator
     }
 
     /**
+     * Check if validator has been added
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    static public function hasFormat(string $name, string $type): bool
+    {
+        if (isset(self::$formats[$name]) && self::$formats[$name]['type'] === $type) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Get a Validator
      * 
      * @param string $name

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -74,7 +74,7 @@ class Structure extends Validator
      * Structure constructor.
      *
      * @param Document $collection
-     * @param array{name: string, validator: Validator, type: string} $formats
+     * @param array{name: string, validator: Validator, type: string} $formats (optional) Array of format validators
      */
     public function __construct(Document $collection, array $formats = [])
     {

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -73,16 +73,10 @@ class Structure extends Validator
     /**
      * Structure constructor.
      *
-     * @param array $formats (optional) Array of format validators
-     * {name: string, validator: \Utopia\Validator, type: string}
      */
-    public function __construct(Document $collection, array $formats = [])
+    public function __construct(Document $collection)
     {
         $this->collection = $collection;
-
-        foreach ($formats as $format) {
-            self::addFormat($format['name'], $format['validator'], $format['type']);
-        }
     }
 
     /**

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -275,16 +275,11 @@ class Structure extends Validator
             }
 
             if($format) {
-                $format = self::getFormat($format, $type);
-                if ($format['params']) { // get attribute params required for validator constructor, if required
-                    $params = [];
-                    foreach ($format['params'] as $param) {
-                        $params[] = $attribute[$param] ?? '';
-                    }
-                    $validator = $format['callback'](...$params);
-                } else {
-                    $validator = $format['callback']();
-                }
+                // Format encoded as json string containing format name and relevant format options
+                // E.g. Range: json_encode(['name'=>$name, 'min'=>$min, 'max'=>]);
+                $format = json_decode($format, true);
+                $format = self::getFormat($format['name'], $type);
+                $validator = $format['callback']($attribute);
 
                 if($array) { // Validate attribute type
                     if(!is_array($value)) {

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -276,7 +276,7 @@ class Structure extends Validator
 
             if($format) {
                 // Format encoded as json string containing format name and relevant format options
-                // E.g. Range: json_encode(['name'=>$name, 'min'=>$min, 'max'=>]);
+                // E.g. Range: json_encode(['name'=>$name, 'min'=>$min, 'max'=>$max]);
                 $format = json_decode($format, true);
                 $format = self::getFormat($format['name'], $type);
                 $validator = $format['callback']($attribute);

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -98,14 +98,12 @@ class Structure extends Validator
      * @param string $name
      * @param \Closure $callback Callback that accepts $params in order and returns \Utopia\Validator
      * @param string $type Primitive data type for validation
-     * @param string[] $params (optional) Attribute params required by the callback to instantiate Validator
      */
-    static public function addFormat(string $name, \Closure $callback, string $type, array $params = []): void
+    static public function addFormat(string $name, \Closure $callback, string $type): void
     {
         self::$formats[$name] = [
             'callback' => $callback,
             'type' => $type,
-            'params' => $params,
         ];
     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -181,7 +181,7 @@ abstract class Base extends TestCase
     public function testUnknownFormat()
     {
         $this->expectException(\Exception::class);
-        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'bad_format', Database::VAR_STRING, 256, true, null, true, false, 'url'));
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'bad_format', Database::VAR_STRING, 256, true, null, true, false, json_encode(['name'=>'url'])));
     }
 
     public function testAddRemoveAttribute()

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -174,6 +174,16 @@ abstract class Base extends TestCase
         $this->assertEquals(1,1);
     }
 
+    /**
+     * @depends testCreateDeleteAttribute
+     * @expectedException Exception
+     */
+    public function testUnknownFormat()
+    {
+        $this->expectException(\Exception::class);
+        $this->assertEquals(false, static::getDatabase()->createAttribute('attributes', 'bad_format', Database::VAR_STRING, 256, true, null, true, false, 'url'));
+    }
+
     public function testAddRemoveAttribute()
     {
         static::getDatabase()->createCollection('attributesInQueue');

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -94,7 +94,9 @@ class StructureTest extends TestCase
 
     public function setUp(): void
     {
-        Structure::addFormat('email', new Format(0), Database::VAR_STRING);
+        Structure::addFormat('email', function($size) {
+            return new Format($size);
+        }, Database::VAR_STRING, ['size']);
     }
 
     public function tearDown(): void

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -78,25 +78,29 @@ class StructureTest extends TestCase
                 'array' => true,
                 'filters' => [],
             ],
-            [
-                '$id' => 'feedback',
-                'type' => Database::VAR_STRING,
-                'format' => 'email',
-                'size' => 55,
-                'required' => true,
-                'signed' => true,
-                'array' => false,
-                'filters' => [],
-            ],
         ],
         'indexes' => [],
     ];
 
     public function setUp(): void
     {
-        Structure::addFormat('email', function($size) {
+        Structure::addFormat('email', function($attribute) {
+            $size = $attribute['size'] ?? 0;
             return new Format($size);
-        }, Database::VAR_STRING, ['size']);
+        }, Database::VAR_STRING);
+
+        // Cannot encode format when defining constants
+        // So add feedback attribute on startup
+        $this->collection['attributes'][] = [
+            '$id' => 'feedback',
+            'type' => Database::VAR_STRING,
+            'format' => \json_encode(['name'=>'email']),
+            'size' => 55,
+            'required' => true,
+            'signed' => true,
+            'array' => false,
+            'filters' => [],
+        ];
     }
 
     public function tearDown(): void


### PR DESCRIPTION
Most of the required logic for custom validation was [already in place](https://github.com/utopia-php/database/blob/main/src/Database/Validator/Structure.php#L258-L280) in the structure validator, but it was not being used in the Database class.

This PR:
1. Adds a param when creating attributes to store any custom validation on the attribute:
    ```php
    /**
    @param string $format JSON-encoded string of format metadata. Key 'name' required.
    */
    ```
2. Updates the logic for `Structure::addFormat` to accept a callback which creates a validator based on attribute structure. 
3. Throws an exception on `createAttribute` methods when a format is unknown.

The custom validator name is stored as the $format param for attribute creation and is used to use the correct validator for document structure. This way, validators external to this library can be passed down to structure validation.

**Testing**
- [x] TODO