### PR TITLE
Accept 36 chars as keys

### DIFF
--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -9,7 +9,7 @@ class Key extends Validator
     /**
      * @var string
      */
-    protected $message = 'Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars';
+    protected $message = 'Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars';
 
     /**
      * Get Description.
@@ -46,7 +46,7 @@ class Key extends Validator
             return false;
         }
 
-        if (\mb_strlen($value) > 32) {
+        if (\mb_strlen($value) > 36) {
             return false;
         }
 

--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -9,7 +9,7 @@ class Key extends Validator
     /**
      * @var string
      */
-    protected $message = 'Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars';
+    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore';
 
     /**
      * Get Description.

--- a/src/Database/Validator/UID.php
+++ b/src/Database/Validator/UID.php
@@ -15,6 +15,6 @@ class UID extends Key
      */
     public function getDescription()
     {
-        return 'UID must contain only alphanumeric chars or non-leading underscore, shorter than 32 chars';
+        return 'UID must contain only alphanumeric chars or non-leading underscore, shorter than 36 chars';
     }
 }

--- a/src/Database/Validator/UID.php
+++ b/src/Database/Validator/UID.php
@@ -15,6 +15,6 @@ class UID extends Key
      */
     public function getDescription()
     {
-        return 'UID must contain only alphanumeric chars or non-leading underscore, shorter than 36 chars';
+        return 'UID must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore';
     }
 }

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -43,10 +43,10 @@ class KeyTest extends TestCase
         $this->assertEquals(false, $this->object->isValid('as$$5dasdasdas'));
         $this->assertEquals(false, $this->object->isValid('as-5dasdasdas'));
 
-        // At most 32 chars
-        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribe'));
-        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscribers'));
-        $this->assertEquals(true, $this->object->isValid('5f058a89258075f058a89258075f058t'));
-        $this->assertEquals(false, $this->object->isValid('5f058a89258075f058a89258075f058tx'));
+        // At most 36 chars
+        $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribersss'));
+        $this->assertEquals(false, $this->object->isValid('socialAccountForYoutubeSubscriberssss'));
+        $this->assertEquals(true, $this->object->isValid('5f058a89258075f058a89258075f058t9214'));
+        $this->assertEquals(false, $this->object->isValid('5f058a89258075f058a89258075f058tx9214'));
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
 
         // Shorter than 36 chars
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeee']), true);
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeeee']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
@@ -126,7 +126,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertEquals($object->isValid(['team:_abcd']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['team:abcd/']), false);
         $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
         $this->assertEquals($object->isValid(['team:/abcd']), false);
@@ -136,8 +136,8 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
         $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
 
-        // Shorter than 32 chars
-        $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddd']), true);
-        $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccdddddddde']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        // Shorter than 36 chars
+        $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeee']), true);
+        $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeeee']), false);
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
@@ -126,7 +126,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertEquals($object->isValid(['team:_abcd']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
         $this->assertEquals($object->isValid(['team:abcd/']), false);
         $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
         $this->assertEquals($object->isValid(['team:/abcd']), false);
@@ -136,8 +136,8 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
         $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 32 chars');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain only letters with no spaces or special chars and be shorter than 36 chars');
     }
 }


### PR DESCRIPTION
This PR increases the supported length for Keys and UIDs from 32 chars to 36 chars. With this change, we can support `uuidv4` as valid UIDs.

**Testing**
Tests have been updated to reflect this change