### PR TITLE
[WIP] Feat: separate collection and document permissions

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -293,8 +293,8 @@ class Database
 
         $collection = new Document([
             '$id' => $id,
-            '$read' => ['role:all'],
-            '$write' => ['role:all'],
+            '$read' => [],
+            '$write' => [],
             'name' => $id,
             'attributes' => $attributes,
             'indexes' => $indexes,


### PR DESCRIPTION
This PR adds collection-level permissions to the Authorization validator. A few observations:

- `Authorization::__construct()` took a document as the first param. This isn't used at all in validation.
- Rather than remove the document altogether, we can use this to store the collection to check permissions

**Testing**
Unit tests have been added for both collection and document level permissions.