### PR TITLE
Check index limit after appending to index queue

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -322,9 +322,10 @@ abstract class Adapter
      * Get current index count from collection document
      * 
      * @param Document $collection
+     * @param bool $strict (optional) Only count indexes in collection, ignoring queue count
      * @return int
      */
-    abstract public function getIndexCount(Document $collection): int;
+    abstract public function getIndexCount(Document $collection, bool $strict = false): int;
 
     /**
      * Get maximum index limit.

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -288,9 +288,10 @@ abstract class Adapter
      * Get current attribute count from collection document
      * 
      * @param Document $collection
+     * @param bool $strict (optional) Only count attributes in collection, ignoring queue count
      * @return int
      */
-    abstract public function getAttributeCount(Document $collection): int;
+    abstract public function getAttributeCount(Document $collection, bool $strict = true): int;
 
     /**
      * Get maximum column limit.

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -682,17 +682,17 @@ class MariaDB extends Adapter
      * Get current attribute count from collection document
      * 
      * @param Document $collection
-     * @param bool $strict (optional) Only count indexes in collection, ignoring queue count
+     * @param bool $strict (optional) Only count attributes in collection, ignoring queue count
      * @return int
      */
     public function getAttributeCount(Document $collection, bool $strict = false): int
     {
-        $attributes = $collection->getAttribute('attributes') ?? [];
-        $attributesInQueue = $collection->getAttribute('attributesInQueue') ?? [];
+        $attributes = \count($collection->getAttribute('attributes') ?? []);
+        $attributesInQueue = ($strict) ? 0 : \count($collection->getAttribute('attributesInQueue') ?? []);
 
         // +4 ==> account for default columns
         // +1 ==> virtual columns count as total, so add as buffer
-        return \count($attributes) + \count($attributesInQueue) + 4 + 1;
+        return $attributes + $attributesInQueue + 4 + 1;
     }
 
     /**

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -655,15 +655,16 @@ class MariaDB extends Adapter
      * Get current index count from collection document
      * 
      * @param Document $collection
+     * @param bool $strict (optional) Only count indexes in collection, ignoring queue count
      * @return int
      */
-    public function getIndexCount(Document $collection): int
+    public function getIndexCount(Document $collection, bool $strict = false): int
     {
-        $indexes = $collection->getAttribute('indexes') ?? [];
-        $indexesInQueue = $collection->getAttribute('indexesInQueue') ?? [];
+        $indexes = \count($collection->getAttribute('indexes') ?? []);
+        $indexesInQueue = ($strict) ? 0 : \count($collection->getAttribute('indexesInQueue') ?? []);
 
         // +3 ==> hardcoded number of default indexes from createCollection
-        return \count($indexes) + \count($indexesInQueue) + 3;
+        return $indexes + $indexesInQueue + 3;
     }
 
     /**
@@ -681,9 +682,10 @@ class MariaDB extends Adapter
      * Get current attribute count from collection document
      * 
      * @param Document $collection
+     * @param bool $strict (optional) Only count indexes in collection, ignoring queue count
      * @return int
      */
-    public function getAttributeCount(Document $collection): int
+    public function getAttributeCount(Document $collection, bool $strict = false): int
     {
         $attributes = $collection->getAttribute('attributes') ?? [];
         $attributesInQueue = $collection->getAttribute('attributesInQueue') ?? [];

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -686,15 +686,16 @@ class MongoDB extends Adapter
      * Get current index count from collection document
      * 
      * @param Document $collection
+     * @param bool $strict (optional) Only count indexes in collection, ignoring queue count
      * @return int
      */
-    public function getIndexCount(Document $collection): int
+    public function getIndexCount(Document $collection, bool $strict = false): int
     {
-        $indexes = $collection->getAttribute('indexes') ?? [];
-        $indexesInQueue = $collection->getAttribute('indexesInQueue') ?? [];
+        $indexes = \count((array) $collection->getAttribute('indexes') ?? []);
+        $indexesInQueue = ($strict) ? 0 : \count((array) $collection->getAttribute('indexesInQueue') ?? []);
 
         // +3 ==> hardcoded number of default indexes from createCollection
-        return \count((array) $indexes) + \count((array) $indexesInQueue) + 3;
+        return $indexes + $indexesInQueue + 3;
     }
 
     /**

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -713,14 +713,15 @@ class MongoDB extends Adapter
      * Get current attribute count from collection document
      * 
      * @param Document $collection
+     * @param bool $strict (optional) Only count attributes in collection, ignoring queue count
      * @return int
      */
-    public function getAttributeCount(Document $collection): int
+    public function getAttributeCount(Document $collection, bool $strict = false): int
     {
-        $attributes = $collection->getAttribute('attributes') ?? [];
-        $attributesInQueue = $collection->getAttribute('attributesInQueue') ?? [];
+        $attributes = \count($collection->getAttribute('attributes') ?? []);
+        $attributesInQueue = ($strict) ? 0 : \count($collection->getAttribute('attributesInQueue') ?? []);
 
-        return \count($attributes) + \count($attributesInQueue);
+        return $attributes + $attributesInQueue;
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -689,10 +689,6 @@ class Database
 
         $collection = $this->getCollection($collection);
 
-        if ($this->adapter->getIndexCount($collection) >= $this->adapter->getIndexLimit()) {
-            throw new LimitException('Index limit reached. Cannot create new index.');
-        }
-
         $collection->setAttribute('indexesInQueue', new Document([
             '$id' => $id,
             'type' => $type,
@@ -700,7 +696,11 @@ class Database
             'lengths' => $lengths,
             'orders' => $orders,
         ]), Document::SET_TYPE_APPEND);
-    
+
+        if ($this->adapter->getIndexCount($collection) > $this->adapter->getIndexLimit()) {
+            throw new LimitException('Index limit reached. Cannot create new index.');
+        }
+
         if($collection->getId() !== self::COLLECTIONS) {
             $this->updateDocument(self::COLLECTIONS, $collection->getId(), $collection);
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -597,7 +597,7 @@ class Database
 
         $collection = $this->getCollection($collection);
 
-        if ($this->adapter->getIndexCount($collection) >= $this->adapter->getIndexLimit()) {
+        if ($this->adapter->getIndexCount($collection, true) >= $this->adapter->getIndexLimit()) {
             throw new LimitException('Index limit reached. Cannot create new index.');
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -391,7 +391,7 @@ class Database
         $collection = $this->getCollection($collection);
 
         if ($this->adapter->getAttributeLimit() > 0 && 
-            $this->adapter->getAttributeCount($collection) >= $this->adapter->getAttributeLimit())
+            $this->adapter->getAttributeCount($collection, true) >= $this->adapter->getAttributeLimit())
         {
             throw new LimitException('Column limit reached. Cannot create new attribute.');
         }
@@ -518,12 +518,6 @@ class Database
     {
         $collection = $this->getCollection($collection);
 
-        if ($this->adapter->getAttributeLimit() > 0 && 
-            $this->adapter->getAttributeCount($collection) >= $this->adapter->getAttributeLimit())
-        {
-            throw new LimitException('Column limit reached. Cannot create new attribute.');
-        }
-
         $collection->setAttribute('attributesInQueue', new Document([
             '$id' => $id,
             'type' => $type,
@@ -534,6 +528,12 @@ class Database
             'array' => $array,
             'filters' => $filters,
         ]), Document::SET_TYPE_APPEND);
+
+        if ($this->adapter->getAttributeLimit() > 0 && 
+            $this->adapter->getAttributeCount($collection) > $this->adapter->getAttributeLimit())
+        {
+            throw new LimitException('Column limit reached. Cannot create new attribute.');
+        }
 
         if ($this->adapter->getRowLimit() > 0 && 
             $this->adapter->getAttributeWidth($collection) >= $this->adapter->getRowLimit())


### PR DESCRIPTION
The previous logic properly throws `LimitException` on both `createIndex` and `addIndexInQueue` methods, when handled as separate methods. However, when implementing in Appwrite, the error must be properly thrown from `addIndexInQueue` since the Database worker, not `appwrite` itself, calls `createIndex`. 

This PR: 
1. changes the location in code where we check the limit, but no functionality has changed. Note the sign change from `>=` to `>` with the refactored logic.
2. Limit checking methods now accept a `$strict` parameter to only count columns/indexes on table and not in queue. 


**Testing**
- Existing unit tests cover proper exception handling.