### PR TITLE
Fix: remove unique index from collection name

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -230,16 +230,7 @@ class Database
             ['indexesInQueue', self::VAR_STRING, 1000000, false],
         ]);
 
-        /** @var Document[] $indexes*/
-        $indexes = [
-            new Document([
-                '$id' => '_key_1',
-                'type' => self::INDEX_UNIQUE,
-                'attributes' => ['name'],
-            ])
-        ];
-
-        $this->createCollection(self::COLLECTIONS, $attributes, $indexes);
+        $this->createCollection(self::COLLECTIONS, $attributes);
 
         return true;
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -64,6 +64,15 @@ abstract class Base extends TestCase
 
         $this->assertCount(1, static::getDatabase()->listCollections());
 
+        // Collection names should not be unique
+        $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('actors2'));
+        $this->assertCount(2, static::getDatabase()->listCollections());
+        $collection = static::getDatabase()->getCollection('actors2');
+        $collection->setAttribute('name', 'actors'); // change name to one that exists
+        $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->updateDocument($collection->getCollection(), $collection->getId(), $collection));
+        $this->assertEquals(true, static::getDatabase()->deleteCollection('actors2')); // Delete collection when finished
+        $this->assertCount(1, static::getDatabase()->listCollections());
+
         $this->assertEquals(false, static::getDatabase()->getCollection('actors')->isEmpty());
         $this->assertEquals(true, static::getDatabase()->deleteCollection('actors'));
         $this->assertEquals(true, static::getDatabase()->getCollection('actors')->isEmpty());


### PR DESCRIPTION
The `Utopia\Database\Database->create()` method created a unique index on collection names. This index has been removed, as the `uniqid` should be the only unique column.

Unanswered questions:
- [x] How to properly unit test this?