### PR TITLE
Throw exception on case-insensitive duplicate IDs

### DIFF
--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -112,10 +112,19 @@ class MongoDB extends Adapter
 
         $collection = $database->$id;
 
-        // Mongo creates an index for _id; _uid, _read and _write index by default
+        // Mongo creates an index for _id; _uid (unique, case insensitive), _read and _write index by default
         // Returns the name of the created index as a string.
-        // Update $this->getIndexCount when adding another default index
-        $uid = $collection->createIndex(['_uid' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_uid', 'unique' => true]);
+        $uid = $collection->createIndex([
+            '_uid' => $this->getOrder(Database::ORDER_DESC)],
+            [
+                'name' => '_uid',
+                'unique' => true,
+                'collation' => [ // https://docs.mongodb.com/manual/core/index-case-insensitive/#create-a-case-insensitive-index
+                    'locale' => 'en',
+                    'strength' => 1
+                ],
+            ]
+        );
         $read = $collection->createIndex(['_read' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_read_permissions']);
         $write = $collection->createIndex(['_write' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_write_permissions']);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -644,6 +644,14 @@ class Database
 
         $collection = $this->getCollection($collection);
 
+        // index IDs are case insensitive
+        $indexes = $collection->getAttribute('indexes', []); /** @var Document[] $indexes */
+        foreach ($indexes as $index) {
+            if (\strtolower($index->getId()) === \strtolower($id)) {
+                throw new DuplicateException('Index already exists');
+            }
+        }
+
         if ($this->adapter->getIndexCount($collection, true) >= $this->adapter->getIndexLimit()) {
             throw new LimitException('Index limit reached. Cannot create new index.');
         }
@@ -735,6 +743,22 @@ class Database
         }
 
         $collection = $this->getCollection($collection);
+
+        // index IDs are case insensitive
+        $indexes = $collection->getAttribute('indexes', []); /** @var Document[] $indexes */
+        $indexesInQueue = $collection->getAttribute('indexesInQueue', []); /** @var Document[] $indexesInQueue */
+
+        foreach ($indexes as $index) {
+            if (\strtolower($index->getId()) === \strtolower($id)) {
+                throw new DuplicateException('Index already exists');
+            }
+        }
+
+        foreach ($indexesInQueue as $index) {
+            if (\strtolower($index->getId()) === \strtolower($id)) {
+                throw new DuplicateException('Index already exists in queue');
+            }
+        }
 
         $collection->setAttribute('indexesInQueue', new Document([
             '$id' => $id,

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -388,11 +388,11 @@ class Database
         \array_walk($attributes, function ($attribute) use ($id) {
             if ($attribute instanceof Document) {
                 if (\strtolower($attribute->getId()) === \strtolower($id)) {
-                    throw new Duplicate('Attribute already exists', 400);
+                    throw new DuplicateException('Attribute already exists', 400);
                 }
             } else {
                 if (\strtolower($attribute['$id']) === \strtolower($id)) {
-                    throw new Duplicate('Attribute already exists', 400);
+                    throw new DuplicateException('Attribute already exists', 400);
                 }
             }
         });
@@ -541,13 +541,13 @@ class Database
 
         \array_walk($attributes, function ($attribute) use ($id) {
             if (\strtolower($attribute->getId()) === \strtolower($id)) {
-                throw new Duplicate('Attribute already exists', 400);
+                throw new DuplicateException('Attribute already exists', 400);
             }
         });
 
         \array_walk($attributesInQueue, function ($attribute) use ($id) {
             if (\strtolower($attribute->getId()) === \strtolower($id)) {
-                throw new Duplicate('Attribute already exists in queue', 400);
+                throw new DuplicateException('Attribute already exists in queue', 400);
             }
         });
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -397,17 +397,11 @@ class Database
 
         // attribute IDs are case insensitive
         $attributes = $collection->getAttribute('attributes', []); /** @var Document[] $attributes */
-        \array_walk($attributes, function ($attribute) use ($id) {
-            if ($attribute instanceof Document) {
-                if (\strtolower($attribute->getId()) === \strtolower($id)) {
-                    throw new DuplicateException('Attribute already exists', 400);
-                }
-            } else {
-                if (\strtolower($attribute['$id']) === \strtolower($id)) {
-                    throw new DuplicateException('Attribute already exists', 400);
-                }
+        foreach ($attributes as $attribute) {
+            if (\strtolower($attribute->getId()) === \strtolower($id)) {
+                throw new DuplicateException('Attribute already exists');
             }
-        });
+        }
 
         if ($this->adapter->getAttributeLimit() > 0 && 
             $this->adapter->getAttributeCount($collection, true) >= $this->adapter->getAttributeLimit())
@@ -551,17 +545,17 @@ class Database
         $attributes = $collection->getAttribute('attributes');
         $attributesInQueue = $collection->getAttribute('attributesInQueue');
 
-        \array_walk($attributes, function ($attribute) use ($id) {
+        foreach ($attributes as $attribute) {
             if (\strtolower($attribute->getId()) === \strtolower($id)) {
-                throw new DuplicateException('Attribute already exists', 400);
+                throw new DuplicateException('Attribute already exists');
             }
-        });
+        }
 
-        \array_walk($attributesInQueue, function ($attribute) use ($id) {
+        foreach ($attributesInQueue as $attribute) {
             if (\strtolower($attribute->getId()) === \strtolower($id)) {
-                throw new DuplicateException('Attribute already exists in queue', 400);
+                throw new DuplicateException('Attribute already exists in queue');
             }
-        });
+        }
 
         if ($format) {
             $name = \json_decode($format, true)['name'];

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -534,6 +534,23 @@ class Database
     {
         $collection = $this->getCollection($collection);
 
+        /** @var Document[] $attributes */
+        /** @var Document[] $attributesInQueue */
+        $attributes = $collection->getAttribute('attributes');
+        $attributesInQueue = $collection->getAttribute('attributesInQueue');
+
+        \array_walk($attributes, function ($attribute) use ($id) {
+            if (\strtolower($attribute->getId()) === \strtolower($id)) {
+                throw new Duplicate('Attribute already exists', 400);
+            }
+        });
+
+        \array_walk($attributesInQueue, function ($attribute) use ($id) {
+            if (\strtolower($attribute->getId()) === \strtolower($id)) {
+                throw new Duplicate('Attribute already exists in queue', 400);
+            }
+        });
+
         if ($format) {
             $name = \json_decode($format, true)['name'];
             if (!Structure::hasFormat(json_decode($format, true)['name'], $type)) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -179,11 +179,31 @@ abstract class Base extends TestCase
     }
 
     /**
-     * Ensure the collection is removed after use
-     * 
      * @depends testInvalidDefaultValues
      */
-    public function testCleanupInvalidDefaultValues()
+    public function testAttributeCaseInsensitivity()
+    {
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'caseSensitive', Database::VAR_STRING, 128, true));
+        $this->expectException(DuplicateException::class);
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'CaseSensitive', Database::VAR_STRING, 128, true));
+    }
+
+    /**
+     * @depends testAttributeCaseInsensitivity
+     */
+    public function testAttributeQueueCaseInsensitivity()
+    {
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'caseSensitiveInQueue', Database::VAR_STRING, 128, true));
+        $this->expectException(DuplicateException::class);
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'CaseSensitiveInQueue', Database::VAR_STRING, 128, true));
+    }
+
+    /**
+     * Ensure the collection is removed after use
+     * 
+     * @depends testAttributeQueueCaseInsensitivity
+     */
+    public function testCleanupAttributeTests()
     {
         static::getDatabase()->deleteCollection('attributes');
         $this->assertEquals(1,1);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -8,7 +8,7 @@ use stdClass;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception\Authorization as ExceptionAuthorization;
-use Utopia\Database\Exception\Duplicate;
+use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
@@ -1418,7 +1418,7 @@ abstract class Base extends TestCase
      */
     public function testExceptionDuplicate(Document $document)
     {
-        $this->expectException(Duplicate::class);
+        $this->expectException(DuplicateException::class);
 
         $document->setAttribute('$id', 'duplicated');
         
@@ -1433,7 +1433,7 @@ abstract class Base extends TestCase
      */
     public function testUniqueIndexDuplicate()
     {
-        $this->expectException(Duplicate::class);
+        $this->expectException(DuplicateException::class);
 
         $this->assertEquals(true, static::getDatabase()->createIndex('movies', 'uniqueIndex', Database::INDEX_UNIQUE, ['name'], [128], [Database::ORDER_ASC]));
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -211,9 +211,31 @@ abstract class Base extends TestCase
     }
 
     /**
+     * @depends testAttributeQueueCaseInsensitivity
+     */
+
+    public function testIndexCaseInsensitivity()
+    {
+        $this->assertEquals(true, static::getDatabase()->createIndex('attributes', 'key_caseSensitive', Database::INDEX_KEY, ['caseSensitive'], [128]));
+        $this->expectException(DuplicateException::class);
+        $this->assertEquals(true, static::getDatabase()->createIndex('attributes', 'key_CaseSensitive', Database::INDEX_KEY, ['caseSensitive'], [128]));
+    }
+
+    /**
+     * @depends testIndexCaseInsensitivity
+     */
+
+    public function testIndexQueueCaseInsensitivity()
+    {
+        $this->assertEquals(true, static::getDatabase()->createIndex('attributes', 'key_caseSensitiveInQueue', Database::INDEX_KEY, ['caseSensitive'], [128]));
+        $this->expectException(DuplicateException::class);
+        $this->assertEquals(true, static::getDatabase()->createIndex('attributes', 'key_CaseSensitiveInQueue', Database::INDEX_KEY, ['caseSensitive'], [128]));
+    }
+
+    /**
      * Ensure the collection is removed after use
      * 
-     * @depends testAttributeQueueCaseInsensitivity
+     * @depends testIndexQueueCaseInsensitivity
      */
     public function testCleanupAttributeTests()
     {


### PR DESCRIPTION
MongoDB document keys are [case sensitive](https://docs.mongodb.com/manual/core/document/#field-names), but MariaDB column names [are not](https://mariadb.com/kb/en/identifier-case-sensitivity/).

This PR adds a case-insensitive check when creating attributes/indexes or adding one to the queue, and will throw `Utopia\Database\Exception\Duplicate` if a match is found. 

This PR also changes the default index on `_uid` for the MongoDB adapter to be case-insensitive.

**Testing**
Tests have been added to catch these exceptions.

**Unanswered questions**
- [x] ~~When adding attributes to a collection, the attribute document is appended to `$attribute->getAttribute('attributes')`, and when fetched, returns `Document[] $attributes`. However, when adding all attributes at once via `createCollection`, I receive just a plain array, not a Document. I had to hack around this problem, and I would like to not have to do this:~~
