### PR TITLE
Accept periods, spaces, and hyphens as keys

### DIFF
--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -9,7 +9,7 @@ class Key extends Validator
     /**
      * @var string
      */
-    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore';
+    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces';
 
     /**
      * Get Description.
@@ -38,11 +38,19 @@ class Key extends Validator
             return false;
         }
 
+        // no leading underscores
         if(mb_substr($value, 0, 1) === '_') {
             return false;
         }
+
+        // no trailing spaces
+        // https://mariadb.com/kb/en/identifier-names/#further-rules
+        if(\rtrim($value) !== $value) {
+            return false;
+        }
         
-        if (\preg_match('/[^A-Za-z0-9\_]/', $value)) {
+        // Valid chars: A-Z, a-z, 0-9, underscore, period, hyphen, space
+        if (\preg_match('/[^A-Za-z0-9\_\.\-\ ]/', $value)) {
             return false;
         }
 

--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -9,7 +9,7 @@ class Key extends Validator
     /**
      * @var string
      */
-    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces';
+    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore';
 
     /**
      * Get Description.
@@ -43,14 +43,8 @@ class Key extends Validator
             return false;
         }
 
-        // no trailing spaces
-        // https://mariadb.com/kb/en/identifier-names/#further-rules
-        if(\rtrim($value) !== $value) {
-            return false;
-        }
-        
         // Valid chars: A-Z, a-z, 0-9, underscore, period, hyphen, space
-        if (\preg_match('/[^A-Za-z0-9\_\.\-\ ]/', $value)) {
+        if (\preg_match('/[^A-Za-z0-9\_\.\-]/', $value)) {
             return false;
         }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -141,6 +141,20 @@ abstract class Base extends TestCase
         $collection = static::getDatabase()->getCollection('attributes');
         $this->assertCount(0, $collection->getAttribute('attributes'));
 
+        // Test for custom chars in ID
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as_5dasdasdas', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as5dasdasdas_', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', '.as5dasdasdas', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as.5dasdasdas', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as5dasdasdas.', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', '-as5dasdasdas', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as-5dasdasdas', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as5dasdasdas-', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'dasda asdasd', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', ' dasdaasdasd', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'socialAccountForYoutubeSubscribersss', Database::VAR_BOOLEAN, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', '5f058a89258075f058a89258075f058t9214', Database::VAR_BOOLEAN, 0, true));
+
         // Using this collection to test invalid default values
         // static::getDatabase()->deleteCollection('attributes');
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -150,8 +150,6 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', '-as5dasdasdas', Database::VAR_BOOLEAN, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as-5dasdasdas', Database::VAR_BOOLEAN, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'as5dasdasdas-', Database::VAR_BOOLEAN, 0, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'dasda asdasd', Database::VAR_BOOLEAN, 0, true));
-        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', ' dasdaasdasd', Database::VAR_BOOLEAN, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'socialAccountForYoutubeSubscribersss', Database::VAR_BOOLEAN, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', '5f058a89258075f058a89258075f058t9214', Database::VAR_BOOLEAN, 0, true));
 

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -36,14 +36,7 @@ class KeyTest extends TestCase
         $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
         $this->assertEquals(true, $this->object->isValid('a_sdasdasdas'));
 
-        // No trailing spaces
-        $this->assertEquals(false, $this->object->isValid('asdasdads    '));
-        $this->assertEquals(false, $this->object->isValid('asdasdads   '));
-        $this->assertEquals(false, $this->object->isValid('asdasdads  '));
-        $this->assertEquals(false, $this->object->isValid('asdasdads '));
-        $this->assertEquals(true, $this->object->isValid('asdasdads'));
-
-        // Special chars allowed: underscore, period, hyphen, space
+        // Special chars allowed: underscore, period, hyphen
         $this->assertEquals(true, $this->object->isValid('as5dadasdas_'));
         $this->assertEquals(true, $this->object->isValid('as_5dasdasdas'));
         $this->assertEquals(true, $this->object->isValid('.as5dasdasdas'));
@@ -52,9 +45,8 @@ class KeyTest extends TestCase
         $this->assertEquals(true, $this->object->isValid('-as5dasdasdas'));
         $this->assertEquals(true, $this->object->isValid('as5dasdasdas-'));
         $this->assertEquals(true, $this->object->isValid('as-5dasdasdas'));
-        $this->assertEquals(true, $this->object->isValid('dasda asdasd'));
-        $this->assertEquals(true, $this->object->isValid(' dasdaasdasd'));
 
+        $this->assertEquals(false, $this->object->isValid('dasda asdasd'));
         $this->assertEquals(false, $this->object->isValid('asd"asd6sdas'));
         $this->assertEquals(false, $this->object->isValid('asd\'as0asdas'));
         $this->assertEquals(false, $this->object->isValid('as!5dasdasdas'));

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -36,12 +36,39 @@ class KeyTest extends TestCase
         $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
         $this->assertEquals(true, $this->object->isValid('a_sdasdasdas'));
 
-        // No Special characters
-        $this->assertEquals(false, $this->object->isValid('dasda asdasd'));
+        // No trailing spaces
+        $this->assertEquals(false, $this->object->isValid('asdasdads    '));
+        $this->assertEquals(false, $this->object->isValid('asdasdads   '));
+        $this->assertEquals(false, $this->object->isValid('asdasdads  '));
+        $this->assertEquals(false, $this->object->isValid('asdasdads '));
+        $this->assertEquals(true, $this->object->isValid('asdasdads'));
+
+        // Special chars allowed: underscore, period, hyphen, space
+        $this->assertEquals(true, $this->object->isValid('as5dadasdas_'));
+        $this->assertEquals(true, $this->object->isValid('as_5dasdasdas'));
+        $this->assertEquals(true, $this->object->isValid('.as5dasdasdas'));
+        $this->assertEquals(true, $this->object->isValid('as5dasdasdas.'));
+        $this->assertEquals(true, $this->object->isValid('as.5dasdasdas'));
+        $this->assertEquals(true, $this->object->isValid('-as5dasdasdas'));
+        $this->assertEquals(true, $this->object->isValid('as5dasdasdas-'));
+        $this->assertEquals(true, $this->object->isValid('as-5dasdasdas'));
+        $this->assertEquals(true, $this->object->isValid('dasda asdasd'));
+        $this->assertEquals(true, $this->object->isValid(' dasdaasdasd'));
+
         $this->assertEquals(false, $this->object->isValid('asd"asd6sdas'));
         $this->assertEquals(false, $this->object->isValid('asd\'as0asdas'));
-        $this->assertEquals(false, $this->object->isValid('as$$5dasdasdas'));
-        $this->assertEquals(false, $this->object->isValid('as-5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as!5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as@5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as#5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as$5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as%5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as^5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as&5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as*5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as(5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as)5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as+5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('as=5dasdasdas'));
 
         // At most 36 chars
         $this->assertEquals(true, $this->object->isValid('socialAccountForYoutubeSubscribersss'));

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
 
         // Shorter than 36 chars
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeee']), true);
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeeee']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
@@ -126,7 +126,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertEquals($object->isValid(['team:_abcd']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
         $this->assertEquals($object->isValid(['team:abcd/']), false);
         $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
         $this->assertEquals($object->isValid(['team:/abcd']), false);
@@ -136,8 +136,8 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
         $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
 
         // Shorter than 36 chars
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeee']), true);
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeeee']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
@@ -126,7 +126,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertEquals($object->isValid(['team:_abcd']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['team:abcd/']), false);
         $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
         $this->assertEquals($object->isValid(['team:/abcd']), false);
@@ -136,8 +136,8 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
         $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, underscore, and space. Can\'t start with a leading underscore or have trailing spaces');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
     }
 }


### PR DESCRIPTION
This PR adds support for additional special characters for keys: periods, spaces, and hyphens. As custom attributes, however, MariaDB brings the following restriction:

> Database, table and column names can't end with space characters
> ref: https://mariadb.com/kb/en/identifier-names/#further-rules

This PR adds the extra characters to the Key validator (which UID inherits) and adds both unit tests and as attributes on each database adapter. 

The regex changes just add the additional characters as valid:
https://github.com/utopia-php/database/blob/1f6ce90e2649b874a662bdf8c0cd0cb5b0ce836b/src/Database/Validator/Key.php#L52-L55
![regexforkeys](https://user-images.githubusercontent.com/9708641/128432338-57aa7da2-29a1-41f0-ae52-1ffc715ca8f7.png)
