### PR TITLE
feat(order-type): allow order type with natural order

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -524,10 +524,19 @@ class MariaDB extends Adapter
                     )";
             }
         }
-        $orders[] = '_id '.Database::ORDER_ASC; // Enforce last ORDER by '_id'
 
+        // Allow after pagination without any order
         if (empty($orderAttributes) && !empty($orderAfter)) {
-            $where[] = "( _id > {$orderAfter['$internalId']} )"; // Allow after pagination without any order
+            $where[] = "( _id > {$orderAfter['$internalId']} )";
+        }
+
+        // Allow order type without any order attribute, fallback to the natural order (_id)
+        if(empty($orderAttributes) && !empty($orderTypes)) {
+            $attribute = $this->filter('_id');
+            $orderType = $this->filter($orderTypes[0] ?? Database::ORDER_ASC);
+            $orders[] = $attribute.' '.$orderType;
+        } else {
+            $orders[] = '_id '.Database::ORDER_ASC; // Enforce last ORDER by '_id'
         }
 
         $permissions = (Authorization::$status) ? $this->getSQLPermissions($roles) : '1=1'; // Disable join when no authorization required

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -532,9 +532,7 @@ class MariaDB extends Adapter
 
         // Allow order type without any order attribute, fallback to the natural order (_id)
         if(empty($orderAttributes) && !empty($orderTypes)) {
-            $attribute = $this->filter('_id');
-            $orderType = $this->filter($orderTypes[0] ?? Database::ORDER_ASC);
-            $orders[] = $attribute.' '.$orderType;
+            $orders[] = '_id '.$this->filter($orderTypes[0] ?? Database::ORDER_ASC);
         } else {
             $orders[] = '_id '.Database::ORDER_ASC; // Enforce last ORDER by '_id'
         }

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -438,12 +438,21 @@ class MongoDB extends Adapter
 
         // queries
         $filters = $this->buildFilters($queries);
-        if (empty($orderAttributes) && !empty($orderAfter)) {
-            $filters = array_merge($filters, [
-                '_id' => [
-                    $this->getQueryOperator(Query::TYPE_GREATER) => new \MongoDB\BSON\ObjectId($orderAfter['$internalId'])
-                ]
-            ]);
+
+        if (empty($orderAttributes)) {
+            // Allow after pagination without any order
+            if(!empty($orderAfter)) {
+                $filters = array_merge($filters, [
+                    '_id' => [
+                        $this->getQueryOperator(Query::TYPE_GREATER) => new \MongoDB\BSON\ObjectId($orderAfter['$internalId'])
+                    ]
+                ]);
+            }
+            // Allow order type without any order attribute, fallback to the natural order (_id)
+            if(!empty($orderTypes)) {
+                $orderType = $this->getOrder($this->filter($orderTypes[0] ?? Database::ORDER_ASC));
+                $options['sort']['_id'] = $orderType;
+            }
         }
 
         if (!empty($orderAfter) && !empty($orderAttributes) && array_key_exists(0, $orderAttributes)) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -740,6 +740,20 @@ abstract class Base extends TestCase
         $this->assertEquals('Work in Progress 2', $documents[5]['name']);
 
         /**
+         * ORDER BY natural
+         */
+        $base = array_reverse(static::getDatabase()->find('movies', [], 25, 0));
+        $documents = static::getDatabase()->find('movies', [], 25, 0, [], [Database::ORDER_DESC]);
+
+        $this->assertEquals(6, count($documents));
+        $this->assertEquals($base[0]['name'], $documents[0]['name']);
+        $this->assertEquals($base[1]['name'], $documents[1]['name']);
+        $this->assertEquals($base[2]['name'], $documents[2]['name']);
+        $this->assertEquals($base[3]['name'], $documents[3]['name']);
+        $this->assertEquals($base[4]['name'], $documents[4]['name']);
+        $this->assertEquals($base[5]['name'], $documents[5]['name']);
+
+        /**
          * ORDER BY - Multiple attributes
          */
         $documents = static::getDatabase()->find('movies', [], 25, 0, ['price', 'name'], [Database::ORDER_DESC, Database::ORDER_DESC]);


### PR DESCRIPTION
- allows to order by `ASC` or `DESC` without specifying any `orderAttributes`
- this will fallback to the natural order by `_id`