### PR TITLE
fix(cache): don't save document into cache on update

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1122,7 +1122,7 @@ class Database
                     foreach (array_reverse($filters) as $filter) {
                         $node = $this->decodeAttribute($filter, $node);
 
-                        if (array_key_exists('$id', $node)) { // if `$id` exists, create a Document instance
+                        if ($filter === 'json' && array_key_exists('$id', $node)) { // if `$id` exists, create a Document instance
                             $node = new Document($node);
                         }
                     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -893,10 +893,6 @@ class Database
 
         $this->cache->purge('cache-'.$this->getNamespace().'-'.$collection->getId().'-'.$id);
 
-        if (!empty($document->getInternalId())) { // Only save document into cache, when internal ID is present
-            $this->cache->save('cache-'.$this->getNamespace().'-'.$collection->getId().'-'.$id, $document->getArrayCopy());
-        }
-
         return $document;
     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -892,7 +892,10 @@ class Database
         $document = $this->decode($collection, $document);
 
         $this->cache->purge('cache-'.$this->getNamespace().'-'.$collection->getId().'-'.$id);
-        $this->cache->save('cache-'.$this->getNamespace().'-'.$collection->getId().'-'.$id, $document->getArrayCopy());
+
+        if (!empty($document->getInternalId())) { // Only save document into cache, when internal ID is present
+            $this->cache->save('cache-'.$this->getNamespace().'-'.$collection->getId().'-'.$id, $document->getArrayCopy());
+        }
 
         return $document;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -164,7 +164,20 @@ class Database
                     return $value;
                 }
 
-                return json_decode($value, true);
+                $value = json_decode($value, true);
+
+                if(array_key_exists('$id', $value)) {
+                    return new Document($value);
+                } else {
+                    $value = array_map(function ($item) {
+                        if (is_array($item) && array_key_exists('$id', $item)) { // if `$id` exists, create a Document instance
+                            return new Document($item);
+                        }
+                        return $item;
+                    }, $value);
+                }
+
+                return $value;
             }
         );
     }
@@ -1121,10 +1134,6 @@ class Database
                 if (($node !== null)) {
                     foreach (array_reverse($filters) as $filter) {
                         $node = $this->decodeAttribute($filter, $node);
-
-                        if ($filter === 'json' && array_key_exists('$id', $node)) { // if `$id` exists, create a Document instance
-                            $node = new Document($node);
-                        }
                     }
                 }
             }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1114,17 +1114,21 @@ class Database
             if(is_null($value)) {
                 continue;
             }
-            
+
             $value = ($array) ? $value : [$value];
 
             foreach ($value as &$node) {
                 if (($node !== null)) {
                     foreach (array_reverse($filters) as $filter) {
                         $node = $this->decodeAttribute($filter, $node);
+
+                        if (array_key_exists('$id', $node)) { // if `$id` exist, create a Document instance
+                            $node = new Document($node);
+                        }
                     }
                 }
             }
-            
+
             $document->setAttribute($key, ($array) ? $value : $value[0]);
         }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1166,9 +1166,9 @@ abstract class Base extends TestCase
         $this->assertEquals([], $result->getAttribute('memberships'));
         $this->assertEquals(['admin','developer','tester',], $result->getAttribute('roles'));
         $this->assertEquals([
-            ['$id' => '1', 'label' => 'x'],
-            ['$id' => '2', 'label' => 'y'],
-            ['$id' => '3', 'label' => 'z'],
+            new Document(['$id' => '1', 'label' => 'x']),
+            new Document(['$id' => '2', 'label' => 'y']),
+            new Document(['$id' => '3', 'label' => 'z']),
         ], $result->getAttribute('tags'));
     }
 


### PR DESCRIPTION
Problem:
- when a collection get created, the cache only had the version without an internal ID present

Solution:
- only save a document into cache on `updateDocument` when an internal ID is present