### PR TITLE
Fix default attribute index count

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -88,13 +88,6 @@ abstract class Adapter
     }
 
     /**
-     * Returns number of indexes used by default.
-     * 
-     * @return int 
-     */
-    abstract static public function getNumberOfDefaultIndexes(): int;
-
-    /**
      * Create Database
      *
      * @return bool
@@ -315,6 +308,20 @@ abstract class Adapter
      * @return int
      */
     abstract public static function getRowLimit(): int;
+
+    /**
+     * Returns number of attributes used by default.
+     *
+     * @return int
+     */
+    abstract static public function getNumberOfDefaultAttributes(): int;
+
+    /**
+     * Returns number of indexes used by default.
+     *
+     * @return int
+     */
+    abstract static public function getNumberOfDefaultIndexes(): int;
 
     /**
      * Estimate maximum number of bytes required to store a document in $collection.

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -31,11 +31,6 @@ class MariaDB extends Adapter
         $this->pdo = $pdo;
     }
 
-    public static function getNumberOfDefaultIndexes(): int
-    {
-        return 4;
-    }
-
     /**
      * Create Database
      * 
@@ -737,7 +732,7 @@ class MariaDB extends Adapter
         $attributesInQueue = ($strict) ? 0 : \count($collection->getAttribute('attributesInQueue') ?? []);
 
         // +1 ==> virtual columns count as total, so add as buffer
-        return $attributes + $attributesInQueue + static::getNumberOfDefaultIndexes() + 1;
+        return $attributes + $attributesInQueue + static::getNumberOfDefaultAttributes() + 1;
     }
 
     /**
@@ -761,6 +756,16 @@ class MariaDB extends Adapter
     public static function getRowLimit(): int
     {
         return 65535;
+    }
+
+    public static function getNumberOfDefaultAttributes(): int
+    {
+        return 4;
+    }
+
+    public static function getNumberOfDefaultIndexes(): int
+    {
+        return 3;
     }
 
     /**

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -31,11 +31,6 @@ class MongoDB extends Adapter
         $this->client = $client;
     }
 
-    public static function getNumberOfDefaultIndexes(): int
-    {
-        return 4;
-    }
-
     /**
      * Create Database
      * 
@@ -782,7 +777,7 @@ class MongoDB extends Adapter
         $attributes = \count($collection->getAttribute('attributes') ?? []);
         $attributesInQueue = ($strict) ? 0 : \count($collection->getAttribute('attributesInQueue') ?? []);
 
-        return $attributes + $attributesInQueue;
+        return $attributes + $attributesInQueue + static::getNumberOfDefaultAttributes();
     }
 
     /**
@@ -805,6 +800,16 @@ class MongoDB extends Adapter
     public static function getRowLimit(): int
     {
         return 0;
+    }
+
+    public static function getNumberOfDefaultAttributes(): int
+    {
+        return 4;
+    }
+
+    public static function getNumberOfDefaultIndexes(): int
+    {
+        return 3;
     }
 
     /**

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -112,15 +112,14 @@ class MongoDB extends Adapter
 
         $collection = $database->$id;
 
-        // Mongo creates an index for _id; _uid, _read and _write index by default
+        // Mongo creates an index for _id; _uid and _read index by default
         // Returns the name of the created index as a string.
         // Update $this->getIndexCount when adding another default index
         $uid = $collection->createIndex(['_uid' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_uid', 'unique' => true]);
         $read = $collection->createIndex(['_read' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_read_permissions']);
-        $write = $collection->createIndex(['_write' => $this->getOrder(Database::ORDER_DESC)], ['name' => '_write_permissions']);
 
 
-        if (!$read || !$write || !$uid) {
+        if (!$uid || !$read) {
             return false;
         }
 


### PR DESCRIPTION
In https://github.com/utopia-php/database/pull/46, we refactored the default index count into a public static method for clarity and maintainability. However, I overlooked in my review that we don't have a 1-1 for default attributes&indexes - we don't index **$write** permissions since they aren't used in any of our queries. 

This PR:
- Removes the default index on `_write` in the MongoDB adapter
- Adds an additional method `getNumberOfDefaultAttributes()` to adapters.

**Testing**
Current test suite is sufficient to cover this change.