### PR TITLE
Removed unused document from Authorization constructor

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -783,7 +783,7 @@ class Database
         // TODO@kodumbeats Check if returned cache id matches request
         if ($cache = $this->cache->load('cache-'.$this->getNamespace().'-'.$collection->getId().'-'.$id, self::TTL)) {
             $document = new Document($cache);
-            $validator = new Authorization($document, self::PERMISSION_READ);
+            $validator = new Authorization(self::PERMISSION_READ);
 
             if (!$validator->isValid($document->getRead()) && $collection->getId() !== self::COLLECTIONS) { // Check if user has read access to this document
                 return new Document();
@@ -800,7 +800,7 @@ class Database
 
         $document->setAttribute('$collection', $collection->getId());
 
-        $validator = new Authorization($document, self::PERMISSION_READ);
+        $validator = new Authorization(self::PERMISSION_READ);
 
         if (!$validator->isValid($document->getRead()) && $collection->getId() !== self::COLLECTIONS) { // Check if user has read access to this document
             return new Document();
@@ -831,7 +831,7 @@ class Database
      */
     public function createDocument(string $collection, Document $document): Document
     {
-        $validator = new Authorization($document, self::PERMISSION_WRITE);
+        $validator = new Authorization(self::PERMISSION_WRITE);
 
         if (!$validator->isValid($document->getWrite())) { // Check if user has write access to this document
             throw new AuthorizationException($validator->getDescription());
@@ -882,7 +882,7 @@ class Database
         // $data['$id'] = $old->getId();
         // $data['$collection'] = $old->getCollection();
 
-        $validator = new Authorization($old, 'write');
+        $validator = new Authorization('write');
 
         if (!$validator->isValid($old->getWrite())) { // Check if user has write access to this document
             throw new AuthorizationException($validator->getDescription());
@@ -920,7 +920,7 @@ class Database
     {
         $document = $this->getDocument($collection, $id);
 
-        $validator = new Authorization($document, 'write');
+        $validator = new Authorization('write');
 
         if (!$validator->isValid($document->getWrite())) { // Check if user has write access to this document
             throw new AuthorizationException($validator->getDescription());

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -13,11 +13,6 @@ class Authorization extends Validator
     static $roles = ['role:all' => true];
 
     /**
-     * @var Document
-     */
-    protected $document;
-
-    /**
      * @var string
      */
     protected $action = '';
@@ -28,12 +23,10 @@ class Authorization extends Validator
     protected $message = 'Authorization Error';
 
     /**
-     * @param Document $document
-     * @param string   $action
+     * @param string $action
      */
-    public function __construct(Document $document, $action)
+    public function __construct($action)
     {
-        $this->document = $document;
         $this->action = $action;
     }
 

--- a/tests/Database/Validator/AuthorizationTest.php
+++ b/tests/Database/Validator/AuthorizationTest.php
@@ -24,7 +24,7 @@ class AuthorizationTest extends TestCase
             '$read' => ['user:123', 'team:123'],
             '$write' => ['role:all'],
         ]);
-        $object = new Authorization($document, 'read');
+        $object = new Authorization('read');
 
         $this->assertEquals($object->isValid($document->getRead()), false);
         $this->assertEquals($object->isValid(''), false);


### PR DESCRIPTION
The Authorization validator required a `Utopia\Database\Document` object but isn't used during validation. This PR removes the document from the constructor.

**Testing**
Test suite has been updated to reflect this change.