### PR TITLE
feat(query): before pagination

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -233,7 +233,7 @@ abstract class Adapter
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param array $cursor
+     * @param array $cursor Array copy of document used for before/after pagination
      * @param string $cursorDirection
      *
      * @return Document[]

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -233,11 +233,12 @@ abstract class Adapter
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param array $orderAfter
+     * @param array $cursor
+     * @param string $cursorDirection
      *
      * @return Document[]
      */
-    abstract public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], array $orderAfter = []): array;
+    abstract public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], array $cursor = [], string $cursorDirection = Database::CURSOR_AFTER): array;
 
     /**
      * Count Documents

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -507,7 +507,7 @@ class MariaDB extends Adapter
 
             // Get most dominant/first order attribute
             if ($i === 0 && !empty($cursor)) {
-                $orderOperatorInternalId = Query::TYPE_GREATER;
+                $orderOperatorInternalId = Query::TYPE_GREATER; // To preserve natural order
                 $orderOperator = $orderType === Database::ORDER_DESC ? Query::TYPE_LESSER : Query::TYPE_GREATER;
 
                 if ($cursorDirection === Database::CURSOR_BEFORE) {

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -517,9 +517,9 @@ class MariaDB extends Adapter
                 }
 
                 $where[] = "(
-                        {$attribute} {$this->getSQLOperator($orderOperator)} :after 
+                        {$attribute} {$this->getSQLOperator($orderOperator)} :cursor 
                         OR (
-                            {$attribute} = :after 
+                            {$attribute} = :cursor 
                             AND
                             _id {$this->getSQLOperator($orderOperatorInternalId)} {$cursor['$internalId']}
                         )
@@ -585,7 +585,7 @@ class MariaDB extends Adapter
             if (is_null($cursor[$attribute] ?? null)) {
                 throw new Exception("Order attribute '{$attribute}' is empty.");
             }
-            $stmt->bindValue(':after', $cursor[$attribute], $this->getPDOType($cursor[$attribute]));
+            $stmt->bindValue(':cursor', $cursor[$attribute], $this->getPDOType($cursor[$attribute]));
         }
 
         $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -608,7 +608,7 @@ class MariaDB extends Adapter
         }
 
         if ($cursorDirection === Database::CURSOR_BEFORE) {
-            $results = array_reverse($results);
+            $results = array_reverse($results); //TODO: check impact on array_reverse
         }
 
         return $results;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -40,6 +40,10 @@ class Database
     // Collections
     const COLLECTIONS = 'collections';
 
+    // Cursor
+    const CURSOR_BEFORE = 'before';
+    const CURSOR_AFTER = 'after';
+
     // Lengths
     const LENGTH_KEY = 255;
 
@@ -990,21 +994,22 @@ class Database
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param Document|null $orderAfter
+     * @param Document|null $cursor
+     * @param string $cursorDirection
      *
      * @return Document[]
      */
-    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null): array
+    public function find(string $collection, array $queries = [], int $limit = 25, int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $cursor = null, string $cursorDirection = self::CURSOR_AFTER): array
     {
         $collection = $this->getCollection($collection);
 
-        if (!empty($orderAfter) && $orderAfter->getCollection() !== $collection->getId()) {
+        if (!empty($cursor) && $cursor->getCollection() !== $collection->getId()) {
             throw new Exception("orderAfter Document must be from the same Collection.");
         }
 
-        $orderAfter = empty($orderAfter) ? [] : $orderAfter->getArrayCopy();
+        $cursor = empty($cursor) ? [] : $cursor->getArrayCopy();
 
-        $results = $this->adapter->find($collection->getId(), $queries, $limit, $offset, $orderAttributes, $orderTypes, $orderAfter);
+        $results = $this->adapter->find($collection->getId(), $queries, $limit, $offset, $orderAttributes, $orderTypes, $cursor, $cursorDirection);
 
         foreach ($results as &$node) {
             $node = $this->casting($collection, $node);
@@ -1021,13 +1026,14 @@ class Database
      * @param int $offset
      * @param array $orderAttributes
      * @param array $orderTypes
-     * @param Document|null $orderAfter
+     * @param Document|null $cursor
+     * @param string $cursorDirection
      * 
      * @return Document|bool
      */
-    public function findOne(string $collection, array $queries = [], int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $orderAfter = null)
+    public function findOne(string $collection, array $queries = [], int $offset = 0, array $orderAttributes = [], array $orderTypes = [], Document $cursor = null, string $cursorDirection = Database::CURSOR_AFTER)
     {
-        $results = $this->find($collection, $queries, /*limit*/ 1, $offset, $orderAttributes, $orderTypes, $orderAfter);
+        $results = $this->find($collection, $queries, /*limit*/ 1, $offset, $orderAttributes, $orderTypes, $cursor, $cursorDirection);
         return \reset($results);
     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1004,7 +1004,7 @@ class Database
         $collection = $this->getCollection($collection);
 
         if (!empty($cursor) && $cursor->getCollection() !== $collection->getId()) {
-            throw new Exception("orderAfter Document must be from the same Collection.");
+            throw new Exception("cursor Document must be from the same Collection.");
         }
 
         $cursor = empty($cursor) ? [] : $cursor->getArrayCopy();

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -843,6 +843,33 @@ abstract class Base extends TestCase
         $this->assertEmpty(count($documents));
 
         /**
+         * ORDER BY - Before
+         */
+        $movies = static::getDatabase()->find('movies', [], 25, 0, [], []);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[5], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[3]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[3], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[1]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[2]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[2], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[1]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[1], Database::CURSOR_BEFORE);
+        $this->assertEquals(1, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [], $movies[0], Database::CURSOR_BEFORE);
+        $this->assertEmpty(count($documents));
+
+        /**
          * ORDER BY - After by natural order
          */
         $movies = array_reverse(static::getDatabase()->find('movies', [], 25, 0, [], []));
@@ -865,6 +892,33 @@ abstract class Base extends TestCase
         $this->assertEmpty(count($documents));
 
         /**
+         * ORDER BY - Before by natural order
+         */
+        $movies = array_reverse(static::getDatabase()->find('movies', [], 25, 0, [], []));
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [Database::ORDER_DESC], $movies[5], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[3]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [Database::ORDER_DESC], $movies[3], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[1]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[2]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [Database::ORDER_DESC], $movies[2], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[1]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [Database::ORDER_DESC], $movies[1], Database::CURSOR_BEFORE);
+        $this->assertEquals(1, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, [], [Database::ORDER_DESC], $movies[0], Database::CURSOR_BEFORE);
+        $this->assertEmpty(count($documents));
+
+        /**
          * ORDER BY - Single Attribute After
          */
         $movies = static::getDatabase()->find('movies', [], 25, 0, ['year'], [Database::ORDER_DESC]);
@@ -879,16 +933,43 @@ abstract class Base extends TestCase
         $this->assertEquals($movies[4]['name'], $documents[0]['name']);
         $this->assertEquals($movies[5]['name'], $documents[1]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[3]);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[4]);
         $this->assertEquals(1, count($documents));
         $this->assertEquals($movies[5]['name'], $documents[0]['name']);
 
-        $documents = static::getDatabase()->find('movies', [], 1, 1, ['year'], [Database::ORDER_DESC], $movies[5]);
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[5]);
+        $this->assertEmpty(count($documents));
+
+        /**
+         * ORDER BY - Single Attribute Before
+         */
+        $movies = static::getDatabase()->find('movies', [], 25, 0, ['year'], [Database::ORDER_DESC]);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[5], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[3]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[3], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[1]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[2]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[2], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[1]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[1], Database::CURSOR_BEFORE);
+        $this->assertEquals(1, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['year'], [Database::ORDER_DESC], $movies[0], Database::CURSOR_BEFORE);
         $this->assertEmpty(count($documents));
 
 
         /**
-         * ORDER BY - Multiple After
+         * ORDER BY - Multiple Attribute After
          */
         $movies = static::getDatabase()->find('movies', [], 25, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC]);
 
@@ -910,6 +991,34 @@ abstract class Base extends TestCase
         $this->assertEmpty(count($documents));
 
         /**
+         * ORDER BY - Multiple Attribute Before
+         */
+        $movies = static::getDatabase()->find('movies', [], 25, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC]);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[5], Database::CURSOR_BEFORE);
+
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[3]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[4]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[4], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[2]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[3]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[2], Database::CURSOR_BEFORE);
+        $this->assertEquals(2, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+        $this->assertEquals($movies[1]['name'], $documents[1]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[1], Database::CURSOR_BEFORE);
+        $this->assertEquals(1, count($documents));
+        $this->assertEquals($movies[0]['name'], $documents[0]['name']);
+
+        $documents = static::getDatabase()->find('movies', [], 2, 0, ['price', 'year'], [Database::ORDER_DESC, Database::ORDER_ASC], $movies[0], Database::CURSOR_BEFORE);
+        $this->assertEmpty(count($documents));
+
+        /**
          * ORDER BY - After Exception
          */
 
@@ -919,7 +1028,6 @@ abstract class Base extends TestCase
 
         $this->expectException(Exception::class);
         static::getDatabase()->find('movies', [], 2, 0, [], [], $document);
-
 
         /**
          * Limit

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -894,7 +894,7 @@ abstract class Base extends TestCase
         /**
          * ORDER BY - Before by natural order
          */
-        $movies = array_reverse(static::getDatabase()->find('movies', [], 25, 0, [], []));
+        $movies = static::getDatabase()->find('movies', [], 25, 0, [], [Database::ORDER_DESC]);
 
         $documents = static::getDatabase()->find('movies', [], 2, 0, [], [Database::ORDER_DESC], $movies[5], Database::CURSOR_BEFORE);
         $this->assertEquals(2, count($documents));


### PR DESCRIPTION
Adds the ability to paginate `before` an id.

Technically, it will be done the way `after` is paginated - just that the ordering is reversed and after we fetched the results we invert the array. Sadly there is no easy implementation, since negative offsets are not a thing.

Source: https://medium.com/swlh/how-to-implement-cursor-pagination-like-a-pro-513140b65f32

Breaking changes:
- renames `orderAfter` to `cursor`
- adds `cursorDirection` with `after` by default
