### PR TITLE
Disallow leading special characters for Keys

### DIFF
--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -9,7 +9,7 @@ class Key extends Validator
     /**
      * @var string
      */
-    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore';
+    protected $message = 'Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char';
 
     /**
      * Get Description.
@@ -38,8 +38,9 @@ class Key extends Validator
             return false;
         }
 
-        // no leading underscores
-        if(mb_substr($value, 0, 1) === '_') {
+        // no leading special characters
+        $leading = \mb_substr($value, 0, 1);
+        if($leading === '_' || $leading === '.' || $leading === '-') {
             return false;
         }
 

--- a/tests/Database/Validator/KeyTest.php
+++ b/tests/Database/Validator/KeyTest.php
@@ -32,17 +32,16 @@ class KeyTest extends TestCase
         $this->assertEquals(true, $this->object->isValid('asdas7as9as'));
         $this->assertEquals(true, $this->object->isValid('5f058a8925807'));
 
-        // No leading underscore
+        // No leading special chars
         $this->assertEquals(false, $this->object->isValid('_asdasdasdas'));
-        $this->assertEquals(true, $this->object->isValid('a_sdasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('.as5dasdasdas'));
+        $this->assertEquals(false, $this->object->isValid('-as5dasdasdas'));
 
         // Special chars allowed: underscore, period, hyphen
         $this->assertEquals(true, $this->object->isValid('as5dadasdas_'));
         $this->assertEquals(true, $this->object->isValid('as_5dasdasdas'));
-        $this->assertEquals(true, $this->object->isValid('.as5dasdasdas'));
         $this->assertEquals(true, $this->object->isValid('as5dasdasdas.'));
         $this->assertEquals(true, $this->object->isValid('as.5dasdasdas'));
-        $this->assertEquals(true, $this->object->isValid('-as5dasdasdas'));
         $this->assertEquals(true, $this->object->isValid('as5dasdasdas-'));
         $this->assertEquals(true, $this->object->isValid('as-5dasdasdas'));
 

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -99,20 +99,20 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading underscores
         $this->assertEquals($object->isValid(['member:_1234']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
 
         // No special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
         $this->assertEquals($object->isValid(['user:12&4']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
         $this->assertEquals($object->isValid(['member:ab(124']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
 
         // Shorter than 36 chars
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeee']), true);
         $this->assertEquals($object->isValid(['user:aaaaaaaabbbbbbbbccccccccddddddddeeeee']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertEquals($object->isValid(['memmber:1234']), false);
@@ -126,7 +126,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertEquals($object->isValid(['team:_abcd']), false);
-        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
         $this->assertEquals($object->isValid(['team:abcd/']), false);
         $this->assertEquals($object->getDescription(), 'Team role must not be empty.');
         $this->assertEquals($object->isValid(['team:/abcd']), false);
@@ -136,8 +136,8 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->isValid(['team:abcd/e/fgh']), false);
         $this->assertEquals($object->getDescription(), 'Permission roles may contain at most one "/" character.');
         $this->assertEquals($object->isValid(['team:ab&cd3/efgh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
-        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a leading underscore');
+        $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -97,11 +97,15 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->getDescription(), 'Permission roles must be one of: all, guest, member');
 
         // team:$value, member:$value and user:$value must have valid Key for $value
-        // No leading underscores
+        // No leading special chars
         $this->assertEquals($object->isValid(['member:_1234']), false);
         $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
+        $this->assertEquals($object->isValid(['member:-1234']), false);
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
+        $this->assertEquals($object->isValid(['member:.1234']), false);
+        $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
 
-        // No special characters
+        // No unsupported special characters
         $this->assertEquals($object->isValid(['member:12$4']), false);
         $this->assertEquals($object->getDescription(), '[role:$id] $id must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
         $this->assertEquals($object->isValid(['user:12&4']), false);


### PR DESCRIPTION
This PR changes the Key validator to no longer accept leading hyphens and periods as valid.

**Testing**:
The test suite has been updated to reflect this change.