### PR TITLE
Accept array of index documents when constructing Queries validator

### DIFF
--- a/src/Database/Validator/Queries.php
+++ b/src/Database/Validator/Queries.php
@@ -4,6 +4,7 @@ namespace Utopia\Database\Validator;
 
 use Utopia\Validator;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Validator\QueryValidator;
 use Utopia\Database\Query;
 
@@ -38,15 +39,21 @@ class Queries extends Validator
      * Queries constructor
      *
      * @param QueryValidator $validator
-     * @param array $indexes
-     * @param array $indexesInQueue
+     * @param Document[] $indexes
+     * @param Document[] $indexesInQueue
      * @param bool $strict
      */
     public function __construct($validator, $indexes, $indexesInQueue, $strict = true)
     {
         $this->validator = $validator;
-        $this->indexes = $indexes;
-        $this->indexesInQueue = $indexesInQueue;
+
+        foreach ($indexes as $index) {
+            $this->indexes[] = $index->getArrayCopy(['attributes', 'type']);
+        }
+        foreach ($indexesInQueue as $index) {
+            $this->indexesInQueue[] = $index->getArrayCopy(['attributes', 'type']);
+        }
+
         $this->strict = $strict;
     }
 

--- a/tests/Database/Validator/QueriesTest.php
+++ b/tests/Database/Validator/QueriesTest.php
@@ -5,6 +5,7 @@ namespace Utopia\Tests\Validator;
 use Utopia\Database\Validator\QueryValidator;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Queries;
 
@@ -73,63 +74,8 @@ class QueriesTest extends TestCase
                 'filters' => [],
             ],
         ],
-        'indexes' => [
-            [
-                '$id' => 'testindex',
-                'type' => 'key',
-                'attributes' => [
-                    'title',
-                    'description'
-                ],
-                'orders' => [
-                    'ASC',
-                    'DESC'
-                ],
-            ],
-            [
-                '$id' => 'testindex2',
-                'type' => 'key',
-                'attributes' => [
-                    'title',
-                    'description',
-                    'price'
-                ],
-                'orders' => [
-                    'ASC',
-                    'DESC'
-                ],
-            ],
-            [
-                '$id' => 'testindex3',
-                'type' => 'fulltext',
-                'attributes' => [
-                    'title'
-                ],
-                'orders' => []
-            ],
-            [
-                '$id' => 'testindex4',
-                'type' => 'key',
-                'attributes' => [
-                    'description'
-                ],
-                'orders' => []
-            ],
-        ],
-        'indexesInQueue' => [
-            [
-                '$id' => 'testindex4',
-                'type' => 'key',
-                'attributes' => [
-                    'price',
-                    'title'
-                ],
-                'orders' => [
-                    'ASC',
-                    'DESC'
-                ]
-            ],
-        ]
+        'indexes' => [],
+        'indexesInQueue' => []
     ];
 
 
@@ -151,6 +97,67 @@ class QueriesTest extends TestCase
         $query2 = Query::parse('description.equal("Best movie ever")');
 
         array_push($this->queries, $query1, $query2);
+
+        // Constructor expects Document[] $indexes
+        // Object property declaration cannot initialize a Document object
+        // Add Document[] $indexes separately
+        $index1 = new Document([
+            '$id' => 'testindex',
+            'type' => 'key',
+            'attributes' => [
+                'title',
+                'description'
+            ],
+            'orders' => [
+                'ASC',
+                'DESC'
+            ],
+        ]);
+
+        $index2 = new Document([
+            '$id' => 'testindex2',
+            'type' => 'key',
+            'attributes' => [
+                'title',
+                'description',
+                'price'
+            ],
+            'orders' => [
+                'ASC',
+                'DESC'
+            ],
+        ]);
+        $index3 = new Document([
+            '$id' => 'testindex3',
+            'type' => 'fulltext',
+            'attributes' => [
+                'title'
+            ],
+            'orders' => []
+        ]);
+        $index4 = new Document([
+            '$id' => 'testindex4',
+            'type' => 'key',
+            'attributes' => [
+                'description'
+            ],
+            'orders' => []
+        ]);
+        $indexInQueue = new Document([
+            '$id' => 'testindex4',
+            'type' => 'key',
+            'attributes' => [
+                'price',
+                'title'
+            ],
+            'orders' => [
+                'ASC',
+                'DESC'
+            ]
+        ]);
+
+        $this->collection['indexes'] = [$index1, $index2, $index3, $index4];
+        $this->collection['indexesInQueue'] = [$indexInQueue];
     }
 
     public function tearDown(): void


### PR DESCRIPTION
This PR refactors the Queries validator constructor method to accept array of documents:
```diff
- @var array $indexes
+ @var Document[] $indexes

- @var array $indexesInQueue
+ @var Document[] $indexesInQueue
```

This improves the DX when consuming in Appwrite, as the construction of Queries validator becomes simpler:
```php
$validator = new Queries($queryValidator, $collection->getAttribute('indexes'), $collection->getAttribute('indexesInQueue'));
```

**Testing**:
The current test suite should cover this modification.