### PR TITLE
Throw correct error when updating documents with unique index

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -375,7 +375,7 @@ class MariaDB extends Adapter
                 case 1062:
                 case 23000:
                     $this->getPDO()->rollBack();
-                    throw new Duplicate('Duplicated document: '.$e->getMessage()); // TODO add test for catching this exception
+                    throw new Duplicate('Duplicated document: '.$e->getMessage());
                     break;
 
                 default:
@@ -434,7 +434,21 @@ class MariaDB extends Adapter
         }
 
         if(!empty($attributes)) {
-            $stmt->execute();
+            try {
+                $stmt->execute();
+            } catch (PDOException $e) {
+                switch ($e->getCode()) {
+                    case 1062:
+                    case 23000:
+                        $this->getPDO()->rollBack();
+                        throw new Duplicate('Duplicated document: '.$e->getMessage());
+                        break;
+
+                    default:
+                        throw $e;
+                        break;
+                }
+            }
         }
 
         if(!$this->getPDO()->commit()) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1567,4 +1567,26 @@ abstract class Base extends TestCase
             'generes' => ['animation', 'kids'],
         ]));
     }
+
+    /**
+     * @depends testUniqueIndexDuplicate
+     */
+    public function testUniqueIndexDuplicateUpdate()
+    {
+        // create document then update to conflict with index
+        $document = static::getDatabase()->createDocument('movies', new Document([
+            '$read' => ['role:all', 'user1', 'user2'],
+            '$write' => ['role:all', 'user1x', 'user2x'],
+            'name' => 'Frozen 5',
+            'director' => 'Chris Buck & Jennifer Lee',
+            'year' => 2013,
+            'price' => 39.50,
+            'active' => true,
+            'generes' => ['animation', 'kids'],
+        ]));
+
+        $this->expectException(DuplicateException::class);
+
+        static::getDatabase()->updateDocument('movies', $document->getId(), $document->setAttribute('name',  'Frozen'));
+    }
 }


### PR DESCRIPTION
This PR catches the exception thrown when a collection enforces a unique index, and a document is updated to conflict with an existing document in the collection.

**Testing**:
Tests have been added to catch this exception properly.