### PR TITLE
Add test for case insensitive documentID

### DIFF
--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1537,11 +1537,24 @@ abstract class Base extends TestCase
      */
     public function testExceptionDuplicate(Document $document)
     {
-        $this->expectException(DuplicateException::class);
-
         $document->setAttribute('$id', 'duplicated');
-        
         static::getDatabase()->createDocument($document->getCollection(), $document);
+
+        $this->expectException(DuplicateException::class);
+        static::getDatabase()->createDocument($document->getCollection(), $document);
+    }
+
+    /**
+     * @depends testGetDocument
+     */
+    public function testExceptionCaseInsensitiveDuplicate(Document $document)
+    {
+        $document->setAttribute('$id', 'caseSensitive');
+        static::getDatabase()->createDocument($document->getCollection(), $document);
+
+        $document->setAttribute('$id', 'CaseSensitive');
+
+        $this->expectException(DuplicateException::class);
         static::getDatabase()->createDocument($document->getCollection(), $document);
         
         return $document;


### PR DESCRIPTION
This PR adds a test to check the case-insensitive index on `$id` across all adapters.

**Related PRs**
https://github.com/utopia-php/database/pull/49

**Testing**
Tests are included in this PR