### PR TITLE
Pass document and database to encodeAttribute to mirror decodeAttribute

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -966,7 +966,7 @@ class Database
             foreach ($value as &$node) {
                 if (($node !== null)) {
                     foreach ($filters as $filter) {
-                        $node = $this->encodeAttribute($filter, $node);
+                        $node = $this->encodeAttribute($filter, $node, $document);
                     }
                 }
             }
@@ -1075,14 +1075,14 @@ class Database
      * 
      * @return mixed
      */
-    protected function encodeAttribute(string $name, $value)
+    protected function encodeAttribute(string $name, $value, Document $document)
     {
         if (!isset(self::$filters[$name])) {
             throw new Exception('Filter not found');
         }
 
         try {
-            $value = self::$filters[$name]['encode']($value);
+            $value = self::$filters[$name]['encode']($value, $document, $this);
         } catch (\Throwable $th) {
             throw $th;
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1069,9 +1069,13 @@ class Database
 
     /**
      * Encode Attribute
+     *
+     * Passes the attribute $value, and $document context to a predefined filter
+     *  that allow you to manipulate the input format of the given attribute.
      * 
      * @param string $name
      * @param mixed $value
+     * @param Document $document
      * 
      * @return mixed
      */


### PR DESCRIPTION
In https://github.com/utopia-php/database/pull/64, we added the ability to pass the document when encoding an attribute:
https://github.com/utopia-php/database/blob/7c26cb324ccefb047f06733f59871c937dba4cb9/src/Database/Database.php#L1093-L1105

This PR extends that functionality to encodeAttribute so we can manipulate the document when trying to encode into a database format. 