### PR TITLE
Add checkAttribute method

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -473,6 +473,40 @@ class Database
     }
 
     /**
+     * Checks if attribute can be added to collection.
+     * Used to check attribute limits without asking the database
+     * Returns true if attribute can be added to collection, throws exception otherwise
+     *
+     * @param Document $collection
+     * @param Document $attribute
+     *
+     * @throws LimitException
+     * @return bool
+     */
+    public function checkAttribute(Document $collection, Document $attribute): bool
+    {
+        $collection = clone $collection;
+
+        $collection->setAttribute('attributes', $attribute, Document::SET_TYPE_APPEND);
+
+        if ($this->adapter->getAttributeLimit() > 0 &&
+            $this->adapter->getAttributeCount($collection) > $this->adapter->getAttributeLimit())
+        {
+            throw new LimitException('Column limit reached. Cannot create new attribute.');
+            return false;
+        }
+
+        if ($this->adapter->getRowLimit() > 0 &&
+            $this->adapter->getAttributeWidth($collection) >= $this->adapter->getRowLimit())
+        {
+            throw new LimitException('Row width limit reached. Cannot create new attribute.');
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Delete Attribute
      * 
      * @param string $collection

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1296,6 +1296,35 @@ abstract class Base extends TestCase
     }
 
     /**
+     * @depends testExceptionAttributeLimit
+     */
+    public function testCheckAttributeCountLimit()
+    {
+        if (static::getAdapterName() === 'mariadb' || static::getAdapterName() === 'mysql') {
+            $collection = static::getDatabase()->getCollection('attributeLimit');
+
+            // create same attribute in testExceptionAttributeLimit
+            $attribute = new Document([
+                    '$id' => 'breaking',
+                    'type' => Database::VAR_INTEGER,
+                    'size' => 0,
+                    'required' => true,
+                    'default' => null,
+                    'signed' => true,
+                    'array' => false,
+                    'filters' => [],
+            ]);
+
+            $this->expectException(LimitException::class);
+            $this->assertEquals(false, static::getDatabase()->checkAttribute($collection, $attribute));
+        }
+
+        // Default assertion for other adapters
+        $this->assertEquals(1,1);
+
+    }
+
+    /**
      * Using phpunit dataProviders to check that all these combinations of types/sizes throw exceptions
      * https://phpunit.de/manual/3.7/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers
      */
@@ -1388,6 +1417,35 @@ abstract class Base extends TestCase
             $this->expectException(LimitException::class);
             $this->assertEquals(false, static::getDatabase()->createAttribute("widthLimit{$key}", "breaking", Database::VAR_STRING, 100, true));
         } 
+
+        // Default assertion for other adapters
+        $this->assertEquals(1,1);
+    }
+
+    /**
+     * @dataProvider rowWidthExceedsMaximum
+     * @depends testExceptionWidthLimit
+     */
+    public function testCheckAttributeWidthLimit($key, $stringSize, $stringCount, $intCount, $floatCount, $boolCount)
+    {
+        if (static::getAdapterRowLimit() > 0) {
+            $collection = static::getDatabase()->getCollection("widthLimit{$key}");
+
+            // create same attribute in testExceptionWidthLimit
+            $attribute = new Document([
+                    '$id' => 'breaking',
+                    'type' => Database::VAR_STRING,
+                    'size' => 100,
+                    'required' => true,
+                    'default' => null,
+                    'signed' => true,
+                    'array' => false,
+                    'filters' => [],
+            ]);
+
+            $this->expectException(LimitException::class);
+            $this->assertEquals(false, static::getDatabase()->checkAttribute($collection, $attribute));
+        }
 
         // Default assertion for other adapters
         $this->assertEquals(1,1);


### PR DESCRIPTION
If attribute creation/deletion are performed entirely asynchronously, then there's no way to throw an in-memory exception for attribute limits. This PR creates a method which checks for attribute limits without modifying the original `Document $collection` object.

**Testing**
This PR includes tests for each exception the new method throws.

**Questions**
- [ ] Should we take the DRY approach and use this method in `Database->createAttribute()`?

