### PR TITLE
feat: get limit methods on database

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -473,6 +473,40 @@ class Database
     }
 
     /**
+     * Checks if attribute can be added to collection.
+     * Used to check attribute limits without asking the database
+     * Returns true if attribute can be added to collection, throws exception otherwise
+     *
+     * @param Document $collection
+     * @param Document $attribute
+     *
+     * @throws LimitException
+     * @return bool
+     */
+    public function checkAttribute(Document $collection, Document $attribute): bool
+    {
+        $collection = clone $collection;
+
+        $collection->setAttribute('attributes', $attribute, Document::SET_TYPE_APPEND);
+
+        if ($this->adapter->getAttributeLimit() > 0 &&
+            $this->adapter->getAttributeCount($collection) > $this->adapter->getAttributeLimit())
+        {
+            throw new LimitException('Column limit reached. Cannot create new attribute.');
+            return false;
+        }
+
+        if ($this->adapter->getRowLimit() > 0 &&
+            $this->adapter->getAttributeWidth($collection) >= $this->adapter->getRowLimit())
+        {
+            throw new LimitException('Row width limit reached. Cannot create new attribute.');
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Delete Attribute
      * 
      * @param string $collection

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1164,4 +1164,27 @@ class Database
     {
         return \uniqid();
     }
+
+    /**
+     * Get adapter attribute limit, accounting for internal metadata
+     * Returns 0 to indicate no limit
+     *
+     * @return int
+     */
+    public function getAttributeLimit()
+    {
+        // If negative, return 0
+        // -1 ==> virtual columns count as total, so treat as buffer
+        return \max($this->adapter->getAttributeLimit() - $this->adapter->getNumberOfDefaultAttributes() - 1, 0);
+    }
+
+    /**
+     * Get adapter index limit
+     *
+     * @return int
+     */
+    public function getIndexLimit()
+    {
+        return $this->adapter->getIndexLimit() - $this->adapter->getNumberOfDefaultIndexes();
+    }
 }

--- a/tests/Database/Adapter/MariaDBTest.php
+++ b/tests/Database/Adapter/MariaDBTest.php
@@ -40,15 +40,6 @@ class MariaDBTest extends Base
     }
 
     /**
-     * 
-     * @return int 
-     */
-    static function getUsedIndexes(): int
-    {
-        return MariaDB::getNumberOfDefaultIndexes();
-    }
-
-    /**
      * @return Adapter
      */
     static function getDatabase(): Database

--- a/tests/Database/Adapter/MongoDBTest.php
+++ b/tests/Database/Adapter/MongoDBTest.php
@@ -40,15 +40,6 @@ class MongoDBTest extends Base
     }
 
     /**
-     * 
-     * @return int 
-     */
-    static function getUsedIndexes(): int
-    {
-        return MongoDB::getNumberOfDefaultIndexes();
-    }
-
-    /**
      * @return Adapter
      */
     static function getDatabase(): Database

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1295,7 +1295,7 @@ abstract class Base extends TestCase
      */
     public function testCheckAttributeCountLimit()
     {
-        if (static::getAdapterName() === 'mariadb' || static::getAdapterName() === 'mysql') {
+        if ($this->getDatabase()->getAttributeLimit() > 0) {
             $collection = static::getDatabase()->getCollection('attributeLimit');
 
             // create same attribute in testExceptionAttributeLimit

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1265,7 +1265,7 @@ abstract class Base extends TestCase
 
     public function testExceptionAttributeLimit()
     {
-        if (static::getAdapterName() === 'mariadb' || static::getAdapterName() === 'mysql') {
+        if ($this->getDatabase()->getAttributeLimit() > 0) {
             // load the collection up to the limit
             $attributes = [];
             for ($i=0; $i < $this->getDatabase()->getAttributeLimit(); $i++) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1296,6 +1296,35 @@ abstract class Base extends TestCase
     }
 
     /**
+     * @depends testExceptionAttributeLimit
+     */
+    public function testCheckAttributeCountLimit()
+    {
+        if (static::getAdapterName() === 'mariadb' || static::getAdapterName() === 'mysql') {
+            $collection = static::getDatabase()->getCollection('attributeLimit');
+
+            // create same attribute in testExceptionAttributeLimit
+            $attribute = new Document([
+                    '$id' => 'breaking',
+                    'type' => Database::VAR_INTEGER,
+                    'size' => 0,
+                    'required' => true,
+                    'default' => null,
+                    'signed' => true,
+                    'array' => false,
+                    'filters' => [],
+            ]);
+
+            $this->expectException(LimitException::class);
+            $this->assertEquals(false, static::getDatabase()->checkAttribute($collection, $attribute));
+        }
+
+        // Default assertion for other adapters
+        $this->assertEquals(1,1);
+
+    }
+
+    /**
      * Using phpunit dataProviders to check that all these combinations of types/sizes throw exceptions
      * https://phpunit.de/manual/3.7/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers
      */
@@ -1388,6 +1417,35 @@ abstract class Base extends TestCase
             $this->expectException(LimitException::class);
             $this->assertEquals(false, static::getDatabase()->createAttribute("widthLimit{$key}", "breaking", Database::VAR_STRING, 100, true));
         } 
+
+        // Default assertion for other adapters
+        $this->assertEquals(1,1);
+    }
+
+    /**
+     * @dataProvider rowWidthExceedsMaximum
+     * @depends testExceptionWidthLimit
+     */
+    public function testCheckAttributeWidthLimit($key, $stringSize, $stringCount, $intCount, $floatCount, $boolCount)
+    {
+        if (static::getAdapterRowLimit() > 0) {
+            $collection = static::getDatabase()->getCollection("widthLimit{$key}");
+
+            // create same attribute in testExceptionWidthLimit
+            $attribute = new Document([
+                    '$id' => 'breaking',
+                    'type' => Database::VAR_STRING,
+                    'size' => 100,
+                    'required' => true,
+                    'default' => null,
+                    'signed' => true,
+                    'array' => false,
+                    'filters' => [],
+            ]);
+
+            $this->expectException(LimitException::class);
+            $this->assertEquals(false, static::getDatabase()->checkAttribute($collection, $attribute));
+        }
 
         // Default assertion for other adapters
         $this->assertEquals(1,1);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1268,7 +1268,7 @@ abstract class Base extends TestCase
         if (static::getAdapterName() === 'mariadb' || static::getAdapterName() === 'mysql') {
             // load the collection up to the limit
             $attributes = [];
-            for ($i=0; $i < 1012; $i++) {
+            for ($i=0; $i < $this->getDatabase()->getAttributeLimit(); $i++) {
                 $attributes[] = new Document([
                     '$id' => "test{$i}",
                     'type' => Database::VAR_INTEGER,
@@ -1459,7 +1459,7 @@ abstract class Base extends TestCase
         // MariaDB, MySQL, and MongoDB create 3 indexes per new collection
         // MongoDB create 4 indexes per new collection
         // Add up to the limit, then check if the next index throws IndexLimitException
-        for ($i=0; $i < (64 - static::getUsedIndexes()); $i++) {
+        for ($i=0; $i < ($this->getDatabase()->getIndexLimit()); $i++) {
             $this->assertEquals(true, static::getDatabase()->createIndex('indexLimit', "index{$i}", Database::INDEX_KEY, ["test{$i}"], [16]));
         }
         $this->expectException(LimitException::class);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -30,11 +30,6 @@ abstract class Base extends TestCase
      */
     abstract static protected function getAdapterRowLimit(): int;
 
-    /**
-     * @return int
-     */
-    abstract static protected function getUsedIndexes(): int;
-
     public function setUp(): void
     {
         Authorization::setRole('role:all');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1538,4 +1538,18 @@ abstract class Base extends TestCase
 
         static::getDatabase()->updateDocument('movies', $document->getId(), $document->setAttribute('name',  'Frozen'));
     }
+
+    public function testGetAttributeLimit()
+    {
+        if (static::getAdapterName() === 'mariadb' || static::getAdapterName() === 'mysql') {
+            $this->assertEquals(1012, $this->getDatabase()->getAttributeLimit());
+        } else {
+            $this->assertEquals(0, $this->getDatabase()->getAttributeLimit());
+        }
+    }
+
+    public function testGetIndexLimit()
+    {
+        $this->assertEquals(61, $this->getDatabase()->getIndexLimit());
+    }
 }


### PR DESCRIPTION
This PR introduces two methods for easy checks of database limits to keep to a DRY approach:
- `getAttributeLimit()`
- `getIndexLimit()`

**Testing**
Tests have been added for the new methods, and the test suite has been updated to utilize them.

**Dependencies**
Forked from https://github.com/utopia-php/database/pull/72. Will convert from draft when parent branch merged.