### PR TITLE
fix(deps): float validator accepts ints 

### DIFF
--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -325,7 +325,7 @@ class StructureTest extends TestCase
             'title' => 'string',
             'description' => 'Demo description',
             'rating' => 5,
-            'price' => 2,
+            'price' => '2.5',
             'published' => false,
             'tags' => ['dog', 'cat', 'mouse'],
             'feedback' => 'team@appwrite.io',


### PR DESCRIPTION
As of utopia-php/framework:0.19.0, the `FloatValidator` accepts integers as valid floats. This PR updates the `Structure` unit tests with this change.

**Testing**
Affected tests have been updated.