### PR TITLE
Feat: allow null and empty arrays for optional array attributes

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1048,11 +1048,9 @@ class Database
         foreach ($attributes as $attribute) {
             $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
-            $required = $attribute['required'] ?? true;
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key, null);
             
-            $wasNull = \is_null($value);
             $value = ($array) ? $value : [$value];
             $value = (is_null($value)) ? [] : $value;
 
@@ -1060,12 +1058,6 @@ class Database
                 foreach (array_reverse($filters) as $filter) {
                     $node = $this->decodeAttribute($filter, $node, $document);
                 }
-            }
-            // An optional, empty array attribute should return null, not []
-            if ($array && !$required && $wasNull) {
-                $document->setAttribute($key, null);
-            } else {
-                $document->setAttribute($key, ($array) ? $value : $value[0]);
             }
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1059,6 +1059,8 @@ class Database
                     $node = $this->decodeAttribute($filter, $node, $document);
                 }
             }
+
+            $document->setAttribute($key, ($array) ? $value : $value[0]);
         }
 
         return $document;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1048,9 +1048,11 @@ class Database
         foreach ($attributes as $attribute) {
             $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
+            $required = $attribute['required'] ?? true;
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key, null);
             
+            $wasNull = \is_null($value);
             $value = ($array) ? $value : [$value];
             $value = (is_null($value)) ? [] : $value;
 
@@ -1059,8 +1061,12 @@ class Database
                     $node = $this->decodeAttribute($filter, $node, $document);
                 }
             }
-
-            $document->setAttribute($key, ($array) ? $value : $value[0]);
+            // An optional, empty array attribute should return null, not []
+            if ($array && !$required && $wasNull) {
+                $document->setAttribute($key, null);
+            } else {
+                $document->setAttribute($key, ($array) ? $value : $value[0]);
+            }
         }
 
         return $document;

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -254,6 +254,9 @@ class Structure extends Validator
             }
 
             if($array && !$format) { // Validate attribute type for arrays - format for arrays handled separately
+                if($required == false && is_null($value)) {
+                    continue;
+                }
                 if(!is_array($value)) {
                     $this->message = 'Attribute "'.$key.'" must be an array';
                     return false;

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -254,7 +254,7 @@ class Structure extends Validator
             }
 
             if($array && !$format) { // Validate attribute type for arrays - format for arrays handled separately
-                if($required == false && is_null($value)) {
+                if($required == false && empty($value)) { // Allow both null and [] for optional arrays
                     continue;
                 }
                 if(!is_array($value)) {
@@ -275,6 +275,9 @@ class Structure extends Validator
             }
             else {
                 if($required == false && is_null($value)) { // Allow null value to optional params
+                    continue;
+                }
+                if($required == false && $array && empty($value)) { // Allow both null and [] for optional arrays
                     continue;
                 }
 

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -229,31 +229,43 @@ class Structure extends Validator
             $format = $attribute['format'] ?? '';
             $required = $attribute['required'] ?? false;
 
+            if ($required === false && is_null($value)) { // Allow null value to optional params
+                continue;
+            }
+
             switch ($type) {
                 case Database::VAR_STRING:
                     $validator = new Text(0);
                     break;
-                
+
                 case Database::VAR_INTEGER:
                     $validator = new Integer();
                     break;
-                
+
                 case Database::VAR_FLOAT:
                     $validator = new FloatValidator();
                     break;
-                
-                
+
                 case Database::VAR_BOOLEAN:
                     $validator = new Boolean();
                     break;
-                
+
                 default:
                     $this->message = 'Unknown attribute type "'.$type.'"';
                     return false;
                     break;
             }
 
-            if($array && !$format) { // Validate attribute type for arrays - format for arrays handled separately
+            /** @var string $label Error messasage label, either 'format' or 'type' */
+            $label = ($format) ? 'format' : 'type';
+
+            if ($format) {
+                // Format encoded as json string containing format name and relevant format options
+                $format = self::getFormat($format, $type);
+                $validator = $format['callback']($attribute);
+            }
+
+            if($array) { // Validate attribute type for arrays - format for arrays handled separately
                 if($required == false && empty($value)) { // Allow both null and [] for optional arrays
                     continue;
                 }
@@ -268,48 +280,15 @@ class Structure extends Validator
                     }
 
                     if(!$validator->isValid($child)) {
-                        $this->message = 'Attribute "'.$key.'[\''.$x.'\']" has invalid type. '.$validator->getDescription();
+                        $this->message = 'Attribute "'.$key.'[\''.$x.'\']" has invalid '.$label.'. '.$validator->getDescription();
                         return false;
                     }
                 }
             }
             else {
-                if($required == false && is_null($value)) { // Allow null value to optional params
-                    continue;
-                }
-                if($required == false && $array && empty($value)) { // Allow both null and [] for optional arrays
-                    continue;
-                }
-
                 if(!$validator->isValid($value)) {
-                    $this->message = 'Attribute "'.$key.'" has invalid type. '.$validator->getDescription();
+                    $this->message = 'Attribute "'.$key.'" has invalid '.$label.'. '.$validator->getDescription();
                     return false;
-                }
-            }
-
-            if($format) {
-                // Format encoded as json string containing format name and relevant format options
-                $format = self::getFormat($format, $type);
-                $validator = $format['callback']($attribute);
-
-                if($array) { // Validate attribute type
-                    if(!is_array($value)) {
-                        $this->message = 'Attribute "'.$key.'" must be an array';
-                        return false;
-                    }
-
-                    foreach ($value as $x => $child) {
-                        if(!$validator->isValid($child)) {
-                            $this->message = 'Attribute "'.$key.'[\''.$x.'\']" has invalid format. '.$validator->getDescription();
-                            return false;
-                        }
-                    }
-                }
-                else {
-                    if(!$validator->isValid($value)) {
-                        $this->message = 'Attribute "'.$key.'" has invalid format. '.$validator->getDescription();
-                        return false;
-                    }
                 }
             }
         }

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -49,6 +49,16 @@ class StructureTest extends TestCase
                 'filters' => [],
             ],
             [
+                '$id' => 'reviews',
+                'type' => Database::VAR_INTEGER,
+                'format' => '',
+                'size' => 5,
+                'required' => false,
+                'signed' => true,
+                'array' => true,
+                'filters' => [],
+            ],
+            [
                 '$id' => 'price',
                 'type' => Database::VAR_FLOAT,
                 'format' => '',
@@ -314,6 +324,61 @@ class StructureTest extends TestCase
         ])));
 
         $this->assertEquals('Invalid document structure: Attribute "rating" has invalid type. Value must be a valid integer', $validator->getDescription());
+    }
+
+    public function testArrayOfIntegersValidation()
+    {
+        $validator = new Structure(new Document($this->collection));
+
+        $this->assertEquals(true, $validator->isValid(new Document([
+            '$collection' => 'posts',
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'reviews' => [3, 4, 4, 5],
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['dog', 'cat', 'mouse'],
+            'feedback' => 'team@appwrite.io',
+        ])));
+
+        $this->assertEquals(true, $validator->isValid(new Document([
+            '$collection' => 'posts',
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'reviews' => [],
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['dog', 'cat', 'mouse'],
+            'feedback' => 'team@appwrite.io',
+        ])));
+
+        $this->assertEquals(true, $validator->isValid(new Document([
+            '$collection' => 'posts',
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'reviews' => null,
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['dog', 'cat', 'mouse'],
+            'feedback' => 'team@appwrite.io',
+        ])));
+
+        $this->assertEquals(false, $validator->isValid(new Document([
+            '$collection' => 'posts',
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'reviews' => ['', 4, 4, 5],
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['dog', 'cat', 'mouse'],
+            'feedback' => 'team@appwrite.io',
+        ])));
+
+        $this->assertEquals('Invalid document structure: Attribute "reviews[\'0\']" has invalid type. Value must be a valid integer', $validator->getDescription());
     }
 
     public function testFloatValidation()


### PR DESCRIPTION
# Summary
Edge cases around validating arrays kept popping up, so I've cleaned up the logic of the Structure validator, and that covered all cases where the incorrect validator was applied. This change was required because array attributes were validated with the wrong validator. Additionally, this change accepts empty arrays as well as null for optional array attributes.

# Tests
Additional unit tests have been added to Structure tests to check these cases.

## Bug
optional URL array attribute is required
### Request
![Bildschirmfoto 2021-10-28 um 12 39 44](https://user-images.githubusercontent.com/9708641/139468952-25553823-3c8e-46b0-b0e9-cbd87108ce77.png)
### Error
![Bildschirmfoto 2021-10-28 um 12 39 55](https://user-images.githubusercontent.com/9708641/139468951-0366ef8e-f252-4b64-b799-fd3254b5d965.png)
### Structure
![Bildschirmfoto 2021-10-28 um 12 40 32](https://user-images.githubusercontent.com/9708641/139468947-82c77472-a75c-4fc0-b57f-7a3c8a941d95.png)