### PR TITLE
Construct query validator from array of attribute documents

### DIFF
--- a/src/Database/Validator/QueryValidator.php
+++ b/src/Database/Validator/QueryValidator.php
@@ -3,6 +3,7 @@
 namespace Utopia\Database\Validator;
 
 use Utopia\Validator;
+use Utopia\Database\Document;
 use Utopia\Database\Query;
 
 class QueryValidator extends Validator
@@ -34,11 +35,13 @@ class QueryValidator extends Validator
     /**
      * Expression constructor
      *
-     * @param array $schema
+     * @param array $attributes
      */
-    public function __construct($schema)
+    public function __construct($attributes)
     {
-        $this->schema = $schema;
+        foreach ($attributes as $attribute) {
+            $this->schema[] = $attribute->getArrayCopy();
+        }
     }
 
     /**

--- a/src/Database/Validator/QueryValidator.php
+++ b/src/Database/Validator/QueryValidator.php
@@ -35,9 +35,9 @@ class QueryValidator extends Validator
     /**
      * Expression constructor
      *
-     * @param array $attributes
+     * @param Document[] $attributes
      */
-    public function __construct($attributes)
+    public function __construct(array $attributes)
     {
         foreach ($attributes as $attribute) {
             $this->schema[] = $attribute->getArrayCopy();

--- a/tests/Database/Validator/QueriesTest.php
+++ b/tests/Database/Validator/QueriesTest.php
@@ -96,7 +96,13 @@ class QueriesTest extends TestCase
 
     public function setUp(): void
     {
-        $this->queryValidator = new QueryValidator($this->collection['attributes']);
+        // Query validator expects Document[]
+        $attributes = []; /** @var Document[] $attributes */
+        foreach ($this->collection['attributes'] as $attribute) {
+            $attributes[] = new Document($attribute);
+        }
+
+        $this->queryValidator = new QueryValidator($attributes);
 
         $query1 = Query::parse('title.notEqual("Iron Man", "Ant Man")');
         $query2 = Query::parse('description.equal("Best movie ever")');

--- a/tests/Database/Validator/QueryValidatorTest.php
+++ b/tests/Database/Validator/QueryValidatorTest.php
@@ -5,14 +5,20 @@ namespace Utopia\Tests\Validator;
 use Utopia\Database\Validator\QueryValidator;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Database;
+use Utopia\Database\Document;
 use Utopia\Database\Query;
 
 class QueryValidatorTest extends TestCase
 {
     /**
-     * @var array 
+     * @var Document[]
      */
-    protected $schema = [
+    protected $schema;
+
+    /**
+     * @var array
+     */
+    protected $attributes = [
         [
             '$id' => 'title',
             'key' => 'title',
@@ -77,6 +83,10 @@ class QueryValidatorTest extends TestCase
 
     public function setUp(): void
     {
+        // Query validator expects Document[]
+        foreach ($this->attributes as $attribute) {
+            $this->schema[] = new Document($attribute);
+        }
     }
 
     public function tearDown(): void


### PR DESCRIPTION
This PR updates the constructor of the Query Validator to accept an array of Utopia\Database\Document objects. This change was made to harmonize with the Queries validator, which depends on this class.

**Testing**
Affected tests have been updated