### PR TITLE
Feat: add helper method to check query operators

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -89,6 +89,28 @@ class Query
     }
 
     /**
+     * Check if operator is supported
+     *
+     * @return bool
+     */
+    public static function isOperator($value): bool
+    {
+        switch ($value) {
+            case self::TYPE_EQUAL:
+            case self::TYPE_NOTEQUAL:
+            case self::TYPE_LESSER:
+            case self::TYPE_LESSEREQUAL:
+            case self::TYPE_GREATER:
+            case self::TYPE_GREATEREQUAL:
+            case self::TYPE_CONTAINS:
+            case self::TYPE_SEARCH:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
      * Parse query filter
      *
      * @param string $filter 

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -121,4 +121,26 @@ class QueryTest extends TestCase
         $this->assertContains('Iron Man', $query['values']);
     }
 
+    public function testIsOperator()
+    {
+        $this->assertEquals(true, Query::isOperator('equal'));
+        $this->assertEquals(true, Query::isOperator('notEqual'));
+        $this->assertEquals(true, Query::isOperator('lesser'));
+        $this->assertEquals(true, Query::isOperator('lesserEqual'));
+        $this->assertEquals(true, Query::isOperator('greater'));
+        $this->assertEquals(true, Query::isOperator('greaterEqual'));
+        $this->assertEquals(true, Query::isOperator('contains'));
+        $this->assertEquals(true, Query::isOperator('search'));
+
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_EQUAL));
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_NOTEQUAL));
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_LESSER));
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_LESSEREQUAL));
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_GREATER));
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_GREATEREQUAL));
+        $this->assertEquals(true, Query::isOperator(Query::TYPE_CONTAINS));
+        $this->assertEquals(true, Query::isOperator(QUERY::TYPE_SEARCH));
+
+        $this->assertEquals(false, Query::isOperator('invalid'));
+    }
 }


### PR DESCRIPTION
This PR adds a convenience method to the Query class that checks against the list of defined query operators. 

**Testing**
Unit tests were added to validate the method's behavior