### PR TITLE
Feat-auth-improvement

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -121,27 +121,31 @@ class Database
     static protected $filters = [];
 
     /**
-     * @var \Utopia\Database\Validator\Authorization
+     * @var Authorization
      */
-    protected $read;
+    protected Authorization $read;
 
     /**
-     * @var \Utopia\Database\Validator\Authorization
+     * @var Authorization
      */
-    protected $write;
+    protected Authorization $write;
 
     /**
      * Get read authorization
+     * 
+     * @return Authorization
      */
-    public function getRead()
+    public function getRead(): Authorization
     {
         return $this->read;
     }
 
     /**
      * Get write authorization
+     * 
+     * @return Authorization
      */
-    public function getWrite()
+    public function getWrite(): Authorization
     {
         return $this->write;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -198,6 +198,12 @@ class Database
         );
     }
 
+    public function __clone()
+    {
+        $this->read = clone $this->read;
+        $this->write = clone $this->write;
+    }
+
     /**
      * Set Namespace.
      *

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -121,12 +121,12 @@ class Database
     static protected $filters = [];
 
     /**
-     * @var Utopia\Database\Validator\Authorization
+     * @var \Utopia\Database\Validator\Authorization
      */
     protected $read;
 
     /**
-     * @var Utopia\Database\Validator\Authorization
+     * @var \Utopia\Database\Validator\Authorization
      */
     protected $write;
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -369,11 +369,9 @@ class Database
      */
     public function listCollections($limit = 25, $offset = 0): array
     {
-        Authorization::disable();
-
-        $result = $this->find(self::METADATA, [], $limit, $offset);
-
-        Authorization::reset();
+        $result = Authorization::skip(function() use ($limit, $offset) {
+            return $this->find(self::METADATA, [], $limit, $offset);
+        });
 
         return $result;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -145,7 +145,7 @@ class Database
      * 
      * @return Authorization
      */
-    public function getWrite(): Authorization
+    public function getWriteValidator(): Authorization
     {
         return $this->write;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -135,7 +135,7 @@ class Database
      * 
      * @return Authorization
      */
-    public function getRead(): Authorization
+    public function getReadValidator(): Authorization
     {
         return $this->read;
     }

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -160,9 +160,9 @@ class Authorization extends Validator
      */
     public static function skip(callable $callback)
     {
-        self::disable();
+        self::$status = false;
         $result = $callback();
-        self::reset();
+        self::$status = self::$statusDefault;
 
         return $result;
     }
@@ -177,7 +177,7 @@ class Authorization extends Validator
      * 
      * @return void
      */
-    public function disableAuth(): void
+    public function disable(): void
     {
         $this->authStatus = false;
     }
@@ -187,39 +187,19 @@ class Authorization extends Validator
      * 
      * @return void
      */
-    public function enableAuth(): void
+    public function enable(): void
     {
         $this->authStatus = true;
     }
 
     /**
-     * Enable Authorization checks
-     * 
-     * @return void
-     */
-    public static function enable(): void
-    {
-        self::$status = true;
-    }
-
-    /**
      * Disable Authorization checks
      * 
      * @return void
      */
-    public static function disable(): void
+    public function reset(): void
     {
-        self::$status = false;
-    }
-
-    /**
-     * Disable Authorization checks
-     * 
-     * @return void
-     */
-    public static function reset(): void
-    {
-        self::$status = self::$statusDefault;
+        $this->authStatus = self::$statusDefault;
     }
 
     /**

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -170,7 +170,7 @@ class Authorization extends Validator
     /**
      * @var bool
      */
-    public $authStatus = null;
+    protected $authStatus = null;
 
     /**
      * Enable Authorization checks for this instance

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -124,12 +124,15 @@ class Authorization extends Validator
         return (\array_key_exists($role, self::$roles));
     }
 
-    /**
+    /** 
+     * Static status for Authorization validator
+     *  used across multiple instances
      * @var bool
      */
     public static $status = true;
 
     /**
+     * Instance level status for authorization validator
      * @var bool
      */
     protected $authStatus = true;

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -57,6 +57,10 @@ class Authorization extends Validator
             return true;
         }
 
+        if($this->authStatus !== null && $this->authStatus === false) {
+            return true;
+        }
+
         if(empty($permissions)) {
             $this->message = 'No permissions provided for action \''.$this->action.'\'';
             return false;
@@ -161,6 +165,31 @@ class Authorization extends Validator
         self::reset();
 
         return $result;
+    }
+
+    /**
+     * @var bool
+     */
+    public $authStatus = null;
+
+    /**
+     * Enable Authorization checks for this instance
+     * 
+     * @return void
+     */
+    public function disableAuth(): void
+    {
+        $this->authStatus = false;
+    }
+
+    /**
+     * Disable Authorization checks for this instance
+     * 
+     * @return void
+     */
+    public function enableAuth(): void
+    {
+        $this->authStatus = true;
     }
 
     /**

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -57,7 +57,7 @@ class Authorization extends Validator
             return true;
         }
 
-        if($this->authStatus !== null && $this->authStatus === false) {
+        if(!$this->authStatus) {
             return true;
         }
 
@@ -128,6 +128,11 @@ class Authorization extends Validator
      * @var bool
      */
     public static $status = true;
+
+    /**
+     * @var bool
+     */
+    protected $authStatus = true;
     
     /**
      * Default value in case we need
@@ -166,11 +171,6 @@ class Authorization extends Validator
 
         return $result;
     }
-
-    /**
-     * @var bool
-     */
-    protected $authStatus = null;
 
     /**
      * Enable Authorization checks for this instance

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1277,6 +1277,39 @@ abstract class Base extends TestCase
     }
 
     /**
+     * @depends testReadPermissionsSuccess
+     */
+    public function testPermissionDisableClone() {
+        $document = static::getDatabase()->createDocument('documents', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'string' => 'text📝',
+            'integer' => 5,
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+        ]));
+
+        $this->assertEquals(false, $document->isEmpty());
+
+        $database = clone static::getDatabase();
+        $database->getRead()->disableAuth();
+        Authorization::cleanRoles();
+
+        $document = $database->getDocument($document->getCollection(), $document->getId());
+
+        $this->assertEquals(false, $document->isEmpty());
+
+        $document1 = static::getDatabase()->getDocument($document->getCollection(), $document->getId());
+
+        $this->assertEquals(true, $document1->isEmpty());
+        
+        Authorization::setRole('role:all');
+
+        return $document;
+    }
+
+    /**
      * @depends testCreateDocument
      */
     public function testReadPermissionsFailure(Document $document)
@@ -1312,6 +1345,42 @@ abstract class Base extends TestCase
         ]));
 
         $this->assertEquals(false, $document->isEmpty());
+
+        return $document;
+    }
+    /**
+     * @depends testWritePermissionsSuccess
+     */
+    public function testWritePermissionsCloneSuccess(Document $document)
+    {
+        $database = clone static::getDatabase();
+        $database->getWrite()->disableAuth();
+        
+        Authorization::cleanRoles();
+        $document = $database->createDocument('documents', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'string' => 'text📝',
+            'integer' => 5,
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+        ]));
+
+        $this->assertEquals(false, $document->isEmpty());
+
+        $this->expectException(ExceptionAuthorization::class);
+
+
+        $document = static::getDatabase()->createDocument('documents', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'string' => 'text📝',
+            'integer' => 5,
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+        ]));
 
         return $document;
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1312,7 +1312,7 @@ abstract class Base extends TestCase
         $this->assertEquals(false, $document->isEmpty());
 
         $database = clone static::getDatabase();
-        $database->getRead()->disable();
+        $database->getReadValidator()->disable();
         Authorization::cleanRoles();
 
         $document = $database->getDocument($document->getCollection(), $document->getId());
@@ -1373,7 +1373,7 @@ abstract class Base extends TestCase
     public function testWritePermissionsCloneSuccess(Document $document)
     {
         $database = clone static::getDatabase();
-        $database->getWrite()->disable();
+        $database->getWriteValidator()->disable();
         
         Authorization::cleanRoles();
         $document = $database->createDocument('documents', new Document([

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -37,7 +37,6 @@ abstract class Base extends TestCase
 
     public function tearDown(): void
     {
-        Authorization::reset();
     }
 
     public function testCreateExistsDelete()
@@ -976,15 +975,15 @@ abstract class Base extends TestCase
         $count = static::getDatabase()->count('movies');
         $this->assertEquals(5, $count);
         
-        Authorization::disable();
-        $count = static::getDatabase()->count('movies');
+        $count = Authorization::skip(function() {
+            return static::getDatabase()->count('movies');
+        });
         $this->assertEquals(6, $count);
-        Authorization::reset();
         
-        Authorization::disable();
-        $count = static::getDatabase()->count('movies', [], 3);
+        $count = Authorization::skip(function() {
+            return static::getDatabase()->count('movies', [], 3);
+        });
         $this->assertEquals(3, $count);
-        Authorization::reset();
     }
 
     /**
@@ -1293,7 +1292,7 @@ abstract class Base extends TestCase
         $this->assertEquals(false, $document->isEmpty());
 
         $database = clone static::getDatabase();
-        $database->getRead()->disableAuth();
+        $database->getRead()->disable();
         Authorization::cleanRoles();
 
         $document = $database->getDocument($document->getCollection(), $document->getId());
@@ -1354,7 +1353,7 @@ abstract class Base extends TestCase
     public function testWritePermissionsCloneSuccess(Document $document)
     {
         $database = clone static::getDatabase();
-        $database->getWrite()->disableAuth();
+        $database->getWrite()->disable();
         
         Authorization::cleanRoles();
         $document = $database->createDocument('documents', new Document([

--- a/tests/Database/Validator/AuthorizationTest.php
+++ b/tests/Database/Validator/AuthorizationTest.php
@@ -50,24 +50,24 @@ class AuthorizationTest extends TestCase
         $this->assertEquals($object->isValid($document->getRead()), true);
         
         Authorization::cleanRoles();
-        Authorization::disable();
+        $object->disable();
         
         $this->assertEquals($object->isValid($document->getRead()), true);
 
-        Authorization::reset();
+        $object->reset();
         
         $this->assertEquals($object->isValid($document->getRead()), false);
 
         Authorization::setDefaultStatus(false);
-        Authorization::disable();
+        $object->disable();
         
         $this->assertEquals($object->isValid($document->getRead()), true);
 
-        Authorization::reset();
+        $object->reset();
         
         $this->assertEquals($object->isValid($document->getRead()), true);
 
-        Authorization::enable();
+        $object->enable();
         
         $this->assertEquals($object->isValid($document->getRead()), false);
 

--- a/tests/Database/Validator/AuthorizationTest.php
+++ b/tests/Database/Validator/AuthorizationTest.php
@@ -68,6 +68,7 @@ class AuthorizationTest extends TestCase
         $this->assertEquals($object->isValid($document->getRead()), true);
 
         $object->enable();
+        Authorization::setDefaultStatus(true);
         
         $this->assertEquals($object->isValid($document->getRead()), false);
 


### PR DESCRIPTION
Imrpving authorization to support database cloning and disabling auth only in particular instance

## Changelog
1. Added instance status property
2. Removed static enable, disable and reset method
3. Added instance enable, disable and reset method that modifies the instance status property
4. Removed all use of disable,enable,reset using either instance enable/disable or Authorization skip where applicable