### PR TITLE
Fix: statements with OR clauses when counting documents

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -654,7 +654,8 @@ class MariaDB extends Adapter
                 $conditions[] = $this->getSQLCondition('table_main.'.$query->getAttribute(), $query->getOperator(), ':attribute_'.$i.'_'.$key.'_'.$query->getAttribute(), $value);
             }
 
-            $where[] = implode(' OR ', $conditions);
+            $condition = implode(' OR ', $conditions);
+            $where[] = empty($condition) ? '' : '('.$condition.')';
         }
 
         $stmt = $this->getPDO()->prepare("SELECT COUNT(1) as sum FROM (SELECT 1 FROM {$this->getNamespace()}.{$name} table_main

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -916,17 +916,6 @@ abstract class Base extends TestCase
         $this->assertEmpty(count($documents));
 
         /**
-         * ORDER BY - After Exception
-         */
-
-        $document = new Document([
-            '$collection' => 'other collection'
-        ]);
-
-        $this->expectException(Exception::class);
-        static::getDatabase()->find('movies', [], 2, 0, [], [], $document);
-
-        /**
          * Limit
          */
         $documents = static::getDatabase()->find('movies', [], 4, 0, ['name']);
@@ -947,6 +936,26 @@ abstract class Base extends TestCase
         $this->assertEquals('Frozen II', $documents[1]['name']);
         $this->assertEquals('Work in Progress', $documents[2]['name']);
         $this->assertEquals('Work in Progress 2', $documents[3]['name']);
+
+        /**
+         * Test that OR queries are handled correctly
+         */
+        $documents = static::getDatabase()->find('movies', [
+            new Query('director', Query::TYPE_EQUAL, ['TBD', 'Joe Johnston']),
+            new Query('year', Query::TYPE_EQUAL, [2025]),
+        ]);
+        $this->assertEquals(1, count($documents));
+
+        /**
+         * ORDER BY - After Exception
+         * Must be last assertion in test
+         */
+        $document = new Document([
+            '$collection' => 'other collection'
+        ]);
+
+        $this->expectException(Exception::class);
+        static::getDatabase()->find('movies', [], 2, 0, [], [], $document);
     }
 
     /**
@@ -984,6 +993,17 @@ abstract class Base extends TestCase
         Authorization::disable();
         $count = static::getDatabase()->count('movies', [], 3);
         $this->assertEquals(3, $count);
+        Authorization::reset();
+
+        /**
+         * Test that OR queries are handled correctly
+         */
+        Authorization::disable();
+        $count = static::getDatabase()->count('movies', [
+            new Query('director', Query::TYPE_EQUAL, ['TBD', 'Joe Johnston']),
+            new Query('year', Query::TYPE_EQUAL, [2025]),
+        ]);
+        $this->assertEquals(1, $count);
         Authorization::reset();
     }
 


### PR DESCRIPTION
Closes #83

The SQL syntax was different between queries calling `find` vs `count` - the WHERE conditions weren't getting surrounding parentheses for OR statements, leading to inconsistent results between the two methods. 

Testing:
Tests have been added to both methods to ensure this behavior stays in tact. 