### PR TITLE
Feat: pad uniqid with random bytes

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1174,13 +1174,14 @@ class Database
     }
 
     /**
-     * Get 13 Chars Unique ID.
+     * Get Unique ID of varying length
      * 
      * @return string
      */
-    public function getId(): string
+    public function getId(int $length = 13): string
     {
-        return \uniqid();
+        $bytes = \random_bytes(\ceil($length / 2)); // one byte expands to two chars
+        return \substr(\bin2hex($bytes), 0, $length);
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1182,14 +1182,14 @@ class Database
      */
     public function getId(int $padding = 0): string
     {
-        $padding = '';
+        $uniqid = \uniqid();
 
         if ($padding > 0) {
             $bytes = \random_bytes(\ceil($padding / 2)); // one byte expands to two chars
-            $padding = \substr(\bin2hex($bytes), 0, $padding);
+            $uniqid .= \substr(\bin2hex($bytes), 0, $padding);
         }
 
-        return \uniqid() . $padding;
+        return $uniqid;
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1174,14 +1174,22 @@ class Database
     }
 
     /**
-     * Get Unique ID of varying length
-     * 
+     * Get Unique ID
+     *
+     * @param int $padding extra random bytes to append to 13-char uniqid
+     *
      * @return string
      */
-    public function getId(int $length = 13): string
+    public function getId(int $padding = 0): string
     {
-        $bytes = \random_bytes(\ceil($length / 2)); // one byte expands to two chars
-        return \substr(\bin2hex($bytes), 0, $length);
+        $padding = '';
+
+        if ($padding > 0) {
+            $bytes = \random_bytes(\ceil($padding / 2)); // one byte expands to two chars
+            $padding = \substr(\bin2hex($bytes), 0, $padding);
+        }
+
+        return \uniqid() . $padding;
     }
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1680,4 +1680,15 @@ abstract class Base extends TestCase
     {
         $this->assertEquals(61, $this->getDatabase()->getIndexLimit());
     }
+
+    public function testGetId()
+    {
+        $this->assertEquals(13, strlen($this->getDatabase()->getId()));
+        $this->assertEquals(13, strlen($this->getDatabase()->getId(0)));
+        $this->assertEquals(13, strlen($this->getDatabase()->getId(-1)));
+        $this->assertEquals(23, strlen($this->getDatabase()->getId(10)));
+
+        // ensure two sequential calls to getId do not give the same result
+        $this->assertNotEquals($this->getDatabase()->getId(10), $this->getDatabase()->getId(10));
+    }
 }


### PR DESCRIPTION
`uniqid()` generates IDs based on current timestamp, and we've hit collisions in the Appwrite Database API when adding a bunch of documents in sequence. Increasing the entropy was decent idea, but I think the period delimiter will cause more troubles than problems it would solve:
```
mysql> select _uid from documents;
+-------------------------+
| _uid                    |
+-------------------------+
| 619bff85daece7.47129785 |
| 619bff85dd7828.93935232 |
| 619bff85dfdb23.11230448 |
| caseSensitive           |
| duplicated              |
+-------------------------+
5 rows in set (0.00 sec)
```

`random_bytes()` serves as a good replacement with better controls, but we lose the safety that time-based randomIDs provide against collision. This PR adds a $padding parameter to getId to avoid these collisions.

**Testing**
Unit tests have been added to ensure we don't have collisions when creating sequential IDs.