### PR TITLE
Fix: default to 20-char uniqids

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1180,7 +1180,7 @@ class Database
      *
      * @return string
      */
-    public function getId(int $padding = 0): string
+    public function getId(int $padding = 7): string
     {
         $uniqid = \uniqid();
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1683,7 +1683,7 @@ abstract class Base extends TestCase
 
     public function testGetId()
     {
-        $this->assertEquals(13, strlen($this->getDatabase()->getId()));
+        $this->assertEquals(20, strlen($this->getDatabase()->getId()));
         $this->assertEquals(13, strlen($this->getDatabase()->getId(0)));
         $this->assertEquals(13, strlen($this->getDatabase()->getId(-1)));
         $this->assertEquals(23, strlen($this->getDatabase()->getId(10)));


### PR DESCRIPTION
So we don't have to update every `$database->getId()` in Appwrite, this PR sets a default padding of 7 extra chars, leading to a 20-char unique ID, 13 chars based on time, 7 random. 

This should prevent most instances of collision across systems in tandem with unique indexes in the database.