### PR TITLE
skip decoding for null values

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1051,8 +1051,11 @@ class Database
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key, null);
             
+            if(is_null($value)) {
+                continue;
+            }
+
             $value = ($array) ? $value : [$value];
-            $value = (is_null($value)) ? [] : $value;
 
             foreach ($value as &$node) {
                 foreach (array_reverse($filters) as $filter) {


### PR DESCRIPTION
When an encrypted field has NULL value in the db, during decoding it fails. This will resolve that by skipping decoding process if the value is null

Details to error that arises without this fix
https://github.com/appwrite/appwrite/runs/4393263762?check_suite_focus=true