### PR TITLE
Feat: support BIGINT/LONG type

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -910,8 +910,13 @@ class MariaDB extends Adapter
                 break;
 
                 case Database::VAR_INTEGER:
+                    if ($attribute['size'] >= 8) {
+                        $total += 8; // BIGINT takes 8 bytes
+                    } else {
+                        $total += 4; // INT takes 4 bytes
+                    }
+                break;
                 case Database::VAR_FLOAT:
-                    // INT takes 4 bytes
                     // FLOAT(p) takes 4 bytes when p <= 24, 8 otherwise
                     $total += 4;
                 break;
@@ -995,6 +1000,11 @@ class MariaDB extends Adapter
 
             case Database::VAR_INTEGER:  // We don't support zerofill: https://stackoverflow.com/a/5634147/2299554
                 $signed = ($signed) ? '' : ' UNSIGNED';
+
+                if($size >= 8) { // INT = 4 bytes, BIGINT = 8 bytes
+                    return 'BIGINT'.$signed;
+                }
+
                 return 'INT'.$signed;
             break;
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -82,11 +82,12 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string3', Database::VAR_STRING, 65535+1, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string4', Database::VAR_STRING, 16777215+1, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'integer', Database::VAR_INTEGER, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'bigint', Database::VAR_INTEGER, 8, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'float', Database::VAR_FLOAT, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean', Database::VAR_BOOLEAN, 0, true));
 
         $collection = static::getDatabase()->getCollection('attributes');
-        $this->assertCount(7, $collection->getAttribute('attributes'));
+        $this->assertCount(8, $collection->getAttribute('attributes'));
 
         // Array
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_list', Database::VAR_STRING, 128, true, null, true, true));
@@ -95,7 +96,7 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_list', Database::VAR_BOOLEAN, 0, true, null, true, true));
 
         $collection = static::getDatabase()->getCollection('attributes');
-        $this->assertCount(11, $collection->getAttribute('attributes'));
+        $this->assertCount(12, $collection->getAttribute('attributes'));
 
         // Default values
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string_default', Database::VAR_STRING, 256, false, 'test'));
@@ -104,7 +105,7 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'boolean_default', Database::VAR_BOOLEAN, 0, false, false));
 
         $collection = static::getDatabase()->getCollection('attributes');
-        $this->assertCount(15, $collection->getAttribute('attributes'));
+        $this->assertCount(16, $collection->getAttribute('attributes'));
 
         // Delete
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string1'));
@@ -112,6 +113,7 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string3'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string4'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'integer'));
+        $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'bigint'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'float'));
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'boolean'));
 
@@ -344,6 +346,7 @@ abstract class Base extends TestCase
 
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'string', Database::VAR_STRING, 128, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'integer', Database::VAR_INTEGER, 0, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'bigint', Database::VAR_INTEGER, 8, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'float', Database::VAR_FLOAT, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'boolean', Database::VAR_BOOLEAN, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'colors', Database::VAR_STRING, 32, true, null, true, true));
@@ -354,6 +357,7 @@ abstract class Base extends TestCase
             '$write' => ['role:all', 'user1x', 'user2x'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
@@ -365,6 +369,8 @@ abstract class Base extends TestCase
         $this->assertEquals('text📝', $document->getAttribute('string')); // Also makes sure an emoji is working
         $this->assertIsInt($document->getAttribute('integer'));
         $this->assertEquals(5, $document->getAttribute('integer'));
+        $this->assertIsInt($document->getAttribute('bigint'));
+        $this->assertEquals(8589934592, $document->getAttribute('bigint'));
         $this->assertIsFloat($document->getAttribute('float'));
         $this->assertEquals(5.55, $document->getAttribute('float'));
         $this->assertIsBool($document->getAttribute('boolean'));
@@ -1278,6 +1284,7 @@ abstract class Base extends TestCase
             '$write' => ['role:all'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
@@ -1308,6 +1315,7 @@ abstract class Base extends TestCase
             '$write' => ['user1'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
@@ -1326,6 +1334,7 @@ abstract class Base extends TestCase
             '$write' => ['role:all'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
@@ -1350,6 +1359,7 @@ abstract class Base extends TestCase
             '$write' => ['role:all'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
@@ -1370,6 +1380,7 @@ abstract class Base extends TestCase
             '$write' => ['role:all'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
@@ -1383,6 +1394,7 @@ abstract class Base extends TestCase
             '$write' => ['role:all'],
             'string' => 'text📝',
             'integer' => 5,
+            'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],


### PR DESCRIPTION
This PR adds support for BIGINT values, triggered when integer is created with `$size >= 8`. MongoDB shouldn't require any modifications, since it should transparently detect the `LONG` BSON type automatically.

Tests:
Tests have been added to check BIGINT/LONG support.

Related issues:
https://github.com/utopia-php/database/issues/94

Have you read the contribution guide?
Yes.

Refs:
https://mariadb.com/kb/en/bigint/
https://mariadb.com/kb/en/int/
https://mariadb.com/kb/en/data-type-storage-requirements/
https://docs.mongodb.com/manual/reference/bson-types/#bson-types