### PR TITLE
Feat: namespace as table prefixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -340,16 +340,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.19.2",
+            "version": "0.19.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/framework.git",
-                "reference": "49e4374b97c0f4d14bc84b424bdc9c3b7747e15f"
+                "reference": "4c6c841d738cec458b73fec5aedd40fd43bd41a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/framework/zipball/49e4374b97c0f4d14bc84b424bdc9c3b7747e15f",
-                "reference": "49e4374b97c0f4d14bc84b424bdc9c3b7747e15f",
+                "url": "https://api.github.com/repos/utopia-php/framework/zipball/4c6c841d738cec458b73fec5aedd40fd43bd41a7",
+                "reference": "4c6c841d738cec458b73fec5aedd40fd43bd41a7",
                 "shasum": ""
             },
             "require": {
@@ -383,9 +383,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/framework/issues",
-                "source": "https://github.com/utopia-php/framework/tree/0.19.2"
+                "source": "https://github.com/utopia-php/framework/tree/0.19.3"
             },
-            "time": "2021-12-07T09:29:35+00:00"
+            "time": "2021-12-17T13:04:13+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -426,7 +426,7 @@ abstract class Adapter
      */
     public function filter(string $value):string
     {
-        $value = preg_replace("/[^A-Za-z0-9]_/", '', $value);
+        $value = preg_replace("/[^A-Za-z0-9\_\-\.]/", '', $value);
 
         if(\is_null($value)) {
             throw new Exception('Failed to filter key');

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -12,6 +12,11 @@ abstract class Adapter
     protected $namespace = '';
 
     /**
+     * @var string
+     */
+    protected $defaultDatabase = '';
+
+    /**
      * @var array
      */
     protected $debug = [];
@@ -64,7 +69,7 @@ abstract class Adapter
             throw new Exception('Missing namespace');
         }
 
-        $this->namespace = $namespace;
+        $this->namespace = $this->filter($namespace);
 
         return true;
     }
@@ -88,18 +93,61 @@ abstract class Adapter
     }
 
     /**
+     * Set Database.
+     *
+     * Set database to use for current scope
+     *
+     * @param string $name
+     * @param bool $reset
+     *
+     * @throws Exception
+     */
+    public function setDefaultDatabase(string $name, bool $reset = false): bool
+    {
+        if (empty($name) && $reset === false) {
+            throw new Exception('Missing database');
+        }
+
+        $this->defaultDatabase = ($reset) ? '' : $this->filter($name);
+
+        return true;
+    }
+
+    /**
+     * Get Database.
+     *
+     * Get Database from current scope
+     *
+     * @throws Exception
+     *
+     * @return string
+     */
+    public function getDefaultDatabase(): string
+    {
+        if (empty($this->defaultDatabase)) {
+            throw new Exception('Missing database');
+        }
+
+        return $this->defaultDatabase;
+    }
+
+    /**
      * Create Database
+     *
+     * @param string $name
      *
      * @return bool
      */
-    abstract public function create(): bool;
+    abstract public function create(string $name): bool;
 
     /**
      * Check if database exists
      *
+     * @param string $name
+     *
      * @return bool
      */
-    abstract public function exists(): bool;
+    abstract public function exists(string $name): bool;
 
     /**
      * List Databases
@@ -111,9 +159,11 @@ abstract class Adapter
     /**
      * Delete Database
      *
+     * @param string $name
+     *
      * @return bool
      */
-    abstract public function delete(): bool;
+    abstract public function delete(string $name): bool;
 
     /**
      * Create Collection

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -115,7 +115,7 @@ class MariaDB extends Adapter
 
         if (!empty($attributes) || !empty($indexes)) {
             foreach ($attributes as &$attribute) {
-                $attrId = $attribute->getId();
+                $attrId = $this->filter($attribute->getId());
                 $attrType = $this->getSQLType($attribute->getAttribute('type'), $attribute->getAttribute('size', 0), $attribute->getAttribute('signed', true));
 
                 if($attribute->getAttribute('array')) {

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -33,26 +33,30 @@ class MariaDB extends Adapter
 
     /**
      * Create Database
+     *
+     * @param string $name
      * 
      * @return bool
      */
-    public function create(): bool
+    public function create(string $name): bool
     {
-        $name = $this->getNamespace();
+        $name = $this->filter($name);
 
         return $this->getPDO()
-            ->prepare("CREATE DATABASE {$name} /*!40100 DEFAULT CHARACTER SET utf8mb4 */;")
+            ->prepare("CREATE DATABASE IF NOT EXISTS `{$name}` /*!40100 DEFAULT CHARACTER SET utf8mb4 */;")
             ->execute();
     }
 
     /**
      * Check if database exists
      *
+     * @param string $name
+     *
      * @return bool
      */
-    public function exists(): bool
+    public function exists(string $name): bool
     {
-        $name = $this->getNamespace();
+        $name = $this->filter($name);
 
         $stmt = $this->getPDO()
             ->prepare("SELECT SCHEMA_NAME
@@ -62,7 +66,7 @@ class MariaDB extends Adapter
         $stmt->bindValue(':schema', $name, PDO::PARAM_STR);
 
         $stmt->execute();
-        
+
         $document = $stmt->fetch(PDO::FETCH_ASSOC);
 
         return (($document['SCHEMA_NAME'] ?? '') == $name);
@@ -82,14 +86,16 @@ class MariaDB extends Adapter
     /**
      * Delete Database
      * 
+     * @param string $name
+     *
      * @return bool
      */
-    public function delete(): bool
+    public function delete(string $name): bool
     {
-        $name = $this->getNamespace();
+        $name = $this->filter($name);
 
         return $this->getPDO()
-            ->prepare("DROP DATABASE {$name};")
+            ->prepare("DROP DATABASE `{$name}`;")
             ->execute();
     }
 
@@ -103,6 +109,8 @@ class MariaDB extends Adapter
      */
     public function createCollection(string $name, array $attributes = [], array $indexes = []): bool
     {
+        $database = $this->getDefaultDatabase();
+        $namespace = $this->getNamespace();
         $id = $this->filter($name);
 
         if (!empty($attributes) || !empty($indexes)) {
@@ -140,7 +148,7 @@ class MariaDB extends Adapter
             }
 
             $this->getPDO()
-                ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
+                ->prepare("CREATE TABLE IF NOT EXISTS `{$database}`.`{$namespace}_{$id}` (
                     `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                     `_uid` CHAR(255) NOT NULL,
                     `_read` " . $this->getTypeForReadPermission() . " NOT NULL,
@@ -154,7 +162,7 @@ class MariaDB extends Adapter
 
         } else {
             $this->getPDO()
-                ->prepare("CREATE TABLE IF NOT EXISTS {$this->getNamespace()}.{$id} (
+                ->prepare("CREATE TABLE IF NOT EXISTS `{$database}`.`{$namespace}_{$id}` (
                     `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                     `_uid` CHAR(255) NOT NULL,
                     `_read` " . $this->getTypeForReadPermission() . " NOT NULL,
@@ -180,7 +188,7 @@ class MariaDB extends Adapter
         $id = $this->filter($id);
 
         return $this->getPDO()
-            ->prepare("DROP TABLE {$this->getNamespace()}.{$id};")
+            ->prepare("DROP TABLE `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$id}`;")
             ->execute();
     }
 
@@ -206,7 +214,7 @@ class MariaDB extends Adapter
         }
 
         return $this->getPDO()
-            ->prepare("ALTER TABLE {$this->getNamespace()}.{$name}
+            ->prepare("ALTER TABLE `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
                 ADD COLUMN `{$id}` {$type};")
             ->execute();
     }
@@ -226,7 +234,7 @@ class MariaDB extends Adapter
         $id = $this->filter($id);
 
         return $this->getPDO()
-            ->prepare("ALTER TABLE {$this->getNamespace()}.{$name}
+            ->prepare("ALTER TABLE `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
                 DROP COLUMN `{$id}`;")
             ->execute();
     }
@@ -280,7 +288,7 @@ class MariaDB extends Adapter
         $id = $this->filter($id);
 
         return $this->getPDO()
-            ->prepare("ALTER TABLE {$this->getNamespace()}.{$name}
+            ->prepare("ALTER TABLE `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
                 DROP INDEX `{$id}`;")
             ->execute();
     }
@@ -297,7 +305,8 @@ class MariaDB extends Adapter
     {
         $name = $this->filter($collection);
 
-        $stmt = $this->getPDO()->prepare("SELECT * FROM {$this->getNamespace()}.{$name}
+        $stmt = $this->getPDO()->prepare("SELECT *
+            FROM `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
             WHERE _uid = :_uid
             LIMIT 1;
         ");
@@ -351,7 +360,7 @@ class MariaDB extends Adapter
         }
 
         $stmt = $this->getPDO()
-            ->prepare("INSERT INTO {$this->getNamespace()}.{$name}
+            ->prepare("INSERT INTO `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
                 SET {$columns} _uid = :_uid, _read = :_read, _write = :_write");
 
         $stmt->bindValue(':_uid', $document->getId(), PDO::PARAM_STR);
@@ -416,7 +425,7 @@ class MariaDB extends Adapter
         }
 
         $stmt = $this->getPDO()
-            ->prepare("UPDATE {$this->getNamespace()}.{$name}
+            ->prepare("UPDATE `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
                 SET {$columns} _uid = :_uid, _read = :_read, _write = :_write WHERE _uid = :_uid");
 
         $stmt->bindValue(':_uid', $document->getId(), PDO::PARAM_STR);
@@ -473,7 +482,7 @@ class MariaDB extends Adapter
         $this->getPDO()->beginTransaction();
 
         $stmt = $this->getPDO()
-            ->prepare("DELETE FROM {$this->getNamespace()}.{$name}
+            ->prepare("DELETE FROM `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
                 WHERE _uid = :_uid LIMIT 1");
 
         $stmt->bindValue(':_uid', $id, PDO::PARAM_STR);
@@ -581,7 +590,7 @@ class MariaDB extends Adapter
 
         $order = 'ORDER BY '.implode(', ', $orders);
 
-        $stmt = $this->getPDO()->prepare("SELECT table_main.* FROM {$this->getNamespace()}.{$name} table_main
+        $stmt = $this->getPDO()->prepare("SELECT table_main.* FROM `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}` table_main
             WHERE {$permissions} AND ".implode(' AND ', $where)."
             {$order}
             LIMIT :offset, :limit;
@@ -658,7 +667,7 @@ class MariaDB extends Adapter
             $where[] = empty($condition) ? '' : '('.$condition.')';
         }
 
-        $stmt = $this->getPDO()->prepare("SELECT COUNT(1) as sum FROM (SELECT 1 FROM {$this->getNamespace()}.{$name} table_main
+        $stmt = $this->getPDO()->prepare("SELECT COUNT(1) as sum FROM (SELECT 1 FROM `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}` table_main
             WHERE {$permissions} AND ".implode(' AND ', $where)."
             {$limit}) table_count
         ");
@@ -712,10 +721,13 @@ class MariaDB extends Adapter
             $where[] = implode(' OR ', $conditions);
         }
 
-        $stmt = $this->getPDO()->prepare("SELECT SUM({$attribute}) as sum FROM (SELECT {$attribute} FROM {$this->getNamespace()}.{$name} table_main
-            WHERE {$permissions} AND ".implode(' AND ', $where)."
-            {$limit}) table_count
-        ");
+        $stmt = $this->getPDO()->prepare("SELECT SUM({$attribute}) as sum
+            FROM (
+                SELECT {$attribute}
+                FROM `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}` table_main
+                WHERE {$permissions} AND ".implode(' AND ', $where)."
+                {$limit}
+            ) table_count");
 
         foreach($queries as $i => $query) {
             if($query->getOperator() === Query::TYPE_SEARCH) continue;
@@ -1140,7 +1152,7 @@ class MariaDB extends Adapter
             break;
         }
 
-        return 'CREATE '.$type.' '.$id.' ON '.$this->getNamespace().'.'.$collection.' ( '.implode(', ', $attributes).' );';
+        return 'CREATE '.$type.' '.$id.' ON `'.$this->getDefaultDatabase().'`.`'.$this->getNamespace().'_'.$collection.'` ( '.implode(', ', $attributes).' );';
     }
 
     /**

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -99,7 +99,7 @@ class MySQL extends MariaDB
                 break;
         }
 
-        return 'CREATE ' . $type . ' ' . $id . ' ON ' . $this->getNamespace() . '.' . $collection . ' ( ' . implode(', ', $attributes) . ' );';
+        return 'CREATE '.$type.' '.$id.' ON `'.$this->getDefaultDatabase().'`.`'.$this->getNamespace().'_'.$collection.'` ( '.implode(', ', $attributes).' );';
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -241,6 +241,10 @@ class Database
     public function create(string $name): bool
     {
         $this->adapter->create($name);
+
+        // Temporarily change defaultDatabase to create metadata collection
+        $defaultDatabase = $this->getDefaultDatabase();
+
         $this->setDefaultDatabase($name);
 
         /**
@@ -261,7 +265,7 @@ class Database
         ]);
 
         $this->createCollection(self::METADATA, $attributes);
-        $this->setDefaultDatabase('', reset: true);
+        $this->setDefaultDatabase($defaultDatabase);
 
         return true;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -241,12 +241,21 @@ class Database
     public function create(string $name): bool
     {
         $this->adapter->create($name);
-
-        // Temporarily change defaultDatabase to create metadata collection
-        $defaultDatabase = $this->getDefaultDatabase();
-
         $this->setDefaultDatabase($name);
+        $this->createMetadata();
 
+        return true;
+    }
+
+    /**
+     * Create Metadata collection.
+     * @return bool 
+     * @throws LimitException 
+     * @throws AuthorizationException 
+     * @throws StructureException 
+     */
+    public function createMetadata(): bool
+    {
         /**
          * Create array of attribute documents
          * @var Document[] $attributes
@@ -265,7 +274,6 @@ class Database
         ]);
 
         $this->createCollection(self::METADATA, $attributes);
-        $this->setDefaultDatabase($defaultDatabase);
 
         return true;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -13,8 +13,8 @@ use Utopia\Cache\Cache;
 
 class Database
 {
-    // Simple Types
     const VAR_STRING = 'string';
+    // Simple Types
     const VAR_INTEGER = 'integer';
     const VAR_FLOAT = 'double';
     const VAR_BOOLEAN = 'boolean';
@@ -203,13 +203,45 @@ class Database
     }
 
     /**
-     * Create Database
+     * Set database to use for current scope
+     *
+     * @param string $database
+     * @param bool $reset
+     *
+     * @throws Exception
      *
      * @return bool
      */
-    public function create(): bool
+    public function setDefaultDatabase(string $name, bool $reset = false): bool
     {
-        $this->adapter->create();
+        return $this->adapter->setDefaultDatabase($name, $reset);
+    }
+
+    /**
+     * Get Database.
+     *
+     * Get Database from current scope
+     *
+     * @throws Exception
+     *
+     * @return string
+     */
+    public function getDefaultDatabase(): string
+    {
+        return $this->adapter->getDefaultDatabase();
+    }
+
+    /**
+     * Create Database
+     *
+     * @param string $database
+     *
+     * @return bool
+     */
+    public function create(string $name): bool
+    {
+        $this->adapter->create($name);
+        $this->setDefaultDatabase($name);
 
         /**
          * Create array of attribute documents
@@ -229,6 +261,7 @@ class Database
         ]);
 
         $this->createCollection(self::METADATA, $attributes);
+        $this->setDefaultDatabase('', reset: true);
 
         return true;
     }
@@ -238,9 +271,9 @@ class Database
      *
      * @return bool
      */
-    public function exists(): bool
+    public function exists(string $name): bool
     {
-        return $this->adapter->exists();
+        return $this->adapter->exists($name);
     }
 
     /**
@@ -256,11 +289,13 @@ class Database
     /**
      * Delete Database
      *
+     * @param string $name
+     *
      * @return bool
      */
-    public function delete(): bool
+    public function delete(string $name): bool
     {
-        return $this->adapter->delete();
+        return $this->adapter->delete($name);
     }
 
     /**

--- a/src/Database/Validator/Key.php
+++ b/src/Database/Validator/Key.php
@@ -44,8 +44,8 @@ class Key extends Validator
             return false;
         }
 
-        // Valid chars: A-Z, a-z, 0-9, underscore, period, hyphen, space
-        if (\preg_match('/[^A-Za-z0-9\_\.\-]/', $value)) {
+        // Valid chars: A-Z, a-z, 0-9, underscore, hyphen, period
+        if (\preg_match('/[^A-Za-z0-9\_\-\.]/', $value)) {
             return false;
         }
 

--- a/tests/Database/Adapter/MariaDBTest.php
+++ b/tests/Database/Adapter/MariaDBTest.php
@@ -67,6 +67,7 @@ class MariaDBTest extends Base
         $cache = new Cache(new RedisAdapter($redis));
 
         $database = new Database(new MariaDB($pdo), $cache);
+        $database->setDefaultDatabase('utopiaTests');
         $database->setNamespace('myapp_'.uniqid());
 
         return self::$database = $database;

--- a/tests/Database/Adapter/MongoDBTest.php
+++ b/tests/Database/Adapter/MongoDBTest.php
@@ -63,6 +63,7 @@ class MongoDBTest extends Base
         $cache = new Cache(new RedisAdapter($redis));
 
         $database = new Database(new MongoDB($client), $cache);
+        $database->setDefaultDatabase('utopiaTests');
         $database->setNamespace('myapp_'.uniqid());
 
         return self::$database = $database;

--- a/tests/Database/Adapter/MySQLTest.php
+++ b/tests/Database/Adapter/MySQLTest.php
@@ -78,6 +78,7 @@ class MySQLTest extends Base
         $cache = new Cache(new RedisAdapter($redis));
 
         $database = new Database(new MySQL($pdo), $cache);
+        $database->setDefaultDatabase('utopiaTests');
         $database->setNamespace('myapp_'.uniqid());
 
         return self::$database = $database;

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -342,6 +342,117 @@ abstract class Base extends TestCase
         static::getDatabase()->deleteCollection('withSchema');
     }
 
+    public function testCreateCollectionValidator()
+    {
+        $collections = [
+            "validatorTest",
+            "validator-test",
+            "validator_test",
+            "validator.test",
+        ];
+
+        $attributes = [
+            new Document([
+                '$id' => 'attribute1',
+                'type' => Database::VAR_STRING,
+                'size' => 256,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+            new Document([
+                '$id' => 'attribute-2',
+                'type' => Database::VAR_INTEGER,
+                'size' => 0,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+            new Document([
+                '$id' => 'attribute_3',
+                'type' => Database::VAR_BOOLEAN,
+                'size' => 0,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+            new Document([
+                '$id' => 'attribute.4',
+                'type' => Database::VAR_BOOLEAN,
+                'size' => 0,
+                'required' => false,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+        ];
+
+        $indexes = [
+            new Document([
+                '$id' => 'index1',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute1'],
+                'lengths' => [256],
+                'orders' => ['ASC'],
+            ]),
+            new Document([
+                '$id' => 'index-2',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute-2'],
+                'lengths' => [],
+                'orders' => ['ASC'],
+            ]),
+            new Document([
+                '$id' => 'index_3',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute_3'],
+                'lengths' => [],
+                'orders' => ['ASC'],
+            ]),
+            new Document([
+                '$id' => 'index.4',
+                'type' => Database::INDEX_KEY,
+                'attributes' => ['attribute.4'],
+                'lengths' => [],
+                'orders' => ['ASC'],
+            ]),
+        ];
+
+        foreach ($collections as $id) {
+            $collection = static::getDatabase()->createCollection($id, $attributes, $indexes);
+
+            $this->assertEquals(false, $collection->isEmpty());
+            $this->assertEquals($id, $collection->getId());
+
+            $this->assertIsArray($collection->getAttribute('attributes'));
+            $this->assertCount(4, $collection->getAttribute('attributes'));
+            $this->assertEquals('attribute1', $collection->getAttribute('attributes')[0]['$id']);
+            $this->assertEquals(Database::VAR_STRING, $collection->getAttribute('attributes')[0]['type']);
+            $this->assertEquals('attribute-2', $collection->getAttribute('attributes')[1]['$id']);
+            $this->assertEquals(Database::VAR_INTEGER, $collection->getAttribute('attributes')[1]['type']);
+            $this->assertEquals('attribute_3', $collection->getAttribute('attributes')[2]['$id']);
+            $this->assertEquals(Database::VAR_BOOLEAN, $collection->getAttribute('attributes')[2]['type']);
+            $this->assertEquals('attribute.4', $collection->getAttribute('attributes')[3]['$id']);
+            $this->assertEquals(Database::VAR_BOOLEAN, $collection->getAttribute('attributes')[3]['type']);
+
+            $this->assertIsArray($collection->getAttribute('indexes'));
+            $this->assertCount(4, $collection->getAttribute('indexes'));
+            $this->assertEquals('index1', $collection->getAttribute('indexes')[0]['$id']);
+            $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[0]['type']);
+            $this->assertEquals('index-2', $collection->getAttribute('indexes')[1]['$id']);
+            $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[1]['type']);
+            $this->assertEquals('index_3', $collection->getAttribute('indexes')[2]['$id']);
+            $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[2]['type']);
+            $this->assertEquals('index.4', $collection->getAttribute('indexes')[3]['$id']);
+            $this->assertEquals(Database::INDEX_KEY, $collection->getAttribute('indexes')[3]['type']);
+
+            static::getDatabase()->deleteCollection($id);
+        }
+    }
+
     public function testCreateDocument()
     {
         static::getDatabase()->createCollection('documents');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -40,14 +40,18 @@ abstract class Base extends TestCase
         Authorization::reset();
     }
 
+    protected string $testDatabase = 'utopiaTests';
+
     public function testCreateExistsDelete()
     {
-        $this->assertEquals(false, static::getDatabase()->exists());
-        $this->assertEquals(true, static::getDatabase()->create());
-        $this->assertEquals(true, static::getDatabase()->exists());
-        $this->assertEquals(true, static::getDatabase()->delete());
-        $this->assertEquals(false, static::getDatabase()->exists());
-        $this->assertEquals(true, static::getDatabase()->create());
+        // $this->assertEquals(false, static::getDatabase()->exists($this->testDatabase));
+        $this->assertEquals(true, static::getDatabase()->create($this->testDatabase));
+        $this->assertEquals(true, static::getDatabase()->exists($this->testDatabase));
+        $this->assertEquals(true, static::getDatabase()->delete($this->testDatabase));
+        $this->assertEquals(false, static::getDatabase()->exists($this->testDatabase));
+        $this->assertEquals(true, static::getDatabase()->create($this->testDatabase));
+
+        $this->assertEquals(true, static::getDatabase()->setDefaultDatabase($this->testDatabase));
     }
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -44,7 +44,7 @@ abstract class Base extends TestCase
 
     public function testCreateExistsDelete()
     {
-        // $this->assertEquals(false, static::getDatabase()->exists($this->testDatabase));
+        $this->assertEquals(false, static::getDatabase()->exists($this->testDatabase));
         $this->assertEquals(true, static::getDatabase()->create($this->testDatabase));
         $this->assertEquals(true, static::getDatabase()->exists($this->testDatabase));
         $this->assertEquals(true, static::getDatabase()->delete($this->testDatabase));


### PR DESCRIPTION
In order to more easily integrate with existing production setups, Appwrite is moving to contain everything under one database. To do this, the database library required two major changes:

- Supporting a default database where everything will be created
- Prepend namespace to table/collection names

This PR introduces the concept of a "default database" that many DBMS support, synonymous to the `USE` SQL instruction.

**HIDDEN GAINS**
I feel more confident that database/collection names are properly escaped in queries, so we may not need to be afraid to support special ASCII characters as names. These changes were made in both the SQL and Mongo adapters.

**TESTING**
Only small changes to `createExistsDelete` tests were required, rest of suite remains unchanged.