### PR TITLE
Feat: throw custom exception when index key is too large

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -412,6 +412,13 @@ abstract class Adapter
     abstract public function getIndexLimit(): int;
 
     /**
+     * Get maximum index size limit in bytes.
+     *
+     * @return int
+     */
+    abstract public function getIndexSizeLimit(): int;
+
+    /**
      * Does the adapter handle casting?
      * 
      * @return bool

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -831,6 +831,16 @@ class MariaDB extends Adapter
     }
 
     /**
+     * Get maximum index size limit in bytes.
+     *
+     * @return int
+     */
+    public function getIndexSizeLimit(): int
+    {
+        return 3072;
+    }
+
+    /**
      * Get current attribute count from collection document
      * 
      * @param Document $collection

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -863,6 +863,18 @@ class MongoDB extends Adapter
     }
 
     /**
+     * Get maximum index size limit in bytes.
+     * No key limit as of Mongo v4.2
+     * https://docs.mongodb.com/manual/reference/limits/#mongodb-limit-Index-Key-Limit
+     *
+     * @return int
+     */
+    public function getIndexSizeLimit(): int
+    {
+        return 0;
+    }
+
+    /**
      * Get current attribute count from collection document
      * 
      * @param Document $collection

--- a/src/Database/Exception/Size.php
+++ b/src/Database/Exception/Size.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Utopia\Database\Exception;
+
+class Size extends \Exception
+{
+}

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10,6 +10,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Exception\Authorization as ExceptionAuthorization;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
+use Utopia\Database\Exception\Size as SizeException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 
@@ -1732,6 +1733,21 @@ abstract class Base extends TestCase
         $this->assertEquals(false, static::getDatabase()->createIndex('indexLimit', "index64", Database::INDEX_KEY, ["test64"], [16]));
 
         static::getDatabase()->deleteCollection('indexLimit');
+    }
+
+    public function testExceptionIndexSize()
+    {
+        static::getDatabase()->createCollection('indexSizeLimit');
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute('indexSizeLimit', 'testattribute', Database::VAR_STRING, 3073, true));
+
+        $this->assertEquals(true, static::getDatabase()->createDocument('indexSizeLimit', new Document([
+            'testattribute' => \str_repeat('A', 3073)
+        ])));
+
+        $this->expectException(SizeException::class);
+        $this->assertEquals(false, static::getDatabase()->createIndex('indexSizeLimit', 'testindex', Database::INDEX_KEY, ['testattribute'], [3073]));
+        static::getDatabase()->deleteCollection('indexSizeLimit');
     }
 
     /**


### PR DESCRIPTION
This PR exposes the index key limit of each database adapter and throws a Size exception when necessary.

**Testing**
Unit test has been added to catch this exception

**Related PRs:**
https://github.com/appwrite/appwrite/issues/2596