### PR TITLE
Feat: check if collection exists in database

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -142,12 +142,14 @@ abstract class Adapter
 
     /**
      * Check if database exists
+     * Optionally check if collection exists in database
      *
-     * @param string $name
+     * @param string $database database name
+     * @param string $collection (optional) collection name
      *
      * @return bool
      */
-    abstract public function exists(string $name): bool;
+    abstract public function exists(string $database, string $collection): bool;
 
     /**
      * List Databases

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -149,7 +149,7 @@ abstract class Adapter
      *
      * @return bool
      */
-    abstract public function exists(string $database, string $collection): bool;
+    abstract public function exists(string $database, string $collection = null): bool;
 
     /**
      * List Databases

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -59,9 +59,10 @@ class MariaDB extends Adapter
     public function exists(string $database, $collection = ''): bool
     {
         $database = $this->filter($database);
-        $collection = $this->filter($collection);
 
-        if ($collection) {
+        if (!\is_null($collection)) {
+            $collection = $this->filter($collection);
+
             $select = 'TABLE_NAME';
             $from = 'INFORMATION_SCHEMA.TABLES' ;
             $where = 'TABLE_SCHEMA = :schema AND TABLE_NAME = :table';
@@ -80,7 +81,7 @@ class MariaDB extends Adapter
 
         $stmt->bindValue(':schema', $database, PDO::PARAM_STR);
 
-        if ($collection) {
+        if (!\is_null($collection)) {
             $stmt->bindValue(':table', "{$this->getNamespace()}_{$collection}", PDO::PARAM_STR);
         }
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -49,27 +49,46 @@ class MariaDB extends Adapter
 
     /**
      * Check if database exists
+     * Optionally check if collection exists in database
      *
-     * @param string $name
+     * @param string $database database name
+     * @param string $collection (optional) collection name
      *
      * @return bool
      */
-    public function exists(string $name): bool
+    public function exists(string $database, $collection = ''): bool
     {
-        $name = $this->filter($name);
+        $database = $this->filter($database);
+        $collection = $this->filter($collection);
+
+        if ($collection) {
+            $select = 'TABLE_NAME';
+            $from = 'INFORMATION_SCHEMA.TABLES' ;
+            $where = 'TABLE_SCHEMA = :schema AND TABLE_NAME = :table';
+            $match = "{$this->getNamespace()}_{$collection}";
+        } else {
+            $select = 'SCHEMA_NAME';
+            $from = 'INFORMATION_SCHEMA.SCHEMATA' ;
+            $where = 'SCHEMA_NAME = :schema';
+            $match = $database;
+        }
 
         $stmt = $this->getPDO()
-            ->prepare("SELECT SCHEMA_NAME
-                FROM INFORMATION_SCHEMA.SCHEMATA
-                WHERE SCHEMA_NAME = :schema;");
-            
-        $stmt->bindValue(':schema', $name, PDO::PARAM_STR);
+            ->prepare("SELECT {$select}
+                FROM {$from}
+                WHERE {$where};");
+
+        $stmt->bindValue(':schema', $database, PDO::PARAM_STR);
+
+        if ($collection) {
+            $stmt->bindValue(':table', "{$this->getNamespace()}_{$collection}", PDO::PARAM_STR);
+        }
 
         $stmt->execute();
 
         $document = $stmt->fetch(PDO::FETCH_ASSOC);
 
-        return (($document['SCHEMA_NAME'] ?? '') == $name);
+        return (($document[$select] ?? '') === $match);
     }
 
     /**

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -56,7 +56,7 @@ class MariaDB extends Adapter
      *
      * @return bool
      */
-    public function exists(string $database, $collection = ''): bool
+    public function exists(string $database, string $collection = null): bool
     {
         $database = $this->filter($database);
 

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -47,16 +47,29 @@ class MongoDB extends Adapter
 
     /**
      * Check if database exists
+     * Optionally check if collection exists in database
      *
-     * @param string $name
+     * @param string $database database name
+     * @param string $collection (optional) collection name
      *
      * @return bool
      */
-    public function exists(string $name): bool
+    public function exists(string $database, string $collection = ''): bool
     {
-        $name = $this->filter($name);
-        forEach ($this->getClient()->listDatabaseNames() as $key => $value) {
-            if ($name === $value) {
+
+        $database = $this->filter($database);
+        $collection = $this->filter($collection);
+
+        $names = ($collection)
+            ? $this->getClient()->selectDatabase($database)->listCollectionNames()
+            : $this->getClient()->listDatabaseNames();
+
+        $match = ($collection)
+            ? "{$this->getNamespace()}_{$collection}"
+            : $database;
+
+        foreach ($names as $name) {
+            if ($name === $match) {
                 return true;
             }
         }

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -54,19 +54,31 @@ class MongoDB extends Adapter
      *
      * @return bool
      */
-    public function exists(string $database, string $collection = ''): bool
+    public function exists(string $database, string $collection = null): bool
     {
-
         $database = $this->filter($database);
-        $collection = $this->filter($collection);
 
-        $names = ($collection)
-            ? $this->getClient()->selectDatabase($database)->listCollectionNames()
-            : $this->getClient()->listDatabaseNames();
+        if (!\is_null($collection)) {
+            $collection = $this->filter($collection);
 
-        $match = ($collection)
-            ? "{$this->getNamespace()}_{$collection}"
-            : $database;
+            $match = "{$this->getNamespace()}_{$collection}";
+            $names = $this
+                ->getClient()
+                ->selectDatabase($database)
+                ->listCollectionNames([
+                    'filter' => [
+                        'name' => $match
+                    ]
+                ]);
+        } else {
+            $match = $database;
+            $names = $this->getClient()
+                ->listDatabaseNames([
+                    'filter' => [
+                        'name' => $match
+                    ]
+                ]);
+        }
 
         foreach ($names as $name) {
             if ($name === $match) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -287,7 +287,7 @@ class Database
      *
      * @return bool
      */
-    public function exists(string $database, string $collection = ''): bool
+    public function exists(string $database, string $collection = null): bool
     {
         return $this->adapter->exists($database, $collection);
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -280,12 +280,16 @@ class Database
 
     /**
      * Check if database exists
+     * Optionally check if collection exists in database
+     *
+     * @param string $database database name
+     * @param string $collection (optional) collection name
      *
      * @return bool
      */
-    public function exists(string $name): bool
+    public function exists(string $database, string $collection = ''): bool
     {
-        return $this->adapter->exists($name);
+        return $this->adapter->exists($database, $collection);
     }
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -57,15 +57,17 @@ abstract class Base extends TestCase
     /**
      * @depends testCreateExistsDelete
      */
-    public function testCreateListDeleteCollection()
+    public function testCreateListExistsDeleteCollection()
     {
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('actors'));
 
         $this->assertCount(1, static::getDatabase()->listCollections());
+        $this->assertEquals(true, static::getDatabase()->exists($this->testDatabase, 'actors'));
 
         // Collection names should not be unique
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('actors2'));
         $this->assertCount(2, static::getDatabase()->listCollections());
+        $this->assertEquals(true, static::getDatabase()->exists($this->testDatabase, 'actors2'));
         $collection = static::getDatabase()->getCollection('actors2');
         $collection->setAttribute('name', 'actors'); // change name to one that exists
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->updateDocument($collection->getCollection(), $collection->getId(), $collection));
@@ -75,6 +77,7 @@ abstract class Base extends TestCase
         $this->assertEquals(false, static::getDatabase()->getCollection('actors')->isEmpty());
         $this->assertEquals(true, static::getDatabase()->deleteCollection('actors'));
         $this->assertEquals(true, static::getDatabase()->getCollection('actors')->isEmpty());
+        $this->assertEquals(false, static::getDatabase()->exists($this->testDatabase, 'actors'));
     }
 
     public function testCreateDeleteAttribute()


### PR DESCRIPTION
Since moving every collection to a single default database, we lose the ability to know if a collection has been properly configured (e.g. does the metadata table exist). 

This PR extends `Utopia\Database\Database::exists()` to optionally accept a collection name and test for its existence. 

**Notes**
I'm not sold on this, but the only other nice name I could come up with was `collectionExists()` which doesn't fit the pattern. Alternative suggestions welcome.

**Testing**
Unit tests have been added for both success and failure.

