### PR TITLE
Added $id support for sortAttribute

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -705,7 +705,12 @@ class MariaDB extends Adapter
             return $orderAttribute === '$id' ? '_uid' : $orderAttribute;
         }, $orderAttributes);
 
+        $hasIdAttribute = false;
         foreach($orderAttributes as $i => $attribute) {
+            if($attribute === '_uid') {
+                $hasIdAttribute = true;
+            }
+
             $attribute = $this->filter($attribute);
             $orderType = $this->filter($orderTypes[$i] ?? Database::ORDER_ASC);
 
@@ -745,15 +750,17 @@ class MariaDB extends Adapter
         }
 
         // Allow order type without any order attribute, fallback to the natural order (_id)
-        if (empty($orderAttributes) && !empty($orderTypes)) {
-            $order = $orderTypes[0] ?? Database::ORDER_ASC;
-            if ($cursorDirection === Database::CURSOR_BEFORE) {
-                $order = $order === Database::ORDER_ASC ? Database::ORDER_DESC : Database::ORDER_ASC;
+        if(!$hasIdAttribute) {
+            if (empty($orderAttributes) && !empty($orderTypes)) {
+                $order = $orderTypes[0] ?? Database::ORDER_ASC;
+                if ($cursorDirection === Database::CURSOR_BEFORE) {
+                    $order = $order === Database::ORDER_ASC ? Database::ORDER_DESC : Database::ORDER_ASC;
+                }
+    
+                $orders[] = 'table_main._id ' . $this->filter($order);
+            } else {
+                $orders[] = 'table_main._id ' . ($cursorDirection === Database::CURSOR_AFTER ? Database::ORDER_ASC : Database::ORDER_DESC); // Enforce last ORDER by '_id'
             }
-
-            $orders[] = 'table_main._id ' . $this->filter($order);
-        } else {
-            $orders[] = 'table_main._id ' . ($cursorDirection === Database::CURSOR_AFTER ? Database::ORDER_ASC : Database::ORDER_DESC); // Enforce last ORDER by '_id'
         }
 
         foreach ($queries as $i => $query) {

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -544,6 +544,10 @@ class MariaDB extends Adapter
         $where = ['1=1'];
         $orders = [];
 
+        $orderAttributes = \array_map(function($orderAttribute) {
+            return $orderAttribute === '$id' ? '_uid' : $orderAttribute;
+        }, $orderAttributes);
+
         foreach($orderAttributes as $i => $attribute) {
             $attribute = $this->filter($attribute);
             $orderType = $this->filter($orderTypes[$i] ?? Database::ORDER_ASC);

--- a/src/Database/Adapter/MongoDB.php
+++ b/src/Database/Adapter/MongoDB.php
@@ -479,6 +479,10 @@ class MongoDB extends Adapter
         $options = ['sort' => [], 'limit' => $limit, 'skip' => $offset];
 
         // orders
+        $orderAttributes = \array_map(function($orderAttribute) {
+            return $orderAttribute === '$id' ? '_uid' : $orderAttribute;
+        }, $orderAttributes);
+        
         foreach($orderAttributes as $i => $attribute) {
             $attribute = $this->filter($attribute);
             $orderType = $this->filter($orderTypes[$i] ?? Database::ORDER_ASC);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -703,6 +703,17 @@ abstract class Base extends TestCase
         $this->assertEquals(['animation', 'kids'], $documents[0]->getAttribute('generes'));
         $this->assertIsArray($documents[0]->getAttribute('generes'));
 
+        $firstDocumentId = $documents[0]->getId();
+        $lastDocumentId = $documents[\count($documents)]->getId();
+
+         /**
+         * Check $id
+         */
+        $documents = static::getDatabase()->find('movies', [], 25, 0, ['$id'], [Database::ORDER_DESC]);
+        $this->assertEquals($lastDocumentId, $documents[0]->getId());
+        $documents = static::getDatabase()->find('movies', [], 25, 0, ['$id'], [Database::ORDER_ASC]);
+        $this->assertEquals($firstDocumentId, $documents[0]->getId());
+
         /**
          * Check Permissions
          */

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -736,7 +736,7 @@ abstract class Base extends TestCase
          * Check $id
          */
         $documents = static::getDatabase()->find('movies', [], 25, 0, ['$id'], [Database::ORDER_DESC]);
-        $this->assertEquals($lastDocumentId, $documents[0]->getId());
+        $this->assertEquals($lastDocumentId, $documents[\count($documents)-1]->getId());
         $documents = static::getDatabase()->find('movies', [], 25, 0, ['$id'], [Database::ORDER_ASC]);
         $this->assertEquals($firstDocumentId, $documents[0]->getId());
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -704,7 +704,7 @@ abstract class Base extends TestCase
         $this->assertIsArray($documents[0]->getAttribute('generes'));
 
         $firstDocumentId = $documents[0]->getId();
-        $lastDocumentId = $documents[\count($documents)]->getId();
+        $lastDocumentId = $documents[\count($documents) - 1]->getId();
 
          /**
          * Check $id

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -711,6 +711,7 @@ abstract class Base extends TestCase
          * Check Basic
          */
         $documents = static::getDatabase()->find('movies');
+        $movieDocuments = $documents;
 
         $this->assertEquals(5, count($documents));
         $this->assertNotEmpty($documents[0]->getId());
@@ -729,16 +730,31 @@ abstract class Base extends TestCase
         $this->assertEquals(['animation', 'kids'], $documents[0]->getAttribute('generes'));
         $this->assertIsArray($documents[0]->getAttribute('generes'));
 
-        $firstDocumentId = $documents[0]->getId();
-        $lastDocumentId = $documents[\count($documents) - 1]->getId();
+        // Alphabetical order
+        $sortedDocuments = $movieDocuments;
+        \usort($sortedDocuments, function($doc1, $doc2) {
+            return strcmp($doc1['$id'], $doc2['$id']);
+        });
+
+        $firstDocumentId = $sortedDocuments[0]->getId();
+        $lastDocumentId = $sortedDocuments[\count($sortedDocuments) - 1]->getId();
 
          /**
-         * Check $id
+         * Check $id: Notice, this orders ID names alphabetically, not by internal numeric ID
          */
         $documents = static::getDatabase()->find('movies', [], 25, 0, ['$id'], [Database::ORDER_DESC]);
-        $this->assertEquals($lastDocumentId, $documents[\count($documents)-1]->getId());
+        $this->assertEquals($lastDocumentId, $documents[0]->getId());
         $documents = static::getDatabase()->find('movies', [], 25, 0, ['$id'], [Database::ORDER_ASC]);
         $this->assertEquals($firstDocumentId, $documents[0]->getId());
+
+        /**
+         * Check internal numeric ID sorting
+         */
+        $documents = static::getDatabase()->find('movies', [], 25, 0, [], [Database::ORDER_DESC]);
+        $this->assertEquals($movieDocuments[\count($movieDocuments) - 1]->getId(), $documents[0]->getId());
+        $documents = static::getDatabase()->find('movies', [], 25, 0, [], [Database::ORDER_ASC]);
+        $this->assertEquals($movieDocuments[0]->getId(), $documents[0]->getId());
+
 
         /**
          * Check Permissions


### PR DESCRIPTION
Before, people were not able to sort by `$id`, saying `attribute 'id' not found`. Now, people can use `$id` and it is translated to `_uid` under the hood, similar to `queries` with `$id`.

![CleanShot 2022-01-31 at 18 41 19](https://user-images.githubusercontent.com/19310830/151844817-5b62b109-4d59-4c8a-ae0f-a73f946c55bd.png)

![CleanShot 2022-01-31 at 18 41 14](https://user-images.githubusercontent.com/19310830/151844821-6950b0c3-6ff0-409d-baf6-f99427ede184.png)
