### PR TITLE
fix: trailing wildcard search by default

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1256,6 +1256,7 @@ class MariaDB extends Adapter
     {
         switch ($operator) {
             case Query::TYPE_SEARCH:
+                $value = "\"{$value}*\”";
                 return 'MATCH(' . $attribute . ') AGAINST(' . $this->getPDO()->quote($value) . ' IN BOOLEAN MODE)';
                 break;
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -816,16 +816,10 @@ abstract class Base extends TestCase
         // TODO: Looks like the MongoDB implementation is a bit more complex, skipping that for now.
         if (in_array(static::getAdapterName(), ['mysql', 'mariadb'])) {
             $documents = static::getDatabase()->find('movies', [
-                new Query('name', Query::TYPE_SEARCH, ['cap*']),
-            ]);
-
-            $this->assertEquals(2, count($documents));
-
-            $documents = static::getDatabase()->find('movies', [
                 new Query('name', Query::TYPE_SEARCH, ['cap']),
             ]);
 
-            $this->assertEquals(0, count($documents));
+            $this->assertEquals(2, count($documents));
         }
 
         /**


### PR DESCRIPTION
- trailing wildcard search by default
- wrap search condition in `"` to prevent SQL errors