### PR TITLE
Fix: array string validator

### DIFF
--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -235,7 +235,8 @@ class Structure extends Validator
 
             switch ($type) {
                 case Database::VAR_STRING:
-                    $validator = new Text(0);
+                    $size = $attribute['size'] ?? 0;
+                    $validator = new Text($size);
                     break;
 
                 case Database::VAR_INTEGER:

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -268,7 +268,7 @@ class StructureTest extends TestCase
             'feedback' => 'team@appwrite.io',
         ])));
 
-        $this->assertEquals('Invalid document structure: Attribute "tags[\'0\']" has invalid type. Value must be a valid string', $validator->getDescription());
+        $this->assertEquals('Invalid document structure: Attribute "tags[\'0\']" has invalid type. Value must be a valid string and no longer than 55 chars', $validator->getDescription());
 
         $this->assertEquals(false, $validator->isValid(new Document([
             '$collection' => 'posts',

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -250,7 +250,7 @@ class StructureTest extends TestCase
             'feedback' => 'team@appwrite.io',
         ])));
 
-        $this->assertEquals('Invalid document structure: Attribute "title" has invalid type. Value must be a valid string', $validator->getDescription());
+        $this->assertEquals('Invalid document structure: Attribute "title" has invalid type. Value must be a valid string and no longer than 256 chars', $validator->getDescription());
     }
 
     public function testArrayOfStringsValidation()
@@ -281,7 +281,7 @@ class StructureTest extends TestCase
             'feedback' => 'team@appwrite.io',
         ])));
 
-        $this->assertEquals('Invalid document structure: Attribute "tags[\'0\']" has invalid type. Value must be a valid string', $validator->getDescription());
+        $this->assertEquals('Invalid document structure: Attribute "tags[\'0\']" has invalid type. Value must be a valid string and no longer than 55 chars', $validator->getDescription());
 
         $this->assertEquals(true, $validator->isValid(new Document([
             '$collection' => 'posts',

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -295,7 +295,7 @@ class StructureTest extends TestCase
         ])));
 
 
-        $this->assertEquals(true, $validator->isValid(new Document([
+        $this->assertEquals(false, $validator->isValid(new Document([
             '$collection' => 'posts',
             'title' => 'string',
             'description' => 'Demo description',

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -293,6 +293,20 @@ class StructureTest extends TestCase
             'tags' => [],
             'feedback' => 'team@appwrite.io',
         ])));
+
+
+        $this->assertEquals(true, $validator->isValid(new Document([
+            '$collection' => 'posts',
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['too-long-tag-name-to-make-sure-the-length-validator-inside-string-attribute-type-fails-properly'],
+            'feedback' => 'team@appwrite.io',
+        ])));
+
+        $this->assertEquals('Invalid document structure: Attribute "tags[\'0\']" has invalid type. Value must be a valid string and no longer than 55 chars', $validator->getDescription());
     }
 
     public function testIntegerValidation()


### PR DESCRIPTION
Size limit is now properly applied on string arrays:

![image](https://user-images.githubusercontent.com/19310830/157664667-0bf2cce1-038d-49e9-82dc-c5104dcda420.png)
