### PR TITLE
Fix: Symbols in binds

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -409,12 +409,19 @@ class MariaDB extends Adapter
 
         $this->getPDO()->beginTransaction();
 
+        $bindIndex = 0;
+        $bindMap = [];
+
         /**
          * Insert Attributes
          */
         foreach ($attributes as $attribute => $value) { // Parse statement
             $column = $this->filter($attribute);
-            $columns .= "`{$column}`" . '=:' . $column . ',';
+            $bindKey = 'xvalue' . $bindIndex;
+            $columns .= "`{$column}`" . '=:' . $bindKey . ',';
+
+            $bindMap[$attribute] = $bindIndex;
+            $bindIndex++;
         }
 
         $stmt = $this->getPDO()
@@ -428,9 +435,10 @@ class MariaDB extends Adapter
                 $value = json_encode($value);
             }
 
+            $bindKey = 'xvalue' . $bindMap[$attribute];
             $attribute = $this->filter($attribute);
             $value = (is_bool($value)) ? (int)$value : $value;
-            $stmt->bindValue(':' . $attribute, $value, $this->getPDOType($value));
+            $stmt->bindValue(':' . $bindKey, $value, $this->getPDOType($value));
         }
 
         $permissions = [];
@@ -448,6 +456,8 @@ class MariaDB extends Adapter
         }
 
         try {
+            \var_dump($stmt->queryString);
+
             $stmt->execute();
             if (isset($stmtPermissions)) {
                 $stmtPermissions->execute();
@@ -591,9 +601,17 @@ class MariaDB extends Adapter
         /**
          * Update Attributes
          */
+
+        $bindIndex = 0;
+        $bindMap = [];
+
         foreach ($attributes as $attribute => $value) {
             $column = $this->filter($attribute);
-            $columns .= "`{$column}`" . '=:' . $column . ',';
+            $bindKey = 'xvalue' . $bindIndex;
+            $columns .= "`{$column}`" . '=:' . $bindKey . ',';
+
+            $bindMap[$attribute] = $bindIndex;
+            $bindIndex++;
         }
 
         $stmt = $this->getPDO()
@@ -607,9 +625,10 @@ class MariaDB extends Adapter
                 $value = json_encode($value);
             }
 
+            $bindKey = 'xvalue' . $bindMap[$attribute];
             $attribute = $this->filter($attribute);
             $value = (is_bool($value)) ? (int)$value : $value;
-            $stmt->bindValue(':' . $attribute, $value, $this->getPDOType($value));
+            $stmt->bindValue(':' . $bindKey, $value, $this->getPDOType($value));
         }
 
         if (!empty($attributes)) {


### PR DESCRIPTION
Currently, if you create an attribute with a dash or dot `my-name` or `my-name`, the attribute is created. Problem is, if you try to createDocument or updateDocument, you get SQL query error:

![CleanShot 2022-04-01 at 11 35 23](https://user-images.githubusercontent.com/19310830/161237597-71ea2370-3471-414c-b5b9-76cbd2a85ac3.png)

After this PR, binds are custom made and do not include attribute symbols. This resolved the problem and dashes/dots now work properly: 

![CleanShot 2022-04-01 at 11 35 29](https://user-images.githubusercontent.com/19310830/161237590-5c106e23-6f6f-4388-8691-875fde84499f.png)

- [x] Manual QA
- [ ] Write tests