### PR TITLE
Fix: Auth skip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 
 arch:
   - amd64
@@ -9,27 +9,27 @@ language: shell
 
 notifications:
   email:
-  - team@appwrite.io
+    - team@appwrite.io
 
 before_script: docker run --rm --interactive --tty --volume "$(pwd)":/app composer update --ignore-platform-reqs --optimize-autoloader --no-plugins --no-scripts --prefer-dist
 
 before_install:
-- curl -fsSL https://get.docker.com | sh
-- echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
-- mkdir -p $HOME/.docker
-- echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
-- sudo service docker start
-- >
-  if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
-    echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
-  fi
-- docker --version
+  - curl -fsSL https://get.docker.com | sh
+  - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+  - mkdir -p $HOME/.docker
+  - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+  - sudo service docker start
+  - >
+    if [ ! -z "${DOCKERHUB_PULL_USERNAME:-}" ]; then
+      echo "${DOCKERHUB_PULL_PASSWORD}" | docker login --username "${DOCKERHUB_PULL_USERNAME}" --password-stdin
+    fi
+  - docker --version
 
 install:
-- docker-compose up -d
-- sleep 10
+  - docker-compose up -d
+  - sleep 10
 
 script:
-- docker ps
-- docker-compose exec tests vendor/bin/phpunit --configuration phpunit.xml
-- docker-compose exec tests vendor/bin/psalm --show-info=true
+  - docker ps
+  - docker-compose exec tests vendor/bin/phpunit --configuration phpunit.xml
+  - docker-compose exec tests vendor/bin/psalm --show-info=true

--- a/composer.lock
+++ b/composer.lock
@@ -340,16 +340,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.19.9",
+            "version": "0.19.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/framework.git",
-                "reference": "4af9fc866edce1b8cff94731fb26c27599118e87"
+                "reference": "65ced168db8f6e188ceeb0d101f57552c3d8b2af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/framework/zipball/4af9fc866edce1b8cff94731fb26c27599118e87",
-                "reference": "4af9fc866edce1b8cff94731fb26c27599118e87",
+                "url": "https://api.github.com/repos/utopia-php/framework/zipball/65ced168db8f6e188ceeb0d101f57552c3d8b2af",
+                "reference": "65ced168db8f6e188ceeb0d101f57552c3d8b2af",
                 "shasum": ""
             },
             "require": {
@@ -383,9 +383,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/framework/issues",
-                "source": "https://github.com/utopia-php/framework/tree/0.19.9"
+                "source": "https://github.com/utopia-php/framework/tree/0.19.20"
             },
-            "time": "2022-04-14T15:39:47+00:00"
+            "time": "2022-04-14T15:42:37+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -12,7 +12,7 @@ class Authorization extends Validator
      * 
      * @var array
      */
-    static $roles = ['role:all' => true];
+    static array $roles = ['role:all' => true];
 
     /**
      * Action of the authorization validation.
@@ -20,7 +20,7 @@ class Authorization extends Validator
      * 
      * @var string
      */
-    protected $action = '';
+    protected string $action = '';
 
     /**
      * Error message explaining why validation failed.
@@ -179,7 +179,7 @@ class Authorization extends Validator
      * 
      * @return mixed
      */
-    public static function skip(callable $callback)
+    public static function skip(callable $callback): mixed
     {
         $enabled = self::$status;
 

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -27,7 +27,7 @@ class Authorization extends Validator
      * 
      * @var string
      */
-    protected $message = 'Authorization Error';
+    protected string $message = 'Authorization Error';
 
     /**
      * @param string $action Action to check for during validation.
@@ -58,7 +58,7 @@ class Authorization extends Validator
      *
      * @return bool
      */
-    public function isValid($permissions): bool
+    public function isValid(mixed $permissions): bool
     {
         if (!self::$status) {
             return true;
@@ -146,7 +146,7 @@ class Authorization extends Validator
      * 
      * @var bool
      */
-    public static $status = true;
+    public static bool $status = true;
     
     /**
      * Default value in case we need
@@ -154,7 +154,7 @@ class Authorization extends Validator
      *
      * @var bool
      */
-    public static $statusDefault = true;
+    public static bool $statusDefault = true;
 
     /**
      * Change default status.

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -8,24 +8,31 @@ use Utopia\Validator;
 class Authorization extends Validator
 {
     /**
+     * Array of allowed roles.
+     * 
      * @var array
      */
     static $roles = ['role:all' => true];
 
     /**
+     * Action of the authorization validation.
+     * Mainly 'read' or 'write'.
+     * 
      * @var string
      */
     protected $action = '';
 
     /**
+     * Error message explaining why validation failed.
+     * 
      * @var string
      */
     protected $message = 'Authorization Error';
 
     /**
-     * @param string $action
+     * @param string $action Action to check for during validation.
      */
-    public function __construct($action)
+    public function __construct(string $action)
     {
         $this->action = $action;
     }
@@ -70,13 +77,16 @@ class Authorization extends Validator
             }
         }
 
-        $this->message = 'Missing "'.$this->action.'" permission for role "'.$permission.'". Only this scopes "'.\json_encode(self::getRoles()).'" are given and only this are allowed "'.\json_encode($permissions).'".';
+        $this->message = 'Missing "'.$this->action.'" permission. Scopes "'.\json_encode(self::getRoles()).'" are given, but these scopes are allowed: "'.\json_encode($permissions).'"';
 
         return false;
     }
 
     /**
-     * @param string $role
+     * Add role to list of allowed roles for validation.
+     * 
+     * @param string $role Role to add
+     * 
      * @return void
      */
     public static function setRole(string $role): void
@@ -85,7 +95,9 @@ class Authorization extends Validator
     }
 
     /**
-     * @param string $role
+     * Remove role from list of allowed roles for validation.
+     * 
+     * @param string $role Role to remove
      *
      * @return void
      */
@@ -95,6 +107,8 @@ class Authorization extends Validator
     }
 
     /**
+     * Get list of allowed roles.
+     * 
      * @return array
      */
     public static function getRoles(): array
@@ -103,6 +117,8 @@ class Authorization extends Validator
     }
 
     /**
+     * Clear list of allowed roles.
+     * 
      * @return void
      */
     public static function cleanRoles(): void
@@ -111,9 +127,11 @@ class Authorization extends Validator
     }
 
     /**
-     * @param string $role
+     * Check if role is already allowed.
      * 
-     * @return bool
+     * @param string $role Role name to check for
+     * 
+     * @return bool Returns true if role is already in the list
      */
     public static function isRole(string $role): bool
     {
@@ -121,13 +139,18 @@ class Authorization extends Validator
     }
 
     /**
+     * Current Authorization status.
+     * 
+     * true = authorization checks are active
+     * false = authorization checks will not run
+     * 
      * @var bool
      */
     public static $status = true;
     
     /**
      * Default value in case we need
-     *  to reset Authorization status
+     *  to reset Authorization status.
      *
      * @var bool
      */
@@ -135,10 +158,12 @@ class Authorization extends Validator
 
     /**
      * Change default status.
+     * 
      * This will be used for the
-     *  value set on the self::reset() method
+     *  value set on the self::reset() method.
      * 
      * @param bool $status
+     * 
      * @return void
      */
     public static function setDefaultStatus(bool $status): void
@@ -148,23 +173,25 @@ class Authorization extends Validator
     }
 
     /**
-     * Skip Authorization
+     * Skip Authorization for the code executed inside the callback.
      * 
-     * Skips authorization for the code to be executed inside the callback
+     * @param callable $callback function to run without authorization
      * 
      * @return mixed
      */
     public static function skip(callable $callback)
     {
-        self::disable();
+        $enabled = self::$status;
+
+        if ($enabled) self::disable();
         $result = $callback();
-        self::reset();
+        if ($enabled) self::reset();
 
         return $result;
     }
 
     /**
-     * Enable Authorization checks
+     * Enable Authorization checks.
      * 
      * @return void
      */
@@ -174,7 +201,7 @@ class Authorization extends Validator
     }
 
     /**
-     * Disable Authorization checks
+     * Disable Authorization checks.
      * 
      * @return void
      */
@@ -184,7 +211,7 @@ class Authorization extends Validator
     }
 
     /**
-     * Disable Authorization checks
+     * Reset Authorization checks.
      * 
      * @return void
      */
@@ -206,9 +233,7 @@ class Authorization extends Validator
     }
 
     /**
-     * Get Type
-     *
-     * Returns validator type.
+     * Get validator type.
      *
      * @return string
      */


### PR DESCRIPTION
- Better reversion mechanism for skip() method
- Improved docs
- Improved error message

Let's imagine the following pseudo code:
```php
Auth::disable();

$doc = $db->getDocument('users', 'user1'); // Works

$doc = Auth::skip(fn() => $db->getDocument('users', 'user1')); // Works

$doc = $db->getDocument('users', 'user1'); // No longer work
```

If you disable auth, and later use `skip`, it re-enabled auth. After `skip` is finished, the status should be restored to what it was before skipping, instead of enabling it forcefully. 
Can be seen on: https://github.com/utopia-php/database/pull/130/files#diff-f0b0bb401b111034042efdb8f446197096a3fa9592d55d36ca9c6213770e5e25L161