### PR TITLE
Fix: Force object

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -142,7 +142,7 @@ class Database
                     return $value;
                 }
 
-                return json_encode($value);
+                return json_encode($value, JSON_FORCE_OBJECT);
             },
             /**
              * @param mixed $value


### PR DESCRIPTION
We currently use `json_encode` inside `json` filter. Problem is, if you pass empty array `[]`, it will be represented as array `[]`.

In the context of JSON, I would like to open a discussion around adding `JSON_FORCE_OBJECT` to convert an empty PHP array into `{}`.