### PR TITLE
Feat: Add update attribute methods

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -340,16 +340,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.19.20",
+            "version": "0.19.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/framework.git",
-                "reference": "65ced168db8f6e188ceeb0d101f57552c3d8b2af"
+                "reference": "3b7bd8e4acf84fd7d560ced8e0142221d302575d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/framework/zipball/65ced168db8f6e188ceeb0d101f57552c3d8b2af",
-                "reference": "65ced168db8f6e188ceeb0d101f57552c3d8b2af",
+                "url": "https://api.github.com/repos/utopia-php/framework/zipball/3b7bd8e4acf84fd7d560ced8e0142221d302575d",
+                "reference": "3b7bd8e4acf84fd7d560ced8e0142221d302575d",
                 "shasum": ""
             },
             "require": {
@@ -383,9 +383,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/framework/issues",
-                "source": "https://github.com/utopia-php/framework/tree/0.19.20"
+                "source": "https://github.com/utopia-php/framework/tree/0.19.21"
             },
-            "time": "2022-04-14T15:42:37+00:00"
+            "time": "2022-05-12T18:42:28+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -201,6 +201,19 @@ abstract class Adapter
     abstract public function createAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool;
 
     /**
+     * Update Attribute
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param string $type
+     * @param int $size
+     * @param bool $array
+     * 
+     * @return bool
+     */
+    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool;
+
+    /**
      * Delete Attribute
      * 
      * @param string $collection

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -246,6 +246,35 @@ class MariaDB extends Adapter
     }
 
     /**
+     * Update Attribute
+     *
+     * @param string $collection
+     * @param string $id
+     * @param string $type
+     * @param int $size
+     * @param bool $signed
+     * @param bool $array
+     * @return bool
+     * @throws Exception
+     * @throws PDOException
+     */
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool
+    {
+        $name = $this->filter($collection);
+        $id = $this->filter($id);
+        $type = $this->getSQLType($type, $size, $signed);
+
+        if ($array) {
+            $type = 'LONGTEXT';
+        }
+
+        return $this->getPDO()
+            ->prepare("ALTER TABLE `{$this->getDefaultDatabase()}`.`{$this->getNamespace()}_{$name}`
+                MODIFY `{$id}` {$type};")
+            ->execute();
+    }
+
+    /**
      * Rename Attribute
      *
      * @param string $collection

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -703,10 +703,8 @@ class Database
      * 
      * @return bool
      */
-    public function updateAttribute(string $collection, string $id = null, string $type = null, int $size = null, bool $signed = null, bool $array = null): bool
+    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $signed = null, bool $array = null): bool
     {
-        $success = true;
-
         $this->updateAttributeMeta($collection, $id, function($attribute) use($collection, $id, $type, $size, $signed, $array, &$success) {
             if($type !== null || $size !== null || $signed !== null || $array !== null) {
                 $type ??= $attribute->getAttribute('type');
@@ -741,14 +739,13 @@ class Database
                     ->setAttribute('signed', $signed)
                     ->setAttribute('array', $array);
     
-                $success = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array);
+                $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array);
             }
-
 
             $attribute->setAttribute('array', $array);
         });
 
-        return $success;
+        return true;
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -558,23 +558,18 @@ class Database
             throw new Exception('Attribute not found');
         }
 
-        $attribute = $attributes[$attributeIndex];
-
         // Execute update from callback
-        call_user_func($updateCallback, $attribute);
+        call_user_func($updateCallback, $attributes[$attributeIndex]);
 
         // Save
-        $attributes[$attributeIndex] = $attribute;
         $collection->setAttribute('attributes', $attributes, Document::SET_TYPE_ASSIGN);
 
-        /*
         if (
             $this->adapter->getRowLimit() > 0 &&
             $this->adapter->getAttributeWidth($collection) >= $this->adapter->getRowLimit()
         ) {
             throw new LimitException('Row width limit reached. Cannot create new attribute.');
         }
-        */
 
         if ($collection->getId() !== self::METADATA) {
             $this->updateDocument(self::METADATA, $collection->getId(), $collection);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -536,6 +536,224 @@ class Database
     }
 
     /**
+     * Update attribute metadata. Utility method for update attribute methods.
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param string $key Metadata key to update
+     * @param callable $updateCallback method that recieves document, and returns it with changes applied
+     * 
+     * @return Document
+     */
+    private function updateAttributeMeta(string $collection, string $id, callable $updateCallback): void
+    {
+        // Load
+        $collection = $this->getCollection($collection);
+
+        $attributes = $collection->getAttribute('attributes', []);
+
+        $attributeIndex = \in_array($id, \array_map(fn($attribute) => $attribute['$id'], $attributes));
+
+        if($attributeIndex === false) {
+            throw new Exception('Attribute not found');
+        }
+
+        $attribute = $attributes[$attributeIndex];
+
+        // Execute update from callback
+        $attribute = call_user_func($updateCallback, $attribute);
+
+        // Save
+        $attributes[$attributeIndex] = $attribute;
+        $collection->setAttribute('attributes', $attributes, Document::SET_TYPE_ASSIGN);
+
+        if (
+            $this->adapter->getRowLimit() > 0 &&
+            $this->adapter->getAttributeWidth($collection) >= $this->adapter->getRowLimit()
+        ) {
+            throw new LimitException('Row width limit reached. Cannot create new attribute.');
+        }
+
+        if ($collection->getId() !== self::METADATA) {
+            $this->updateDocument(self::METADATA, $collection->getId(), $collection);
+        }
+    }
+
+    /**
+     * Update required status of attribute.
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param bool $required
+     * 
+     * @return void
+     */
+    public function updateAttributeRequired(string $collection, string $id, bool $required): void
+    {
+        $this->updateAttributeMeta($collection, $id, function($attribute) use($required) {
+            $attribute->setAttribute('required', $required);
+        });
+    }
+
+    /**
+     * Update format of attribute.
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param string $format validation format of attribute
+     * 
+     * @return void
+     */
+    public function updateAttributeFormat(string $collection, string $id, string $format): void
+    {
+        $this->updateAttributeMeta($collection, $id, function($attribute) use($format) {
+            if (!Structure::hasFormat($format, $attribute->getAttribute('type'))) {
+                throw new Exception('Format ("' . $format . '") not available for this attribute type ("' . $attribute->getAttribute('type') . '")');
+            }
+
+            $attribute->setAttribute('format', $format);
+        });
+    }
+
+    /**
+     * Update format options of attribute.
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param array $formatOptions assoc array with custom options that can be passed for the format validation
+     * 
+     * @return void
+     */
+    public function updateAttributeFormatOptions(string $collection, string $id, array $formatOptions): void
+    {
+        $this->updateAttributeMeta($collection, $id, function($attribute) use($formatOptions) {
+            $attribute->setAttribute('formatOptions', $formatOptions);
+        });
+    }
+
+    /**
+     * Update filters of attribute.
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param array $filters
+     * 
+     * @return void
+     */
+    public function updateAttributeFormatFilters(string $collection, string $id, array $filters): void
+    {
+        $this->updateAttributeMeta($collection, $id, function($attribute) use($filters) {
+            $attribute->setAttribute('filters', $filters);
+        });
+    }
+
+    /**
+     * Update default value of attribute
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param array|bool|callable|int|float|object|resource|string|null $default
+     * 
+     * @return void
+     */
+    public function updateAttributeDefault(string $collection, string $id, $default = null): void
+    {
+        $this->updateAttributeMeta($collection, $id, function($attribute) use($default) {
+            if ($attribute->getAttribute('required') === true) {
+                throw new Exception('Cannot set a default value on a required attribute');
+            }
+            switch (\gettype($default)) {
+                    // first enforce typed array for each value in $default
+                case 'array':
+                    foreach ($default as $value) {
+                        if ($attribute->getAttribute('type') !== \gettype($value)) {
+                            throw new Exception('Default value contents do not match given type ' . $attribute->getAttribute('type'));
+                        }
+                    }
+                    break;
+                    // then enforce for primitive types
+                case self::VAR_STRING:
+                case self::VAR_INTEGER:
+                case self::VAR_FLOAT:
+                case self::VAR_BOOLEAN:
+                    if ($attribute->getAttribute('type') !== \gettype($default)) {
+                        throw new Exception('Default value ' . $default . ' does not match given type ' . $attribute->getAttribute('type'));
+                    }
+                    break;
+                default:
+                    throw new Exception('Unknown attribute type for: ' . $default);
+                    break;
+            }
+    
+            $attribute->setAttribute('default', $default);
+        });
+    }
+
+    /**
+     * Update Attribute. This method is for updating data that causes underlying structure to change. Check out other updateAttribute methods if you are looking for metadata adjustments.
+     * 
+     * @param string $collection
+     * @param string $id
+     * @param string $type
+     * @param int $size utf8mb4 chars length
+     * @param bool $signed
+     * @param bool $array
+     * 
+     * To update attribute key (ID), use renameAttribute instead.
+     * 
+     * @return bool
+     */
+    public function updateAttribute(string $collection, string $id = null, string $type = null, int $size = null, bool $signed = null, bool $array = null): bool
+    {
+        $success = true;
+
+        $this->updateAttributeMeta($collection, $id, function($attribute) use($collection, $id, $type, $size, $signed, $array, &$success) {
+            if($type !== null || $size !== null || $signed !== null || $array !== null) {
+                $type ??= $attribute->getAttribute('type');
+                $size ??= $attribute->getAttribute('size');
+                $signed ??= $attribute->getAttribute('signed');
+                $array ??= $attribute->getAttribute('array');
+                
+                switch ($type) {
+                    case self::VAR_STRING:
+                        if ($size > $this->adapter->getStringLimit()) {
+                            throw new Exception('Max size allowed for string is: ' . number_format($this->adapter->getStringLimit()));
+                        }
+                        break;
+        
+                    case self::VAR_INTEGER:
+                        $limit = ($signed) ? $this->adapter->getIntLimit() / 2 : $this->adapter->getIntLimit();
+                        if ($size > $limit) {
+                            throw new Exception('Max size allowed for int is: ' . number_format($limit));
+                        }
+                        break;
+                    case self::VAR_FLOAT:
+                    case self::VAR_BOOLEAN:
+                        break;
+                    default:
+                        throw new Exception('Unknown attribute type: ' . $type);
+                        break;
+                }
+    
+                $attribute
+                    ->setAttribute('type', $type)
+                    ->setAttribute('size', $size)
+                    ->setAttribute('signed', $signed)
+                    ->setAttribute('array', $array);
+    
+                $success = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array);
+            }
+
+
+            $attribute->setAttribute('array', $array);
+
+            return $attribute;
+        });
+
+        return $success;
+    }
+
+    /**
      * Checks if attribute can be added to collection.
      * Used to check attribute limits without asking the database
      * Returns true if attribute can be added to collection, throws exception otherwise

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -11,6 +11,8 @@ use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
+use Utopia\Database\Validator\Structure;
+use Utopia\Validator\Range;
 
 abstract class Base extends TestCase
 {
@@ -2094,5 +2096,155 @@ abstract class Base extends TestCase
         $database = static::getDatabase();
         $this->expectExceptionMessage('Attribute name already used');
         $database->renameAttribute('colors', 'verbose', 'hex');
+    }
+
+    public function testUpdateAttributeDefault()
+    {
+        $database = static::getDatabase();
+
+        $flowers = $database->createCollection('flowers');
+        $database->createAttribute('flowers', 'name', Database::VAR_STRING, 128, true);
+        $database->createAttribute('flowers', 'inStock', Database::VAR_INTEGER, 0, false);
+
+        $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'name' => 'Violet',
+            'inStock' => 51
+        ]));
+
+        $doc = $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'name' => 'Lily'
+        ]));
+
+        $this->assertNull($doc->getAttribute('inStock'));
+
+        $database->updateAttributeDefault('flowers', 'inStock', 100);
+
+        $doc = $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'name' => 'Iris'
+        ]));
+
+        $this->assertIsNumeric($doc->getAttribute('inStock'));
+        $this->assertEquals(100, $doc->getAttribute('inStock'));
+
+        $database->updateAttributeDefault('flowers', 'inStock', null);
+    }
+
+    /**
+     * @depends testUpdateAttributeDefault
+     */
+    public function testUpdateAttributeRequired() {
+        $database = static::getDatabase();
+
+        $database->updateAttributeRequired('flowers', 'inStock', true);
+
+        $this->expectExceptionMessage('Invalid document structure: Missing required attribute "inStock"');
+    
+        $doc = $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'name' => 'Lily With Missing Stocks'
+        ]));
+    }
+
+    /**
+     * @depends testUpdateAttributeDefault
+     */
+    public function testUpdateAttributeFilter() {
+        $database = static::getDatabase();
+
+        $database->createAttribute('flowers', 'cartModel', Database::VAR_STRING, 2000, false);
+
+        $doc = $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'name' => 'Lily With CartData',
+            'inStock' => 50,
+            'cartModel' => '{"color":"string","size":"number"}'
+        ]));
+
+        $this->assertIsString($doc->getAttribute('cartModel'));
+        $this->assertEquals('{"color":"string","size":"number"}', $doc->getAttribute('cartModel'));
+
+        $database->updateAttributeFilters('flowers', 'cartModel', ['json']);
+
+        $doc = $database->getDocument('flowers', $doc->getId());
+
+        $this->assertIsArray($doc->getAttribute('cartModel'));
+        $this->assertCount(2, $doc->getAttribute('cartModel'));
+        $this->assertEquals('string', $doc->getAttribute('cartModel')['color']);
+        $this->assertEquals('number', $doc->getAttribute('cartModel')['size']);
+    }
+
+    /**
+     * @depends testUpdateAttributeDefault
+     */
+    public function testUpdateAttributeFormat() {
+        $database = static::getDatabase();
+
+        $database->createAttribute('flowers', 'price', Database::VAR_INTEGER, 0, false);
+
+        $doc = $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            '$id' => 'LiliPriced',
+            'name' => 'Lily Priced',
+            'inStock' => 50,
+            'cartModel' => '{}',
+            'price' => 500
+        ]));
+
+        $this->assertIsNumeric($doc->getAttribute('price'));
+        $this->assertEquals(500, $doc->getAttribute('price'));
+
+        Structure::addFormat('priceRange', function($attribute) {
+            $min = $attribute['formatOptions']['min'];
+            $max = $attribute['formatOptions']['max'];
+
+            return new Range($min, $max);
+        }, Database::VAR_INTEGER);
+
+        $database->updateAttributeFormat('flowers', 'price', 'priceRange');
+        $database->updateAttributeFormatOptions('flowers', 'price', ['min' => 1, 'max' => 10000]);
+
+        $this->expectExceptionMessage('Invalid document structure: Attribute "price" has invalid format. Value must be a valid range between 1 and 10,000');
+    
+        $doc = $database->createDocument('flowers', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'name' => 'Lily Overpriced',
+            'inStock' => 50,
+            'cartModel' => '{}',
+            'price' => 15000
+        ]));
+    }
+
+    /**
+     * @depends testUpdateAttributeDefault
+     * @depends testUpdateAttributeFormat
+     */
+    public function testUpdateAttributeStructure() {
+        // TODO: When this becomes relevant, add many more tests (from all types to all types, chaging size up&down, switchign between array/non-array...
+
+        $database = static::getDatabase();
+
+        $doc = $database->getDocument('flowers', 'LiliPriced');
+        $this->assertIsNumeric($doc->getAttribute('price'));
+        $this->assertEquals(500, $doc->getAttribute('price'));
+
+        $database->updateAttribute('flowers', 'price', Database::VAR_STRING, 255, false, false);
+
+        $doc = $database->getDocument('flowers', 'LiliPriced');
+
+        // TODO: Not working. Probably PHP/library stuff. In database, it is VARCHAR; and metadata is string
+        /*
+        $this->assertIsString($doc->getAttribute('price'));
+        $this->assertEquals('500', $doc->getAttribute('price'));
+        */
     }
 }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2239,12 +2239,12 @@ abstract class Base extends TestCase
 
         $database->updateAttribute('flowers', 'price', Database::VAR_STRING, 255, false, false);
 
+        // Delete cache to force read from database with new schema
+        $database->deleteCachedDocument('flowers', 'LiliPriced');
+
         $doc = $database->getDocument('flowers', 'LiliPriced');
 
-        // TODO: Not working. Probably PHP/library stuff. In database, it is VARCHAR; and metadata is string
-        /*
         $this->assertIsString($doc->getAttribute('price'));
         $this->assertEquals('500', $doc->getAttribute('price'));
-        */
     }
 }


### PR DESCRIPTION
New methods (for migration use, as of right now):

- updateAttributeRequired
- updateAttributeFormat
- updateAttributeFormatOptions
- updateAttributeFormatFilters
- updateAttributeDefault
- updateAttribute (to update size&type&signed&array)

The new private method introduced to prevent code duplication:
- updateAttributeMeta

TODO:

- [x] Write tests
- [x] Implement `adapter->updateAttribute`