### PR TITLE
Creating UpdatedAt and CreatedAt attributes for collections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ $dbUser = 'root';
 $dbPass = 'password';
 
 $pdo = new PDO("mysql:host={$dbHost};port={$dbPort};charset=utf8mb4", $dbUser, $dbPass, [
-    PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
     PDO::ATTR_TIMEOUT => 3, // Seconds
     PDO::ATTR_PERSISTENT => true,
     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
     PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_EMULATE_PREPARES => true,
+    PDO::ATTR_STRINGIFY_FETCHES => true,
 ]);
 
 $cache = new Cache(new NoCache()); // or use any cache adapter you wish
 
 $database = new Database(new MariaDB($pdo), $cache);
 $database->setNamespace('mydb');
-
 $database->create(); // Creates a new schema named `mydb`
 ```
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -86,7 +86,7 @@ class MariaDB extends Adapter
 
         $stmt->execute();
 
-        $document = $stmt->fetch(PDO::FETCH_ASSOC);
+        $document = $stmt->fetch();
 
         return (($document[$select] ?? '') === $match);
     }
@@ -171,11 +171,13 @@ class MariaDB extends Adapter
                 ->prepare("CREATE TABLE IF NOT EXISTS `{$database}`.`{$namespace}_{$id}` (
                         `_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
                         `_uid` CHAR(255) NOT NULL,
+                        `_createdAt` int unsigned DEFAULT NULL,
+                        `_updatedAt` int unsigned DEFAULT NULL,
                         " . \implode(' ', $attributes) . "
                         PRIMARY KEY (`_id`),
                         " . \implode(' ', $indexes) . "
                         UNIQUE KEY `_index1` (`_uid`)
-                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
+                    )")
                 ->execute();
 
             $this->getPDO()
@@ -185,9 +187,9 @@ class MariaDB extends Adapter
                         `_permission` VARCHAR(255) NOT NULL,
                         `_document` VARCHAR(255) NOT NULL,
                         PRIMARY KEY (`_id`),
-                        UNIQUE INDEX `_index1` (`_type`,`_document`,`_permission`),
+                        UNIQUE INDEX `_index1` (`_document`,`_type`,`_permission`),
                         INDEX `_index2` (`_permission`)
-                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
+                    )")
                 ->execute();
         } catch (\Exception $th) {
             $this->getPDO()
@@ -416,18 +418,19 @@ class MariaDB extends Adapter
             LIMIT 1;
         ");
 
-        $stmt->bindValue(':_uid', $id, PDO::PARAM_STR);
-
+        $stmt->bindValue(':_uid', $id);
         $stmt->execute();
 
         /** @var array $document */
-        $document = $stmt->fetch(PDO::FETCH_ASSOC);
+        $document = $stmt->fetch();
         if (empty($document)) {
             return new Document([]);
         }
 
         $document['$id'] = $document['_uid'];
-        $document['$internalId'] = (string)$document['_id'];
+        $document['$internalId'] = $document['_id'];
+        $document['$createdAt'] = (int)$document['_createdAt'];
+        $document['$updatedAt'] = (int)$document['_updatedAt'];
         $document['$read'] = json_decode($document['$read'], true) ?? [];
         $document['$write'] = json_decode($document['$write'], true) ?? [];
 
@@ -435,6 +438,8 @@ class MariaDB extends Adapter
         unset($document['_uid']);
         unset($document['_read']);
         unset($document['_write']);
+        unset($document['_createdAt']);
+        unset($document['_updatedAt']);
 
         return new Document($document);
     }
@@ -452,6 +457,8 @@ class MariaDB extends Adapter
     public function createDocument(string $collection, Document $document): Document
     {
         $attributes = $document->getAttributes();
+        $attributes['_createdAt'] = $document->getCreatedAt();
+        $attributes['_updatedAt'] = $document->getUpdateAt();
         $name = $this->filter($collection);
         $columns = '';
 
@@ -540,6 +547,8 @@ class MariaDB extends Adapter
     public function updateDocument(string $collection, Document $document): Document
     {
         $attributes = $document->getAttributes();
+        $attributes['_updatedAt'] = $document->getUpdateAt();
+
         $name = $this->filter($collection);
         $columns = '';
 
@@ -553,7 +562,7 @@ class MariaDB extends Adapter
         ");
         $permissionsStmt->bindValue(':_uid', $document->getId());
         $permissionsStmt->execute();
-        $permissions = $permissionsStmt->fetchAll(PDO::FETCH_ASSOC);
+        $permissions = $permissionsStmt->fetchAll();
 
         $permissions = array_reduce($permissions, function (array $carry, array $item) {
             $carry[$item['_type']][] = $item['_permission'];
@@ -874,7 +883,7 @@ class MariaDB extends Adapter
         $stmt->bindValue(':offset', $offset, PDO::PARAM_INT);
         $stmt->execute();
 
-        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $results = $stmt->fetchAll();
 
         foreach ($results as $key => $value) {
             $results[$key]['$id'] = $value['_uid'];
@@ -956,7 +965,7 @@ class MariaDB extends Adapter
         $stmt->execute();
 
         /** @var array $result */
-        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $result = $stmt->fetch();
 
         return $result['sum'] ?? 0;
     }
@@ -1019,7 +1028,7 @@ class MariaDB extends Adapter
         $stmt->execute();
 
         /** @var array $result */
-        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        $result = $stmt->fetch();
 
         return $result['sum'] ?? 0;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1104,11 +1104,13 @@ class Database
         }
 
         $collection = $this->getCollection($collection);
+        $time = time();
+
         $document
             ->setAttribute('$id', empty($document->getId()) ? $this->getId() : $document->getId())
             ->setAttribute('$collection', $collection->getId())
-            ->setAttribute('$createdAt', time())
-            ->setAttribute('$updatedAt', time())
+            ->setAttribute('$createdAt', $time)
+            ->setAttribute('$updatedAt', $time)
         ;
 
         $document = $this->encode($collection, $document);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -241,7 +241,7 @@ class Database
     /**
      * Create Database
      *
-     * @param string $database
+     * @param string $name
      *
      * @return bool
      */
@@ -1098,10 +1098,12 @@ class Database
         }
 
         $collection = $this->getCollection($collection);
-
         $document
             ->setAttribute('$id', empty($document->getId()) ? $this->getId() : $document->getId())
-            ->setAttribute('$collection', $collection->getId());
+            ->setAttribute('$collection', $collection->getId())
+            ->setAttribute('$createdAt', time())
+            ->setAttribute('$updatedAt', time())
+        ;
 
         $document = $this->encode($collection, $document);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3,6 +3,7 @@
 namespace Utopia\Database;
 
 use Exception;
+use Utopia\Database\Exception\Duplicate;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Structure;
 use Utopia\Database\Exception\Authorization as AuthorizationException;
@@ -323,15 +324,20 @@ class Database
 
     /**
      * Create Collection
-     * 
+     *
      * @param string $id
      * @param Document[] $attributes (optional)
      * @param Document[] $indexes (optional)
-     * 
+     *
      * @return Document
      */
     public function createCollection(string $id, array $attributes = [], array $indexes = []): Document
     {
+        $collection = $this->getCollection($id);
+        if(!$collection->isEmpty() && $id !== self::METADATA){
+            throw new Duplicate('Collection ' . $id . ' Exists!');
+        }
+
         $this->adapter->createCollection($id, $attributes, $indexes);
 
         if ($id === self::METADATA) {
@@ -1135,6 +1141,8 @@ class Database
         if (!$document->getId() || !$id) {
             throw new Exception('Must define $id attribute');
         }
+
+        $document->setAttribute('$updatedAt', time());
 
         $old = $this->getDocument($collection, $id); // TODO make sure user don\'t need read permission for write operations
         $collection = $this->getCollection($collection);

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -90,6 +90,22 @@ class Document extends ArrayObject
     }
 
     /**
+     * @return int
+     */
+    public function getCreatedAt(): int
+    {
+        return $this->getAttribute('$createdAt');
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdateAt(): int
+    {
+        return $this->getAttribute('$updatedAt');
+    }
+
+    /**
      * Get Document Attributes
      * 
      * @return array
@@ -99,7 +115,15 @@ class Document extends ArrayObject
         $attributes = [];
 
         foreach ($this as $attribute => $value) {
-            if(array_key_exists($attribute, ['$id' => true, '$internalId' => true, '$collection' => true, '$read' => true, '$write' => []])) {
+            if(array_key_exists($attribute, [
+                '$id' => true,
+                '$internalId' => true,
+                '$collection' => true,
+                '$read' => true,
+                '$write' => [],
+                '$createdAt' => true,
+                '$updatedAt' => true,
+            ])) {
                 continue;
             }
 

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -72,7 +72,7 @@ class Structure extends Validator
             'type' => Database::VAR_INTEGER,
             'size' => 0,
             'required' => false,
-            'signed' => true,
+            'signed' => false,
             'array' => false,
             'filters' => [],
         ],
@@ -81,7 +81,7 @@ class Structure extends Validator
             'type' => Database::VAR_INTEGER,
             'size' => 0,
             'required' => false,
-            'signed' => true,
+            'signed' => false,
             'array' => false,
             'filters' => [],
         ]

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -67,6 +67,24 @@ class Structure extends Validator
             'array' => true,
             'filters' => [],
         ],
+        [
+            '$id' => '$createdAt',
+            'type' => Database::VAR_INTEGER,
+            'size' => 0,
+            'required' => false,
+            'signed' => true,
+            'array' => false,
+            'filters' => [],
+        ],
+        [
+            '$id' => '$updatedAt',
+            'type' => Database::VAR_INTEGER,
+            'size' => 0,
+            'required' => false,
+            'signed' => true,
+            'array' => false,
+            'filters' => [],
+        ]
     ];
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -55,6 +55,18 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->setDefaultDatabase($this->testDatabase));
     }
 
+    public function testCreatedAtUpdatedAt()
+    {
+        $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('created_at'));
+
+        $document = static::getDatabase()->createDocument('created_at', new Document([
+            '$id' => 'uid123',
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+        ]));
+
+    }
+
     /**
      * @depends testCreateExistsDelete
      */
@@ -62,18 +74,18 @@ abstract class Base extends TestCase
     {
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('actors'));
 
-        $this->assertCount(1, static::getDatabase()->listCollections());
+        $this->assertCount(2, static::getDatabase()->listCollections());
         $this->assertEquals(true, static::getDatabase()->exists($this->testDatabase, 'actors'));
 
         // Collection names should not be unique
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('actors2'));
-        $this->assertCount(2, static::getDatabase()->listCollections());
+        $this->assertCount(3, static::getDatabase()->listCollections());
         $this->assertEquals(true, static::getDatabase()->exists($this->testDatabase, 'actors2'));
         $collection = static::getDatabase()->getCollection('actors2');
         $collection->setAttribute('name', 'actors'); // change name to one that exists
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->updateDocument($collection->getCollection(), $collection->getId(), $collection));
         $this->assertEquals(true, static::getDatabase()->deleteCollection('actors2')); // Delete collection when finished
-        $this->assertCount(1, static::getDatabase()->listCollections());
+        $this->assertCount(2, static::getDatabase()->listCollections());
 
         $this->assertEquals(false, static::getDatabase()->getCollection('actors')->isEmpty());
         $this->assertEquals(true, static::getDatabase()->deleteCollection('actors'));
@@ -2175,10 +2187,6 @@ abstract class Base extends TestCase
 
         $doc = $database->getDocument('flowers', $doc->getId());
 
-        $this->assertIsInt($doc->getCreatedAt());
-        $this->assertIsInt($doc->getUpdateAt());
-        $this->assertGreaterThan(1650000000, $doc->getCreatedAt());
-
         $this->assertIsArray($doc->getAttribute('cartModel'));
         $this->assertCount(2, $doc->getAttribute('cartModel'));
         $this->assertEquals('string', $doc->getAttribute('cartModel')['color']);
@@ -2251,4 +2259,26 @@ abstract class Base extends TestCase
         $this->assertIsString($doc->getAttribute('price'));
         $this->assertEquals('500', $doc->getAttribute('price'));
     }
+
+    /**
+     * @depends testCreatedAtUpdatedAt
+     */
+    public function testCreatedAtUpdatedAtAssert()
+    {
+        $document = static::getDatabase()->getDocument('created_at', 'uid123');
+
+        $this->assertIsInt($document->getCreatedAt());
+        $this->assertIsInt($document->getUpdateAt());
+        $this->assertGreaterThan(1650000000, $document->getCreatedAt());
+        $this->assertGreaterThan(1650000000, $document->getUpdateAt());
+
+        static::getDatabase()->updateDocument('created_at', 'uid123', $document);
+        $document = static::getDatabase()->getDocument('created_at', 'uid123');
+        $this->assertGreaterThan($document->getCreatedAt(), $document->getUpdateAt());
+
+        $this->expectException(DuplicateException::class);
+        static::getDatabase()->createCollection('created_at');
+
+    }
+
 }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2175,6 +2175,10 @@ abstract class Base extends TestCase
 
         $doc = $database->getDocument('flowers', $doc->getId());
 
+        $this->assertIsInt($doc->getCreatedAt());
+        $this->assertIsInt($doc->getUpdateAt());
+        $this->assertGreaterThan(1650000000, $doc->getCreatedAt());
+
         $this->assertIsArray($doc->getAttribute('cartModel'));
         $this->assertCount(2, $doc->getAttribute('cartModel'));
         $this->assertEquals('string', $doc->getAttribute('cartModel')['color']);


### PR DESCRIPTION
- Adding 2 new attributes to all collections _createdAt, _updatedAt.
- Readme.md changes adding default setting ATTR_EMULATE_PREPARES, ATTR_STRINGIFY_FETCHES, which are default .
- Removing MYSQL_ATTR_INIT_COMMAND (charset=utf8mb4) , which is set on new PDO.
- Removing PDO::FETCH_ASSOC on each query , which is set globally on connection.
- On CREATE TABLE remove "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" which are set on default database instance creation.