### PR TITLE
Fix: Required string structure validator

### DIFF
--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -229,7 +229,8 @@ class Structure extends Validator
 
             $keys[$name] = $attribute; // List of allowed attributes to help find unknown ones
 
-            if($required && !isset($structure[$name])) {
+            // Do not use empty() check here. That would be true for 0 which we dont want
+            if($required && (!isset($structure[$name]) || $structure[$name] === '')) {
                 $this->message = 'Missing required attribute "'.$name.'"';
                 return false;
             }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -614,6 +614,53 @@ abstract class Base extends TestCase
         static::getDatabase()->deleteCollection('defaults');
     }
 
+    public function testCreateDocumentRequired()
+    {
+        static::getDatabase()->createCollection('required');
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute('required', 'required', Database::VAR_STRING, 128, true));
+
+        $document = static::getDatabase()->createDocument('required', new Document([
+            '$read' => ['role:all'],
+            '$write' => ['role:all'],
+            'required' => 'Yes!'
+        ]));
+
+        $this->assertNotEmpty(true, $document->getId());
+
+        $this->assertIsString($document->getAttribute('required'));
+        $this->assertEquals('Yes!', $document->getAttribute('required'));
+
+        $errMsg = "";
+        try {
+            $document = static::getDatabase()->createDocument('required', new Document([
+                '$read' => ['role:all'],
+                '$write' => ['role:all'],
+                // 'required' => 'No!'
+            ]));
+        } catch(\Exception $err) {
+            $errMsg = $err->getMessage();
+        }
+
+        $this->assertEquals('Invalid document structure: Missing required attribute "required"', $errMsg);
+
+        $errMsg = "";
+        try {
+            $document = static::getDatabase()->createDocument('required', new Document([
+                '$read' => ['role:all'],
+                '$write' => ['role:all'],
+                'required' => ''
+            ]));
+        } catch(\Exception $err) {
+            $errMsg = $err->getMessage();
+        }
+
+        $this->assertEquals('Invalid document structure: Missing required attribute "required"', $errMsg);
+
+        // cleanup collection
+        static::getDatabase()->deleteCollection('required');
+    }
+
     /**
      * @depends testCreateDocument
      */

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -330,7 +330,7 @@ class StructureTest extends TestCase
             '$collection' => 'posts',
             'title' => 'string',
             'description' => 'Demo description',
-            'rating' => '',
+            'rating' => 'text',
             'price' => 1.99,
             'published' => false,
             'tags' => ['dog', 'cat', 'mouse'],
@@ -417,7 +417,7 @@ class StructureTest extends TestCase
             'title' => 'string',
             'description' => 'Demo description',
             'rating' => 5,
-            'price' => '',
+            'price' => 'text',
             'published' => false,
             'tags' => ['dog', 'cat', 'mouse'],
             'feedback' => 'team@appwrite.io',
@@ -449,7 +449,7 @@ class StructureTest extends TestCase
             'description' => 'Demo description',
             'rating' => 5,
             'price' => 1.99,
-            'published' => '',
+            'published' => 'text',
             'tags' => ['dog', 'cat', 'mouse'],
             'feedback' => 'team@appwrite.io',
         ])));
@@ -473,5 +473,23 @@ class StructureTest extends TestCase
         ])));
         
         $this->assertEquals('Invalid document structure: Attribute "feedback" has invalid format. Value must be a valid email address', $validator->getDescription());
+    }
+
+    public function testRequiredString()
+    {
+        $validator = new Structure(new Document($this->collection));
+
+        $this->assertEquals(false, $validator->isValid(new Document([
+            '$collection' => 'posts',
+            'title' => '',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['dog', 'cat', 'mouse'],
+            'feedback' => 'team_appwrite.io',
+        ])));
+        
+        $this->assertEquals('Invalid document structure: Missing required attribute "title"', $validator->getDescription());
     }
 }


### PR DESCRIPTION
Currently, you can pass an empty string into a string attribute that is required. This is not expected behavior. This PR makes empty sting invalid in the required string attribute.

0 for integer still works, true/false for boolean still works.

- [x] Added new tests