### PR TITLE
Fix avoid duplicate permissions

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -583,14 +583,14 @@ class MariaDB extends Adapter
         /**
          * Get removed Permissions
          */
-        $readRemoved = array_unique(array_diff($permissions['read'], $document->getRead()));
-        $writeRemoved = array_unique(array_diff($permissions['write'], $document->getWrite()));
+        $readRemoved = array_diff($permissions['read'], $document->getRead());
+        $writeRemoved = array_diff($permissions['write'], $document->getWrite());
 
         /**
          * Get added Permissions
          */
-        $readAdded = array_unique(array_diff($document->getRead(), $permissions['read']));
-        $writeAdded = array_unique(array_diff($document->getWrite(), $permissions['write']));
+        $readAdded = array_diff($document->getRead(), $permissions['read']);
+        $writeAdded = array_diff($document->getWrite(), $permissions['write']);
 
         /**
          * Query to remove permissions

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -583,14 +583,14 @@ class MariaDB extends Adapter
         /**
          * Get removed Permissions
          */
-        $readRemoved = array_diff($permissions['read'], $document->getRead());
-        $writeRemoved = array_diff($permissions['write'], $document->getWrite());
+        $readRemoved = array_unique(array_diff($permissions['read'], $document->getRead()));
+        $writeRemoved = array_unique(array_diff($permissions['write'], $document->getWrite()));
 
         /**
          * Get added Permissions
          */
-        $readAdded = array_diff($document->getRead(), $permissions['read']);
-        $writeAdded = array_diff($document->getWrite(), $permissions['write']);
+        $readAdded = array_unique(array_diff($document->getRead(), $permissions['read']));
+        $writeAdded = array_unique(array_diff($document->getWrite(), $permissions['write']));
 
         /**
          * Query to remove permissions

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -78,7 +78,7 @@ class Document extends ArrayObject
      */
     public function getRead(): array
     {
-        return array_unique($this->getAttribute('$read', []));
+        return $this->getAttribute('$read', []);
     }
 
     /**
@@ -86,7 +86,7 @@ class Document extends ArrayObject
      */
     public function getWrite(): array
     {
-        return array_unique($this->getAttribute('$write', []));
+        return $this->getAttribute('$write', []);
     }
 
     /**

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -78,7 +78,7 @@ class Document extends ArrayObject
      */
     public function getRead(): array
     {
-        return $this->getAttribute('$read', []);
+        return array_unique($this->getAttribute('$read', []));
     }
 
     /**
@@ -86,7 +86,7 @@ class Document extends ArrayObject
      */
     public function getWrite(): array
     {
-        return $this->getAttribute('$write', []);
+        return array_unique($this->getAttribute('$write', []));
     }
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -725,6 +725,30 @@ abstract class Base extends TestCase
     }
 
     /**
+     * @depends testGetDocument
+     */
+    public function testUpdateDocumentDuplicatePermissions(Document $document)
+    {
+        $new = $this->getDatabase()->updateDocument($document->getCollection(), $document->getId(), $document);
+
+        $new
+            ->setAttribute('$read', 'role:guest', Document::SET_TYPE_APPEND)
+            ->setAttribute('$read', 'role:guest', Document::SET_TYPE_APPEND)
+            ->setAttribute('$write', 'role:guest', Document::SET_TYPE_APPEND)
+            ->setAttribute('$write', 'role:guest', Document::SET_TYPE_APPEND)
+        ;
+
+        $this->getDatabase()->updateDocument($new->getCollection(), $new->getId(), $new, true);
+
+        $new = $this->getDatabase()->getDocument($new->getCollection(), $new->getId());
+
+        $this->assertContains('role:guest', $new->getRead());
+        $this->assertContains('role:guest', $new->getWrite());
+
+        return $document;
+    }
+
+    /**
      * @depends testUpdateDocument
      */
     public function testDeleteDocument(Document $document)


### PR DESCRIPTION
Currently if you pass duplicate permission to `updateDocument` you will get `Error: Document already exists`

```js
const read = ["user:abc", "user:cde", "user:abc"];
updateDocument("collection","documentId", { key: "value"}, read); // Error: Document already exists
```

This is because [this lines](https://github.com/utopia-php/database/blob/main/src/Database/Adapter/MariaDB.php#L594-L601) doesn't remove the duplicate items:

```js
$readAdded = array_diff($document->getRead(), $permissions['read']);
$writeAdded = array_diff($document->getWrite(), $permissions['write']);
```

I have used `array_unique` in `getRead` and `getWrite` as this way we make sure we always get unique permission when we request permissions