### PR TITLE
Feat: Permissions validator max-length

### DIFF
--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -31,6 +31,18 @@ class Permissions extends Validator
         'member',
     ];
 
+    protected int $length;
+
+    /**
+     * Permissions constructor.
+     *
+     * @param int $length maximum amount of permissions. 0 means unlimited.
+     */
+    public function __construct(int $length = 0)
+    {
+        $this->length = $length;
+    }
+
     /**
      * Get Description.
      *
@@ -56,6 +68,11 @@ class Permissions extends Validator
     {
         if(!is_array($roles)) {
             $this->message = 'Permissions roles must be an array of strings.';
+            return false;
+        }
+
+        if ($this->length && \count($roles) > $this->length) {
+            $this->message = 'You can only provide up to ' . $this->length . ' permissions.';
             return false;
         }
 

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -143,5 +143,17 @@ class PermissionsTest extends TestCase
         $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
         $this->assertEquals($object->isValid(['team:abcd/ef*gh']), false);
         $this->assertEquals($object->getDescription(), '[team:$teamId/$role] $teamID and $role must be valid keys: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char');
+    
+        // Permission-list length must be valid
+        $object = new Permissions(100);
+
+        $permissions = \array_fill(0, 100, "role:all");
+
+        $this->assertEquals($object->isValid($permissions), true);
+
+        $permissions[] = "role:all";
+
+        $this->assertEquals($object->isValid($permissions), false);
+        $this->assertEquals($object->getDescription(), 'You can only provide up to 100 permissions.');
     }
 }


### PR DESCRIPTION
In Appwrite we recently introduced the default maximum length for each array input which is 100 elements. With this change, we add support for this new feature into permissions validator.

- [x] Feature implemented
- [x] Tests implemented