### PR TITLE
Fix: Date ordering with Cursor

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -896,7 +896,14 @@ class MariaDB extends Adapter
 
         if (!empty($cursor) && !empty($orderAttributes) && array_key_exists(0, $orderAttributes)) {
             $attribute = $orderAttributes[0];
-            $attribute = $attribute === '_uid' ? '$id' : $attribute;
+
+            $attribute = match ($attribute) {
+                '_uid' => '$id',
+                '_createdAt' => '$createdAt',
+                '_updatedAt' => '$updatedAt',
+                default => $attribute
+            };
+
             if (is_null($cursor[$attribute] ?? null)) {
                 throw new Exception("Order attribute '{$attribute}' is empty.");
             }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1271,7 +1271,7 @@ abstract class Base extends TestCase
         $this->assertEquals($documentsTest[1]['$id'], $documents[0]['$id']);
 
         /**
-         * ORDER BY DATE + CURSOR
+         * ORDER BY CREATE DATE + CURSOR
          */
         $documentsTest = static::getDatabase()->find('movies', [], 2, 0, ['$createdAt'], [Database::ORDER_DESC]);
         $documents = static::getDatabase()->find('movies', [], 1, 0, ['$createdAt'], [Database::ORDER_DESC], $documentsTest[0], Database::CURSOR_AFTER);
@@ -1279,7 +1279,7 @@ abstract class Base extends TestCase
         $this->assertEquals($documentsTest[1]['$id'], $documents[0]['$id']);
 
         /**
-         * ORDER BY DATE + CURSOR
+         * ORDER BY UPDATE DATE + CURSOR
          */
         $documentsTest = static::getDatabase()->find('movies', [], 2, 0, ['$updatedAt'], [Database::ORDER_DESC]);
         $documents = static::getDatabase()->find('movies', [], 1, 0, ['$updatedAt'], [Database::ORDER_DESC], $documentsTest[0], Database::CURSOR_AFTER);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1263,10 +1263,26 @@ abstract class Base extends TestCase
         $this->assertEquals($documentsTest[1]['$id'], $documents[0]['$id']);
 
         /**
-         * ORDER BY + ID CURSOR
+         * ORDER BY ID + CURSOR
          */
         $documentsTest = static::getDatabase()->find('movies', [], 2, 0, ['$id'], [Database::ORDER_DESC]);
         $documents = static::getDatabase()->find('movies', [], 1, 0, ['$id'], [Database::ORDER_DESC], $documentsTest[0], Database::CURSOR_AFTER);
+        
+        $this->assertEquals($documentsTest[1]['$id'], $documents[0]['$id']);
+
+        /**
+         * ORDER BY DATE + CURSOR
+         */
+        $documentsTest = static::getDatabase()->find('movies', [], 2, 0, ['$createdAt'], [Database::ORDER_DESC]);
+        $documents = static::getDatabase()->find('movies', [], 1, 0, ['$createdAt'], [Database::ORDER_DESC], $documentsTest[0], Database::CURSOR_AFTER);
+        
+        $this->assertEquals($documentsTest[1]['$id'], $documents[0]['$id']);
+
+        /**
+         * ORDER BY DATE + CURSOR
+         */
+        $documentsTest = static::getDatabase()->find('movies', [], 2, 0, ['$updatedAt'], [Database::ORDER_DESC]);
+        $documents = static::getDatabase()->find('movies', [], 1, 0, ['$updatedAt'], [Database::ORDER_DESC], $documentsTest[0], Database::CURSOR_AFTER);
         
         $this->assertEquals($documentsTest[1]['$id'], $documents[0]['$id']);
 


### PR DESCRIPTION
We previously had a PR addressing this for $id: https://github.com/utopia-php/database/pull/140

This PR addresses the same edge case, but for createdAt+updatedAt.

Issue: https://github.com/appwrite/appwrite/issues/3403

- [x] Implemented new tests