### PR TITLE
feat: index validation without order

### DIFF
--- a/src/Database/Validator/Queries.php
+++ b/src/Database/Validator/Queries.php
@@ -173,12 +173,9 @@ class Queries extends Validator
     protected function arrayMatch(array $indexes, array $queries): bool
     {
         // Check the count of indexes first for performance
-        if (count($queries) > count($indexes)) {
+        if (count($queries) !== count($indexes)) {
             return false;
         }
-
-        // Remove unused indices to support covering indexes.
-        $indexes = array_slice($indexes, 0, count($queries));
 
         // Sort them for comparison, the order is not important here anymore.
         sort($indexes, SORT_STRING);

--- a/src/Database/Validator/QueryValidator.php
+++ b/src/Database/Validator/QueryValidator.php
@@ -29,6 +29,7 @@ class QueryValidator extends Validator
         'lesserEqual',
         'greater',
         'greaterEqual',
+        'contains',
         'search',
     ];
 

--- a/src/Database/Validator/QueryValidator.php
+++ b/src/Database/Validator/QueryValidator.php
@@ -29,7 +29,6 @@ class QueryValidator extends Validator
         'lesserEqual',
         'greater',
         'greaterEqual',
-        'contains',
         'search',
     ];
 
@@ -40,6 +39,10 @@ class QueryValidator extends Validator
      */
     public function __construct(array $attributes)
     {
+        foreach ($attributes as $attribute) {
+            $this->schema[] = $attribute->getArrayCopy();
+        }
+
         $this->schema[] = [
             'key' => '$id',
             'array' => false,
@@ -60,10 +63,6 @@ class QueryValidator extends Validator
             'type' => Database::VAR_INTEGER,
             'size' => 0
         ];
-
-        foreach ($attributes as $attribute) {
-            $this->schema[] = $attribute->getArrayCopy();
-        }
     }
 
     /**

--- a/tests/Database/Validator/QueriesTest.php
+++ b/tests/Database/Validator/QueriesTest.php
@@ -254,60 +254,6 @@ class QueriesTest extends TestCase
         ]));
     }
 
-    public function testCoveringIndexQueries()
-    {
-        $validator = new Queries($this->queryValidator, [new Document([
-            '$id' => 'testindex5',
-            'type' => 'key',
-            'attributes' => [
-                'title',
-                'price',
-                'rating'
-            ],
-            'orders' => []
-        ])], true);
-
-        // Test for SUCCESS
-        $this->assertTrue($validator->isValid([
-            Query::parse('title.lesserEqual("string")')
-        ]));
-
-        $this->assertTrue($validator->isValid([
-            Query::parse('title.lesserEqual("string")'),
-            Query::parse('price.lesserEqual(6.50)')
-        ]));
-
-        $this->assertTrue($validator->isValid([
-            Query::parse('price.lesserEqual(6.50)'),
-            Query::parse('title.lesserEqual("string")')
-        ]));
-
-        $this->assertTrue($validator->isValid([
-            Query::parse('title.lesserEqual("string")'),
-            Query::parse('price.lesserEqual(6.50)'),
-            Query::parse('rating.lesserEqual(2002)')
-        ]));
-
-        // Test for Failure
-        $this->assertFalse($validator->isValid([
-            Query::parse('price.lesserEqual(6.50)'),
-        ]));
-
-        $this->assertFalse($validator->isValid([
-            Query::parse('rating.lesserEqual(2002)'),
-        ]));
-
-        $this->assertFalse($validator->isValid([
-            Query::parse('price.lesserEqual(6.50)'),
-            Query::parse('year.lesserEqual(2002)')
-        ]));
-
-        $this->assertFalse($validator->isValid([
-            Query::parse('rating.lesserEqual(2002)'),
-            Query::parse('price.lesserEqual(6.50)')
-        ]));
-    }
-
     public function testIsStrict()
     {
         $validator = new Queries($this->queryValidator, $this->collection['indexes']);

--- a/tests/Database/Validator/QueriesTest.php
+++ b/tests/Database/Validator/QueriesTest.php
@@ -173,6 +173,7 @@ class QueriesTest extends TestCase
         $this->assertTrue($validator->isValid($this->queries));
 
         $this->queries[] = Query::parse('price.lesserEqual(6.50)');
+        $this->queries[] = Query::parse('price.greaterEqual(5.50)');
         $this->assertTrue($validator->isValid($this->queries));
 
         // Test for FAILURE
@@ -210,6 +211,12 @@ class QueriesTest extends TestCase
         ])], true);
 
         // Test for SUCCESS
+        $this->assertTrue($validator->isValid([
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('rating.lesserEqual(2002)')
+        ]));
+
         $this->assertTrue($validator->isValid([
             Query::parse('price.lesserEqual(6.50)'),
             Query::parse('title.lesserEqual("string")'),

--- a/tests/Database/Validator/QueriesTest.php
+++ b/tests/Database/Validator/QueriesTest.php
@@ -96,8 +96,9 @@ class QueriesTest extends TestCase
 
     public function setUp(): void
     {
-        // Query validator expects Document[]
-        $attributes = []; /** @var Document[] $attributes */
+        /** @var Document[] $attributes */
+        $attributes = [];
+
         foreach ($this->collection['attributes'] as $attribute) {
             $attributes[] = new Document($attribute);
         }
@@ -138,6 +139,7 @@ class QueriesTest extends TestCase
                 'DESC'
             ],
         ]);
+
         $index3 = new Document([
             '$id' => 'testindex3',
             'type' => 'fulltext',
@@ -146,6 +148,7 @@ class QueriesTest extends TestCase
             ],
             'orders' => []
         ]);
+
         $index4 = new Document([
             '$id' => 'testindex4',
             'type' => 'key',
@@ -164,23 +167,21 @@ class QueriesTest extends TestCase
 
     public function testQueries()
     {
-        // test for SUCCESS
+        // Test for SUCCESS
         $validator = new Queries($this->queryValidator, $this->collection['indexes']);
 
-        $this->assertEquals(true, $validator->isValid($this->queries));
+        $this->assertTrue($validator->isValid($this->queries));
 
         $this->queries[] = Query::parse('price.lesserEqual(6.50)');
-        $this->assertEquals(true, $validator->isValid($this->queries));
+        $this->assertTrue($validator->isValid($this->queries));
 
-
-        // test for FAILURE
-
+        // Test for FAILURE
         $this->queries[] = Query::parse('rating.greater(4)');
 
-        $this->assertEquals(false, $validator->isValid($this->queries));
+        $this->assertFalse($validator->isValid($this->queries));
         $this->assertEquals("Index not found: title,description,price,rating", $validator->getDescription());
 
-        // test for queued index
+        // Test for queued index
         $query1 = Query::parse('price.lesserEqual(6.50)');
         $query2 = Query::parse('title.notEqual("Iron Man", "Ant Man")');
 
@@ -188,22 +189,124 @@ class QueriesTest extends TestCase
         $this->assertEquals(false, $validator->isValid($this->queries));
         $this->assertEquals("Index not found: price,title", $validator->getDescription());
 
-        // test fulltext
-
+        // Test fulltext
         $query3 = Query::parse('description.search("iron")');
         $this->queries = [$query3];
-        $this->assertEquals(false, $validator->isValid($this->queries));
+        $this->assertFalse($validator->isValid($this->queries));
         $this->assertEquals("Search operator requires fulltext index: description", $validator->getDescription());
+    }
+
+    public function testLooseOrderQueries()
+    {
+        $validator = new Queries($this->queryValidator, [new Document([
+            '$id' => 'testindex5',
+            'type' => 'key',
+            'attributes' => [
+                'title',
+                'price',
+                'rating'
+            ],
+            'orders' => []
+        ])], true);
+
+        // Test for SUCCESS
+        $this->assertTrue($validator->isValid([
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('rating.lesserEqual(2002)')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('rating.lesserEqual(2002)'),
+            Query::parse('title.lesserEqual("string")')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('rating.lesserEqual(2002)')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('rating.lesserEqual(2002)'),
+            Query::parse('price.lesserEqual(6.50)')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('rating.lesserEqual(2002)'),
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('price.lesserEqual(6.50)')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('rating.lesserEqual(2002)'),
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('title.lesserEqual("string")')
+        ]));
+    }
+
+    public function testCoveringIndexQueries()
+    {
+        $validator = new Queries($this->queryValidator, [new Document([
+            '$id' => 'testindex5',
+            'type' => 'key',
+            'attributes' => [
+                'title',
+                'price',
+                'rating'
+            ],
+            'orders' => []
+        ])], true);
+
+        // Test for SUCCESS
+        $this->assertTrue($validator->isValid([
+            Query::parse('title.lesserEqual("string")')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('price.lesserEqual(6.50)')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('title.lesserEqual("string")')
+        ]));
+
+        $this->assertTrue($validator->isValid([
+            Query::parse('title.lesserEqual("string")'),
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('rating.lesserEqual(2002)')
+        ]));
+
+        // Test for Failure
+        $this->assertFalse($validator->isValid([
+            Query::parse('price.lesserEqual(6.50)'),
+        ]));
+
+        $this->assertFalse($validator->isValid([
+            Query::parse('rating.lesserEqual(2002)'),
+        ]));
+
+        $this->assertFalse($validator->isValid([
+            Query::parse('price.lesserEqual(6.50)'),
+            Query::parse('year.lesserEqual(2002)')
+        ]));
+
+        $this->assertFalse($validator->isValid([
+            Query::parse('rating.lesserEqual(2002)'),
+            Query::parse('price.lesserEqual(6.50)')
+        ]));
     }
 
     public function testIsStrict()
     {
         $validator = new Queries($this->queryValidator, $this->collection['indexes']);
-
-        $this->assertEquals(true, $validator->isStrict());
+        $this->assertTrue($validator->isStrict());
 
         $validator = new Queries($this->queryValidator, $this->collection['indexes'], false);
-
-        $this->assertEquals(false, $validator->isStrict());
+        $this->assertFalse($validator->isStrict());
     }
 }


### PR DESCRIPTION
Ignores query order for validation.

These Queries are Allowed:
- A,B,C
- A,C,B
- B,A,C
- B,C,A
- C,A,B
- C,B,A

Previous implementation only allowed following Queries:
- A,B,C

This will make Indexes more accessible 👍🏻 