### PR TITLE
Refactor permissions

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1161,7 +1161,6 @@ class Database
             $document = new Document($cache);
 
             if ($collection->getId() !== self::METADATA
-                && !$validator->isValid($collection->getRead())
                 && !$validator->isValid($document->getRead())) {
                 return new Document();
             }
@@ -1177,7 +1176,6 @@ class Database
         }
 
         if ($collection->getId() !== self::METADATA
-            && !$validator->isValid($collection->getRead())
             && !$validator->isValid($document->getRead())) {
             return new Document();
         }
@@ -1204,16 +1202,9 @@ class Database
      */
     public function createDocument(string $collection, Document $document): Document
     {
-        $validator = new Authorization(self::PERMISSION_CREATE);
-
         $collection = $this->getCollection($collection);
 
         $time = DateTime::now();
-
-        if ($collection->getId() !== self::METADATA
-            && !$validator->isValid($collection->getCreate())) {
-            throw new AuthorizationException($validator->getDescription());
-        }
 
         $document
             ->setAttribute('$id', empty($document->getId()) ? ID::unique() : $document->getId())
@@ -1261,7 +1252,6 @@ class Database
         $validator = new Authorization(self::PERMISSION_UPDATE);
 
         if ($collection->getId() !== self::METADATA
-            && !$validator->isValid($collection->getUpdate())
             && !$validator->isValid($old->getUpdate())) {
             throw new AuthorizationException($validator->getDescription());
         }
@@ -1299,7 +1289,6 @@ class Database
         $collection = $this->getCollection($collection);
 
         if ($collection->getId() !== self::METADATA
-            && !$validator->isValid($collection->getDelete())
             && !$validator->isValid($document->getDelete())) {
             throw new AuthorizationException($validator->getDescription());
         }

--- a/src/Database/Permission.php
+++ b/src/Database/Permission.php
@@ -104,12 +104,15 @@ class Permission
     /**
      * Map aggregate permissions into the set of individual permissions they represent.
      *
-     * @param array $permissions
+     * @param ?array $permissions
      * @param array $allowed
      * @return array
      */
-    public static function aggregate(array $permissions, array $allowed = Database::PERMISSIONS): array
+    public static function aggregate(?array $permissions, array $allowed = Database::PERMISSIONS): ?array
     {
+        if (\is_null($permissions)) {
+            return null;
+        }
         foreach ($permissions as $i => $permission) {
             $permission = Permission::parse($permission);
             foreach (self::$aggregates as $type => $subTypes) {

--- a/src/Database/Permission.php
+++ b/src/Database/Permission.php
@@ -113,27 +113,28 @@ class Permission
         if (\is_null($permissions)) {
             return null;
         }
+        $mutated = [];
         foreach ($permissions as $i => $permission) {
             $permission = Permission::parse($permission);
             foreach (self::$aggregates as $type => $subTypes) {
                 if ($permission->getPermission() != $type) {
+                    $mutated[] = $permission->toString();
                     continue;
                 }
                 foreach ($subTypes as $subType) {
                     if (!\in_array($subType, $allowed)) {
                         continue;
                     }
-                    $permissions[] = (new Permission(
+                    $mutated[] = (new Permission(
                         $subType,
                         $permission->getRole(),
                         $permission->getIdentifier(),
                         $permission->getDimension()
                     ))->toString();
                 }
-                unset($permissions[$i]);
             }
         }
-        return $permissions;
+        return $mutated;
     }
 
     /**

--- a/src/Database/Permission.php
+++ b/src/Database/Permission.php
@@ -108,7 +108,7 @@ class Permission
      * @param array $allowed
      * @return array
      */
-    public static function aggregate(array $permissions, array $allowed): array
+    public static function aggregate(array $permissions, array $allowed = Database::PERMISSIONS): array
     {
         foreach ($permissions as $i => $permission) {
             $permission = Permission::parse($permission);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2111,10 +2111,6 @@ abstract class Base extends TestCase
 
     public function testReadPermissionsFailure()
     {
-        $this->expectException(ExceptionAuthorization::class);
-
-        Authorization::cleanRoles();
-
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$permissions' => [
                 Permission::read(Role::user('1')),
@@ -2129,6 +2125,14 @@ abstract class Base extends TestCase
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
         ]));
+
+        Authorization::cleanRoles();
+
+        $document = static::getDatabase()->getDocument($document->getCollection(), $document->getId());
+
+        $this->assertEquals(true, $document->isEmpty());
+
+        Authorization::setRole('any');
 
         return $document;
     }
@@ -2154,33 +2158,6 @@ abstract class Base extends TestCase
         ]));
 
         $this->assertEquals(false, $document->isEmpty());
-
-        return $document;
-    }
-
-    /**
-     * @depends testCreateDocument
-     */
-    public function testWritePermissionsFailure(Document $document)
-    {
-        $this->expectException(ExceptionAuthorization::class);
-
-        Authorization::cleanRoles();
-
-        $document = static::getDatabase()->createDocument('documents', new Document([
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::create(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'string' => 'text📝',
-            'integer' => 5,
-            'bigint' => 8589934592, // 2^33
-            'float' => 5.55,
-            'boolean' => true,
-            'colors' => ['pink', 'green', 'blue'],
-        ]));
 
         return $document;
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2082,6 +2082,9 @@ abstract class Base extends TestCase
      */
     public function testReadPermissionsSuccess(Document $document)
     {
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$permissions' => [
                 Permission::read(Role::any()),
@@ -2104,13 +2107,16 @@ abstract class Base extends TestCase
         $document = static::getDatabase()->getDocument($document->getCollection(), $document->getId());
         $this->assertEquals(true, $document->isEmpty());
 
-        Authorization::setRole('any');
+        Authorization::setRole(Role::any()->toString());
 
         return $document;
     }
 
     public function testReadPermissionsFailure()
     {
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$permissions' => [
                 Permission::read(Role::user('1')),
@@ -2132,7 +2138,7 @@ abstract class Base extends TestCase
 
         $this->assertEquals(true, $document->isEmpty());
 
-        Authorization::setRole('any');
+        Authorization::setRole(Role::any()->toString());
 
         return $document;
     }
@@ -2142,6 +2148,8 @@ abstract class Base extends TestCase
      */
     public function testWritePermissionsSuccess(Document $document)
     {
+        Authorization::cleanRoles();
+
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$permissions' => [
                 Permission::read(Role::any()),
@@ -2159,6 +2167,8 @@ abstract class Base extends TestCase
 
         $this->assertEquals(false, $document->isEmpty());
 
+        Authorization::setRole(Role::any()->toString());
+
         return $document;
     }
 
@@ -2168,6 +2178,9 @@ abstract class Base extends TestCase
     public function testWritePermissionsUpdateFailure(Document $document)
     {
         $this->expectException(ExceptionAuthorization::class);
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
 
         $document = static::getDatabase()->createDocument('documents', new Document([
             '$permissions' => [

--- a/tests/Database/Validator/AuthorizationTest.php
+++ b/tests/Database/Validator/AuthorizationTest.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Tests\Validator;
 
+use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\ID;
 use Utopia\Database\Permission;
@@ -21,7 +22,7 @@ class AuthorizationTest extends TestCase
 
     public function testValues()
     {
-        Authorization::setRole('role:all');
+        Authorization::setRole(Role::any()->toString());
 
         $document = new Document([
             '$id' => ID::unique(),
@@ -34,20 +35,20 @@ class AuthorizationTest extends TestCase
                 Permission::delete(Role::any()),
             ],
         ]);
-        $object = new Authorization('read');
+        $object = new Authorization(Database::PERMISSION_READ);
 
         $this->assertEquals($object->isValid($document->getRead()), false);
         $this->assertEquals($object->isValid(''), false);
         $this->assertEquals($object->isValid([]), false);
         $this->assertEquals($object->getDescription(), 'No permissions provided for action \'read\'');
         
-        Authorization::setRole('user:456');
-        Authorization::setRole('user:123');
+        Authorization::setRole(Role::user('456')->toString());
+        Authorization::setRole(Role::user('123')->toString());
         
-        $this->assertEquals(Authorization::isRole('user:456'), true);
-        $this->assertEquals(Authorization::isRole('user:457'), false);
+        $this->assertEquals(Authorization::isRole(Role::user('456')->toString()), true);
+        $this->assertEquals(Authorization::isRole(Role::user('457')->toString()), false);
         $this->assertEquals(Authorization::isRole(''), false);
-        $this->assertEquals(Authorization::isRole('role:all'), true);
+        $this->assertEquals(Authorization::isRole(Role::any()->toString()), true);
 
         $this->assertEquals($object->isValid($document->getRead()), true);
         
@@ -55,7 +56,7 @@ class AuthorizationTest extends TestCase
         
         $this->assertEquals($object->isValid($document->getRead()), false);
 
-        Authorization::setRole('team:123');
+        Authorization::setRole(Role::team('123')->toString());
         
         $this->assertEquals($object->isValid($document->getRead()), true);
         


### PR DESCRIPTION
- Revert permissions checks to check document level
- **Remove authorisation check for document create**
- Implement aggregate functionality permission helper

We have verified that the removal of the authorisation check in `createDocument` should not have an impact in Appwrite, as all resource types that are publicly creatable, already have the necessary checks in place to ensure they can not be abused.