### PR TITLE
Refactor permissions valdiators

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -340,16 +340,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.21.0",
+            "version": "0.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/framework.git",
-                "reference": "5aa5431788460a782065e42b0e8a35e7f139af2f"
+                "reference": "c81789b87a917da2daf336738170ebe01f50ea18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/framework/zipball/5aa5431788460a782065e42b0e8a35e7f139af2f",
-                "reference": "5aa5431788460a782065e42b0e8a35e7f139af2f",
+                "url": "https://api.github.com/repos/utopia-php/framework/zipball/c81789b87a917da2daf336738170ebe01f50ea18",
+                "reference": "c81789b87a917da2daf336738170ebe01f50ea18",
                 "shasum": ""
             },
             "require": {
@@ -383,9 +383,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/framework/issues",
-                "source": "https://github.com/utopia-php/framework/tree/0.21.0"
+                "source": "https://github.com/utopia-php/framework/tree/0.21.1"
             },
-            "time": "2022-08-12T11:37:21+00:00"
+            "time": "2022-09-07T09:56:28+00:00"
         }
     ],
     "packages-dev": [
@@ -2841,16 +2841,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb44e1cc6e557418387ad815780360057e40753e"
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb44e1cc6e557418387ad815780360057e40753e",
-                "reference": "fb44e1cc6e557418387ad815780360057e40753e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
                 "shasum": ""
             },
             "require": {
@@ -2862,7 +2862,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2885,7 +2885,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.1.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
             },
             "funding": [
                 {
@@ -2893,7 +2893,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-29T06:55:37+00:00"
+            "time": "2022-09-12T14:47:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4109,5 +4109,5 @@
         "ext-mongodb": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -53,15 +53,19 @@ class Database
         self::PERMISSION_DELETE,
     ];
 
+    // Roles
+    const ROLE_ANY = 'any';
+    const ROLE_GUESTS = 'guests';
+    const ROLE_USERS = 'users';
+    const ROLE_USER = 'user';
+    const ROLE_TEAM = 'team';
+
     const ROLES = [
-        'any',
-        'users',
-        'user',
-        'team',
-        'member',
-        'guests',
-        'status',
-        'role',
+        self::ROLE_ANY,
+        self::ROLE_GUESTS,
+        self::ROLE_USERS,
+        self::ROLE_USER,
+        self::ROLE_TEAM,
     ];
 
     // Collections

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -70,6 +70,15 @@ class Database
         self::ROLE_MEMBER,
     ];
 
+    // Dimensions
+    const DIMENSION_VERIFIED = 'verified';
+    const DIMENSION_UNVERIFIED = 'unverified';
+
+    const USER_DIMENSIONS = [
+        self::DIMENSION_VERIFIED,
+        self::DIMENSION_UNVERIFIED,
+    ];
+
     // Collections
     const METADATA = '_metadata';
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -59,6 +59,7 @@ class Database
     const ROLE_USERS = 'users';
     const ROLE_USER = 'user';
     const ROLE_TEAM = 'team';
+    const ROLE_MEMBER = 'member';
 
     const ROLES = [
         self::ROLE_ANY,
@@ -66,6 +67,7 @@ class Database
         self::ROLE_USERS,
         self::ROLE_USER,
         self::ROLE_TEAM,
+        self::ROLE_MEMBER,
     ];
 
     // Collections

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -70,6 +70,71 @@ class Database
         self::ROLE_MEMBER,
     ];
 
+    const ROLE_CONFIGURATION = [
+        Database::ROLE_ANY => [
+            'identifier' => [
+                'allowed' => false,
+                'required' => false,
+            ],
+            'dimension' =>[
+                'allowed' => false,
+                'required' => false,
+            ],
+        ],
+        Database::ROLE_GUESTS => [
+            'identifier' => [
+                'allowed' => false,
+                'required' => false,
+            ],
+            'dimension' =>[
+                'allowed' => false,
+                'required' => false,
+            ],
+        ],
+        Database::ROLE_USERS => [
+            'identifier' => [
+                'allowed' => false,
+                'required' => false,
+            ],
+            'dimension' =>[
+                'allowed' => true,
+                'required' => false,
+                'options' => Database::USER_DIMENSIONS
+            ],
+        ],
+        Database::ROLE_USER => [
+            'identifier' => [
+                'allowed' => true,
+                'required' => true,
+            ],
+            'dimension' =>[
+                'allowed' => true,
+                'required' => false,
+                'options' => Database::USER_DIMENSIONS
+            ],
+        ],
+        Database::ROLE_TEAM => [
+            'identifier' => [
+                'allowed' => true,
+                'required' => true,
+            ],
+            'dimension' =>[
+                'allowed' => true,
+                'required' => false,
+            ],
+        ],
+        Database::ROLE_MEMBER => [
+            'identifier' => [
+                'allowed' => true,
+                'required' => true,
+            ],
+            'dimension' =>[
+                'allowed' => false,
+                'required' => false,
+            ],
+        ],
+    ];
+
     // Dimensions
     const DIMENSION_VERIFIED = 'verified';
     const DIMENSION_UNVERIFIED = 'unverified';

--- a/src/Database/Permission.php
+++ b/src/Database/Permission.php
@@ -76,18 +76,18 @@ class Permission
      */
     public static function parse(string $permission): Permission
     {
-        $parts = \explode('("', $permission);
+        $permissionParts = \explode('("', $permission);
 
-        if (\count($parts) !== 2) {
+        if (\count($permissionParts) !== 2) {
             throw new \Exception('Invalid permission string format: "' . $permission . '".');
         }
 
-        $permission = $parts[0];
-        $fullRole = \str_replace('")', '', $parts[1]);
-        $parts = \explode(':', $fullRole);
-        $role = $parts[0];
+        $permission = $permissionParts[0];
+        $fullRole = \str_replace('")', '', $permissionParts[1]);
+        $roleParts = \explode(':', $fullRole);
+        $role = $roleParts[0];
 
-        $hasIdentifier = \count($parts) > 1;
+        $hasIdentifier = \count($roleParts) > 1;
         $hasDimension = \str_contains($fullRole, '/');
 
         if (!$hasIdentifier && !$hasDimension) {
@@ -95,29 +95,39 @@ class Permission
         }
 
         if ($hasIdentifier && !$hasDimension) {
-            return new Permission($permission, $role, $parts[1]);
+            $identifier = $roleParts[1];
+            return new Permission($permission, $role, $identifier);
         }
 
         if (!$hasIdentifier && $hasDimension) {
-            $parts = \explode('/', $fullRole);
-            if (\count($parts) !== 2) {
+            $dimensionParts = \explode('/', $fullRole);
+            if (\count($dimensionParts) !== 2) {
                 throw new \Exception('Only one dimension can be provided.');
             }
-            if (empty($parts[1])) {
+
+            $role = $dimensionParts[0];
+            $dimension = $dimensionParts[1];
+
+            if (empty($dimension)) {
                 throw new \Exception('Dimension must not be empty.');
             }
-            return new Permission($permission, $parts[0], '', $parts[1]);
+            return new Permission($permission, $role, '', $dimension);
         }
 
         // Has both identifier and dimension
-        $parts = \explode('/', $parts[1]);
-        if (\count($parts) !== 2) {
+        $dimensionParts = \explode('/', $roleParts[1]);
+        if (\count($dimensionParts) !== 2) {
             throw new \Exception('Only one dimension can be provided.');
         }
-        if (empty($parts[1])) {
+
+        $identifier = $dimensionParts[0];
+        $dimension = $dimensionParts[1];
+
+        if (empty($dimension)) {
             throw new \Exception('Dimension must not be empty.');
         }
-        return new Permission($permission, $role, $parts[0], $parts[1]);
+
+        return new Permission($permission, $role, $identifier, $dimension);
     }
 
     /**

--- a/src/Database/Role.php
+++ b/src/Database/Role.php
@@ -62,39 +62,48 @@ class Role
      */
     public static function parse(string $role): Role
     {
-        $parts = \explode(':', $role);
-        $hasIdentifier = \count($parts) > 1;
+        $roleParts = \explode(':', $role);
+        $hasIdentifier = \count($roleParts) > 1;
         $hasDimension = \str_contains($role, '/');
-        $role = $parts[0];
+        $role = $roleParts[0];
 
         if (!$hasIdentifier && !$hasDimension) {
-            return new  Role($role);
+            return new Role($role);
         }
 
         if ($hasIdentifier && !$hasDimension) {
-            return new Role($role, $parts[1]);
+            $identifier = $roleParts[1];
+            return new Role($role, $identifier);
         }
 
         if (!$hasIdentifier && $hasDimension) {
-            $parts = \explode('/', $role);
-            if (\count($parts) !== 2) {
+            $dimensionParts = \explode('/', $role);
+            if (\count($dimensionParts) !== 2) {
                 throw new \Exception('Only one dimension can be provided.');
             }
-            if (empty($parts[1])) {
+
+            $role = $dimensionParts[0];
+            $dimension = $dimensionParts[1];
+
+            if (empty($dimension)) {
                 throw new \Exception('Dimension must not be empty.');
             }
-            return new Role($parts[0], '', $parts[1]);
+            return new Role($role, '', $dimension);
         }
 
         // Has both identifier and dimension
-        $parts = \explode('/', $parts[1]);
-        if (\count($parts) !== 2) {
+        $dimensionParts = \explode('/', $roleParts[1]);
+        if (\count($dimensionParts) !== 2) {
             throw new \Exception('Only one dimension can be provided.');
         }
-        if (empty($parts[1])) {
+
+        $identifier = $dimensionParts[0];
+        $dimension = $dimensionParts[1];
+
+        if (empty($dimension)) {
             throw new \Exception('Dimension must not be empty.');
         }
-        return new Role($role, $parts[0], $parts[1]);
+        return new Role($role, $identifier, $dimension);
     }
 
     /**

--- a/src/Database/Role.php
+++ b/src/Database/Role.php
@@ -58,50 +58,66 @@ class Role
      *
      * @param string $role
      * @return Role
+     * @throws \Exception
      */
     public static function parse(string $role): Role
     {
         $parts = \explode(':', $role);
-
-        if (\count($parts) === 1) {
-            return new Role($role);
-        }
+        $hasIdentifier = \count($parts) > 1;
+        $hasDimension = \str_contains($role, '/');
         $role = $parts[0];
-        $fullIdentifier = $parts[1];
-        $parts = \explode('/', $fullIdentifier);
 
-        if (\count($parts) === 1) {
-            return new Role($role, $fullIdentifier);
+        if (!$hasIdentifier && !$hasDimension) {
+            return new  Role($role);
         }
-        $identifier = $parts[0];
-        $dimension = $parts[1];
 
-        return new Role(
-            $role,
-            $identifier,
-            $dimension,
-        );
+        if ($hasIdentifier && !$hasDimension) {
+            return new Role($role, $parts[1]);
+        }
+
+        if (!$hasIdentifier && $hasDimension) {
+            $parts = \explode('/', $role);
+            if (\count($parts) !== 2) {
+                throw new \Exception('Only one dimension can be provided.');
+            }
+            if (empty($parts[1])) {
+                throw new \Exception('Dimension must not be empty.');
+            }
+            return new Role($parts[0], '', $parts[1]);
+        }
+
+        // Has both identifier and dimension
+        $parts = \explode('/', $parts[1]);
+        if (\count($parts) !== 2) {
+            throw new \Exception('Only one dimension can be provided.');
+        }
+        if (empty($parts[1])) {
+            throw new \Exception('Dimension must not be empty.');
+        }
+        return new Role($role, $parts[0], $parts[1]);
     }
 
     /**
      * Create a user role from the given ID
      *
      * @param string $identifier
+     * @param string $status
      * @return Role
      */
-    public static function user(string $identifier): Role
+    public static function user(string $identifier, string $status = ''): Role
     {
-        return new Role('user', $identifier);
+        return new Role('user', $identifier, $status);
     }
 
     /**
      * Create a users role
      *
+     * @param string $status
      * @return Role
      */
-    public static function users(): Role
+    public static function users(string $status = ''): Role
     {
-        return new Role('users');
+        return new Role('users', '', $status);
     }
 
     /**
@@ -134,16 +150,5 @@ class Role
     public static function guests(): Role
     {
         return new Role('guests');
-    }
-
-    /**
-     * Create a status role from the given status
-     *
-     * @param string $status
-     * @return Role
-     */
-    public static function status(string $status): Role
-    {
-        return new Role('status', $status);
     }
 }

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -11,8 +11,7 @@ class Authorization extends Validator
      * @var array
      */
     static $roles = [
-        'any' => true,
-        'role:all' => true,
+        'any' => true
     ];
 
     /**

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -6,7 +6,7 @@ use Utopia\Database\Database;
 use Utopia\Database\Permission;
 use Utopia\Validator;
 
-class Permissions extends Validator
+class Permissions extends Roles
 {
     protected string $message = 'Permissions Error';
 
@@ -97,61 +97,9 @@ class Permissions extends Validator
             $role = $permission->getRole();
             $identifier = $permission->getIdentifier();
             $dimension = $permission->getDimension();
-            $key = new Key();
 
-            switch ($role) {
-                case Database::ROLE_USERS:
-                    if (!empty($identifier)) {
-                        $this->message = 'Role "' . $role . '"' . ' can not have an ID value.';
-                        return false;
-                    }
-                    if (!empty($dimension) && !\in_array($dimension, $this->userDimensions)) {
-                        $this->message = 'Users dimension "' . $dimension . '" is not allowed. Must be one of: ' . \implode(', ', $this->userDimensions);
-                        return false;
-                    }
-                    break;
-                case Database::ROLE_GUESTS:
-                case Database::ROLE_ANY:
-                    if (!empty($identifier)) {
-                        $this->message = 'Role "' . $role . '"' . ' can not have an ID value.';
-                        return false;
-                    }
-                    if (!empty($dimension)) {
-                        $this->message = 'Role "' . $role . '"' . ' can not have a dimension value.';
-                        return false;
-                    }
-                    break;
-                case Database::ROLE_USER:
-                    if (empty($identifier)) {
-                        $this->message = 'Role "' . $role . '"' . ' must have an ID value.';
-                        return false;
-                    }
-                    if (!$key->isValid($identifier)) {
-                        $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    if (!empty($dimension) && !\in_array($dimension, $this->userDimensions)) {
-                        $this->message = 'User dimension "' . $dimension . '" is not allowed. Must be one of: ' . \implode(', ', $this->userDimensions);
-                        return false;
-                    }
-                    break;
-                case Database::ROLE_TEAM:
-                    if (empty($identifier)) {
-                        $this->message = 'Role "' . $role . '"' . ' must have an ID value.';
-                        return false;
-                    }
-                    if (!$key->isValid($identifier)) {
-                        $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    if (!empty($dimension) && !$key->isValid($dimension)) {
-                        $this->message = 'Dimension must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    break;
-                default:
-                    $this->message = 'Role "' . $role . '" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.';
-                    return false;
+            if (!$this->isValidRole($role, $identifier, $dimension)) {
+                return false;
             }
         }
         return true;

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -12,11 +12,6 @@ class Permissions extends Validator
 
     protected array $allowed;
 
-    protected array $userDimensions = [
-        'verified',
-        'unverified',
-    ];
-
     protected int $length;
 
     /**

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -3,6 +3,7 @@
 namespace Utopia\Database\Validator;
 
 use Utopia\Database\Database;
+use Utopia\Database\Permission;
 use Utopia\Validator;
 
 class Permissions extends Validator
@@ -15,12 +16,6 @@ class Permissions extends Validator
     ];
 
     protected array $allowed;
-
-    protected array $legacyDimensions = [
-        'all',
-        'member',
-        'guest'
-    ];
 
     protected array $statusDimensions = [
         'verified',
@@ -79,120 +74,79 @@ class Permissions extends Validator
 
         foreach ($permissions as $permission) {
             if (!\is_string($permission)) {
-                $this->message = 'Permission must be of type string.';
+                $this->message = 'Every permission must be of type string.';
                 return false;
             }
+
             if ($permission === '*') {
                 $this->message = 'Wildcard permission "*" has been replaced. Use "any" instead.';
                 return false;
             }
+
             if (\str_contains($permission, 'role:')) {
-                $this->message = 'Permissions using the "role:" prefix have been deprecated. Use "users", "guests", or "any" instead.';
-            }
-
-            // Parse permissions string in two parts:
-            //  1. Match method name against known methods, and capture entire permissions strings.
-            //    - Given ["read(users)", "create(user:123abc)", "delete(team:123abc/edit)"]
-            //      - The "read", "create" and delete partitions will be matched against all of $this->methods.
-            //      - Then "users", "user:123abc", "team:123abc/edit" permission strings will be captured.
-            //      - If any invalid method is found, the entire permission parameter will be considered invalid.
-            //  2. Match permission name against known permissions and capture permission name, id and dimension.
-            //    - Given ["users", "user:123abc", "team:123abc/edit"]
-            //      - For each permission string:
-            //        - The "users", "user" and "team" partitions will be matched against all of $this->permissions.
-            //        - Then first iteration will not match any permission ID or dimension.
-            //          - If the permission ID is found, the entire permission string will be considered invalid.
-            //        - Then the second iteration will match "123abc" as a permission ID, with type "user".
-            //          - If the permission ID is not found, the entire permission parameter will be considered invalid.
-            //          - If the permissions ID is not a valid ID, the entire permission parameter will be considered invalid.
-            //        - Then the third iteration will match "123abc" as a permissions ID and "edit" as a dimension.
-            //          - If the permission ID is not found, the entire permission parameter will be considered invalid.
-            //          - If the permissions ID is not a valid ID, the entire permission parameter will be considered invalid.
-            //          - If the dimension should be from the known set and is not found, the entire permission parameter will be considered invalid.
-            //        - If any invalid permission name is found, the entire permission string will be considered invalid.
-
-            $allowedRoles = \implode('|', Database::ROLES);
-            $allowedPermissions = \implode('|', $this->allowed);
-
-            // Inner permission string matcher (e.g. "user:123abc", "team:123abc/role") where role name is matched against known roles.
-            $roleMatcher = "(\"(?:{$allowedRoles})(?::(?:[a-zA-Z\d]+[a-zA-Z._\-\d]*))?(?:\/(?:[a-zA-Z\d]+[a-zA-Z._\-]*))?\")";
-
-            // Captures the permission type (e.g. "read", "update") and ensures a role is provided.
-            $permissionString = "/^(?:{$allowedPermissions})\({$roleMatcher}\)$/";
-
-            // Inner role string capture. Same as $roleMatcher, but captures the role and optionally the ID and dimension.
-            $roleCapture = "/^\"(?<role>{$allowedRoles})(?::(?<id>[a-zA-Z\d]+[a-zA-Z._\-\d]*))?(?:\/(?<dimension>[a-zA-Z\d]+[a-zA-Z._\-]*))?\"$/";
-
-            $matches = [];
-            if (!\preg_match($permissionString, $permission, $matches)) {
-                $this->message = 'Must be of the form "permission("role:id/dimension")", got "' . $permission . '".';
+                $this->message = 'Permissions using the "role:" prefix have been replaced. Use "users", "guests", or "any" instead.';
                 return false;
             }
 
-            $submatches = [];
-            \array_shift($matches);
-            foreach ($matches as $match) {
-                if (!\preg_match($roleCapture, $match, $submatches)) {
-                    $this->message = 'Must be of the form "role:id/dimension", got "' . $match . '"';
-                    return false;
+            $allowed = false;
+            foreach ($this->allowed as $allowed) {
+                if (\str_starts_with($permission, $allowed)) {
+                    $allowed = true;
+                    break;
                 }
+            }
+            if (!$allowed) {
+                $this->message = 'Permission "' . $permission . '" is not allowed. Must be one of: ' . \implode(', ', $this->allowed) . '.';
+                return false;
+            }
 
-                $role = $submatches['role'];
-                $id = $submatches['id'] ?? '';
-                $dimension = $submatches['dimension'] ?? '';
+            try {
+                $permission = Permission::parse($permission);
+            } catch (\Exception $e) {
+                $this->message = $e->getMessage();
+                return false;
+            }
 
-                switch ($role) {
-                    case 'any':
-                    case 'guests':
-                    case 'users':
-                        if (!empty($id)) {
-                            $this->message = '"' . $role . '"' . ' permission can not have a value.';
-                            return false;
-                        }
-                        if (!empty($dimension) && !\in_array($dimension, $this->statusDimensions)) {
-                            $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
-                            return false;
-                        }
-                        break;
-                    /** @noinspection PhpMissingBreakStatementInspection */
-                    case 'user':
-                        if (!empty($dimension) && !\in_array($dimension, $this->statusDimensions)) {
-                            $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
-                            return false;
-                        }
-                    case 'member':
-                    case 'team':
-                        $key = new Key();
-                        if (empty($id)) {
-                            $this->message = 'Identifier must not be empty.';
-                            return false;
-                        }
-                        if (!$key->isValid($id)) {
-                            $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
-                            return false;
-                        }
-                        break;
-                    case 'status':
-                        // Dimension is in the ID position for status permission e.g. "status:verified"
-                        if (!\in_array($id, $this->statusDimensions)) {
-                            $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
-                            return false;
-                        }
-                        break;
-                    case 'role':
-                        if (empty($id)) {
-                            $this->message = 'Role must not be empty.';
-                            return false;
-                        }
-                        if (!\in_array($id, $this->legacyDimensions)) {
-                            $this->message = 'Role must be one of: ' . \implode(', ', $this->legacyDimensions);
-                            return false;
-                        }
-                        break;
-                    default:
-                        $this->message = 'Permission must begin with one of: ' . \implode(", ", $permissions);
+            $role = $permission->getRole();
+            $identifier = $permission->getIdentifier();
+            $dimension = $permission->getDimension();
+
+            switch ($role) {
+                case 'users':
+                    if (!empty($dimension) && !\in_array($dimension, $this->statusDimensions)) {
+                        $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
                         return false;
-                }
+                    }
+                case 'guests':
+                case 'any':
+                    if (!empty($identifier)) {
+                        $this->message = 'Role "' . $role . '"' . ' can not have an ID value.';
+                        return false;
+                    }
+                    break;
+                case 'user':
+                    if (!empty($dimension) && !\in_array($dimension, $this->statusDimensions)) {
+                        $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
+                        return false;
+                    }
+                case 'team':
+                    $key = new Key();
+                    if (empty($identifier)) {
+                        $this->message = 'Role "' . $role . '"' . ' must have an ID value.';
+                        return false;
+                    }
+                    if (!$key->isValid($identifier)) {
+                        $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
+                        return false;
+                    }
+                    if (!empty($dimension) && !$key->isValid($dimension)) {
+                        $this->message = 'Dimension must be a valid key: ' . $key->getDescription();
+                        return false;
+                    }
+                    break;
+                default:
+                    $this->message = 'Role "' . $role . '" is not allowed.';
+                    return false;
             }
         }
         return true;

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -10,11 +10,6 @@ class Permissions extends Validator
 {
     protected string $message = 'Permissions Error';
 
-    protected static array $defaults = [
-        ...Database::PERMISSIONS,
-        'write',
-    ];
-
     protected array $allowed;
 
     protected array $statusDimensions = [
@@ -30,14 +25,10 @@ class Permissions extends Validator
      * @param int $length maximum amount of permissions. 0 means unlimited.
      * @param array $allowed allowed permissions. Defaults to all available.
      */
-    public function __construct(int $length = 0, array $allowed = [])
+    public function __construct(int $length = 0, array $allowed = [...Database::PERMISSIONS, Database::PERMISSION_WRITE])
     {
         $this->length = $length;
-        if (empty($allowed)) {
-            $this->allowed = self::$defaults;
-        } else {
-            $this->allowed = $allowed;
-        }
+        $this->allowed = $allowed;
     }
 
     /**

--- a/src/Database/Validator/Permissions.php
+++ b/src/Database/Validator/Permissions.php
@@ -75,14 +75,14 @@ class Permissions extends Roles
                 return false;
             }
 
-            $allowed = false;
+            $isAllowed = false;
             foreach ($this->allowed as $allowed) {
                 if (\str_starts_with($permission, $allowed)) {
-                    $allowed = true;
+                    $isAllowed = true;
                     break;
                 }
             }
-            if (!$allowed) {
+            if (!$isAllowed) {
                 $this->message = 'Permission "' . $permission . '" is not allowed. Must be one of: ' . \implode(', ', $this->allowed) . '.';
                 return false;
             }

--- a/src/Database/Validator/Roles.php
+++ b/src/Database/Validator/Roles.php
@@ -11,6 +11,7 @@ class Roles extends Validator
     protected string $message = 'Roles Error';
 
     protected array $statusDimensions = [
+    protected array $allowed;
         'verified',
         'unverified',
     ];
@@ -21,10 +22,12 @@ class Roles extends Validator
      * Roles constructor.
      *
      * @param int $length maximum amount of role. 0 means unlimited.
+     * @param array $allowed allowed roles. Defaults to all available.
      */
-    public function __construct(int $length = 0, array $allowed = null)
+    public function __construct(int $length = 0, array $allowed = Database::ROLES)
     {
         $this->length = $length;
+        $this->allowed = $allowed;
     }
 
     /**

--- a/src/Database/Validator/Roles.php
+++ b/src/Database/Validator/Roles.php
@@ -3,17 +3,12 @@
 namespace Utopia\Database\Validator;
 
 use Utopia\Database\Database;
+use Utopia\Database\Role;
 use Utopia\Validator;
 
 class Roles extends Validator
 {
     protected string $message = 'Roles Error';
-
-    protected array $legacyDimensions = [
-        'all',
-        'member',
-        'guest'
-    ];
 
     protected array $statusDimensions = [
         'verified',
@@ -27,7 +22,7 @@ class Roles extends Validator
      *
      * @param int $length maximum amount of role. 0 means unlimited.
      */
-    public function __construct(int $length = 0,)
+    public function __construct(int $length = 0, array $allowed = null)
     {
         $this->length = $length;
     }
@@ -66,7 +61,7 @@ class Roles extends Validator
 
         foreach ($roles as $role) {
             if (!\is_string($role)) {
-                $this->message = 'Role must be of type string.';
+                $this->message = 'Every role must be of type string.';
                 return false;
             }
             if ($role === '*') {
@@ -74,73 +69,46 @@ class Roles extends Validator
                 return false;
             }
             if (\str_contains($role, 'role:')) {
-                $this->message = 'Roles using the "role:" prefix have been deprecated. Use "users", "guests", or "any" instead.';
-            }
-
-            $allowedRoles = \implode('|', Database::ROLES);
-
-            $roleMatcher = "/^((?<role>{$allowedRoles})(?::(?<id>[a-zA-Z\d]+[a-zA-Z._\-\d]*))?(?:\/(?<dimension>[a-zA-Z\d]+[a-zA-Z._\-]*))?)$/";
-
-            $matches = [];
-            if (!\preg_match($roleMatcher, $role, $matches)) {
-                $this->message = 'Must be of the form "role:id/dimension", got "' . $role . '".';
+                $this->message = 'Roles using the "role:" prefix have been removed. Use "users", "guests", or "any" instead.';
                 return false;
             }
 
-            $type = $matches['role'];
-            $id = $matches['id'] ?? '';
-            $dimension = $matches['dimension'] ?? '';
+            $role = Role::parse($role);
+            $roleName = $role->getRole();
+            $identifier = $role->getIdentifier();
+            $dimension = $role->getDimension();
 
-            switch ($type) {
-                case 'any':
-                case 'guests':
+            switch ($role->getRole()) {
                 case 'users':
-                    if (!empty($id)) {
-                        $this->message = '"' . $type . '"' . ' role can not have a value.';
-                        return false;
-                    }
                     if (!empty($dimension) && !\in_array($dimension, $this->statusDimensions)) {
                         $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
                         return false;
                     }
+                case 'guests':
+                case 'any':
+                    if (!empty($identifier)) {
+                        $this->message = '"' . $roleName . '"' . ' permission can not have an ID value.';
+                        return false;
+                    }
                     break;
-                /** @noinspection PhpMissingBreakStatementInspection */
                 case 'user':
                     if (!empty($dimension) && !\in_array($dimension, $this->statusDimensions)) {
                         $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
                         return false;
                     }
-                case 'member':
                 case 'team':
                     $key = new Key();
-                    if (empty($id)) {
-                        $this->message = 'ID must not be empty.';
+                    if (empty($identifier)) {
+                        $this->message = '"' . $roleName . '"' . ' permission must have an ID value.';
                         return false;
                     }
-                    if (!$key->isValid($id)) {
-                        $this->message = 'ID must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    break;
-                case 'status':
-                    // Dimension is in the ID position for status role e.g. "status:verified"
-                    if (!\in_array($id, $this->statusDimensions)) {
-                        $this->message = 'Status dimension must be one of: ' . \implode(', ', $this->statusDimensions);
-                        return false;
-                    }
-                    break;
-                case 'role':
-                    if (empty($id)) {
-                        $this->message = 'Role must not be empty.';
-                        return false;
-                    }
-                    if (!\in_array($id, $this->legacyDimensions)) {
-                        $this->message = 'Role must be one of: ' . \implode(', ', $this->legacyDimensions);
+                    if (!$key->isValid($identifier)) {
+                        $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
                         return false;
                     }
                     break;
                 default:
-                    $this->message = 'Permission must begin with one of: ' . \implode(", ", $roles);
+                    $this->message = 'Role "' . $roleName . '" is not allowed.';
                     return false;
             }
         }

--- a/src/Database/Validator/Roles.php
+++ b/src/Database/Validator/Roles.php
@@ -12,11 +12,6 @@ class Roles extends Validator
 
     protected array $allowed;
 
-    protected array $userDimensions = [
-        'verified',
-        'unverified',
-    ];
-
     protected int $length;
 
     /**

--- a/src/Database/Validator/Roles.php
+++ b/src/Database/Validator/Roles.php
@@ -73,6 +73,18 @@ class Roles extends Validator
                 return false;
             }
 
+            $isAllowed = false;
+            foreach ($this->allowed as $allowed) {
+                if (\str_starts_with($role, $allowed)) {
+                    $isAllowed = true;
+                    break;
+                }
+            }
+            if (!$isAllowed) {
+                $this->message = 'Role "' . $role . '" is not allowed. Must be one of: ' . \implode(', ', $this->allowed) . '.';
+                return false;
+            }
+
             try {
                 $role = Role::parse($role);
             } catch (\Exception $e) {

--- a/src/Database/Validator/Roles.php
+++ b/src/Database/Validator/Roles.php
@@ -83,61 +83,9 @@ class Roles extends Validator
             $roleName = $role->getRole();
             $identifier = $role->getIdentifier();
             $dimension = $role->getDimension();
-            $key = new Key();
 
-            switch ($role->getRole()) {
-                case Database::ROLE_USERS:
-                    if (!empty($identifier)) {
-                        $this->message = '"' . $roleName . '"' . ' permission can not have an ID value.';
-                        return false;
-                    }
-                    if (!empty($dimension) && !\in_array($dimension, $this->userDimensions)) {
-                        $this->message = 'Users dimension must be one of: ' . \implode(', ', $this->userDimensions);
-                        return false;
-                    }
-                    break;
-                case Database::ROLE_GUESTS:
-                case Database::ROLE_ANY:
-                    if (!empty($identifier)) {
-                        $this->message = '"' . $roleName . '"' . ' permission can not have an ID value.';
-                        return false;
-                    }
-                    if (!empty($dimension)) {
-                        $this->message = 'Role "' . $roleName . '"' . ' can not have a dimension value.';
-                        return false;
-                    }
-                    break;
-                case Database::ROLE_USER:
-                    if (empty($identifier)) {
-                        $this->message = '"' . $roleName . '"' . ' permission must have an ID value.';
-                        return false;
-                    }
-                    if (!$key->isValid($identifier)) {
-                        $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    if (!empty($dimension) && !\in_array($dimension, $this->userDimensions)) {
-                        $this->message = 'User dimension must be one of: ' . \implode(', ', $this->userDimensions);
-                        return false;
-                    }
-                    break;
-                case Database::ROLE_TEAM:
-                    if (empty($identifier)) {
-                        $this->message = '"' . $roleName . '"' . ' permission must have an ID value.';
-                        return false;
-                    }
-                    if (!$key->isValid($identifier)) {
-                        $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    if (!empty($dimension) && !$key->isValid($dimension)) {
-                        $this->message = 'Dimension must be a valid key: ' . $key->getDescription();
-                        return false;
-                    }
-                    break;
-                default:
-                    $this->message = 'Role "' . $roleName . '" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.';
-                    return false;
+            if (!$this->isValidRole($roleName, $identifier, $dimension)) {
+                return false;
             }
         }
         return true;
@@ -165,5 +113,71 @@ class Roles extends Validator
     public function getType(): string
     {
         return self::TYPE_ARRAY;
+    }
+
+    protected function isValidRole(
+        string $role,
+        string $identifier,
+        string $dimension
+    ): bool
+    {
+        $key = new Key();
+
+        switch ($role) {
+            case Database::ROLE_USERS:
+                if (!empty($identifier)) {
+                    $this->message = 'Role "' . $role . '"' . ' can not have an ID value.';
+                    return false;
+                }
+                if (!empty($dimension) && !\in_array($dimension, Database::USER_DIMENSIONS)) {
+                    $this->message = 'Users dimension must be one of: ' . \implode(', ', Database::USER_DIMENSIONS);
+                    return false;
+                }
+                break;
+            case Database::ROLE_GUESTS:
+            case Database::ROLE_ANY:
+                if (!empty($identifier)) {
+                    $this->message = 'Role "' . $role . '"' . ' can not have an ID value.';
+                    return false;
+                }
+                if (!empty($dimension)) {
+                    $this->message = 'Role "' . $role . '"' . ' can not have a dimension value.';
+                    return false;
+                }
+                break;
+            case Database::ROLE_USER:
+                if (empty($identifier)) {
+                    $this->message = 'Role "' . $role . '"' . ' must have an ID value.';
+                    return false;
+                }
+                if (!$key->isValid($identifier)) {
+                    $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
+                    return false;
+                }
+                if (!empty($dimension) && !\in_array($dimension, Database::USER_DIMENSIONS)) {
+                    $this->message = 'User dimension must be one of: ' . \implode(', ', Database::USER_DIMENSIONS);
+                    return false;
+                }
+                break;
+            case Database::ROLE_TEAM:
+                if (empty($identifier)) {
+                    $this->message = 'Role "' . $role . '"' . ' must have an ID value.';
+                    return false;
+                }
+                if (!$key->isValid($identifier)) {
+                    $this->message = 'Identifier must be a valid key: ' . $key->getDescription();
+                    return false;
+                }
+                if (!empty($dimension) && !$key->isValid($dimension)) {
+                    $this->message = 'Dimension must be a valid key: ' . $key->getDescription();
+                    return false;
+                }
+                break;
+            default:
+                $this->message = 'Role "' . $role . '" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.';
+                return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Database/PermissionHelperTest.php
+++ b/tests/Database/PermissionHelperTest.php
@@ -126,6 +126,18 @@ class PermissionHelperTest extends TestCase
         $this->assertEquals('guests', $permission->getRole());
         $this->assertEmpty($permission->getIdentifier());
         $this->assertEmpty($permission->getDimension());
+
+        $permission = Permission::parse('read("users/verified")');
+        $this->assertEquals('read', $permission->getPermission());
+        $this->assertEquals('users', $permission->getRole());
+        $this->assertEmpty($permission->getIdentifier());
+        $this->assertEquals('verified', $permission->getDimension());
+
+        $permission = Permission::parse('read("users/unverified")');
+        $this->assertEquals('read', $permission->getPermission());
+        $this->assertEquals('users', $permission->getRole());
+        $this->assertEmpty($permission->getIdentifier());
+        $this->assertEquals('unverified', $permission->getDimension());
     }
 
     public function testInputFromParameters()

--- a/tests/Database/RoleHelperTest.php
+++ b/tests/Database/RoleHelperTest.php
@@ -41,7 +41,15 @@ class RoleHelperTest extends TestCase
         $this->assertEquals('123', $role->getIdentifier());
         $this->assertEquals('456', $role->getDimension());
 
+        $role = Role::parse('user:123/verified');
+        $this->assertEquals('user', $role->getRole());
+        $this->assertEquals('123', $role->getIdentifier());
+        $this->assertEquals('verified', $role->getDimension());
 
+        $role = Role::parse('users/verified');
+        $this->assertEquals('users', $role->getRole());
+        $this->assertEmpty($role->getIdentifier());
+        $this->assertEquals('verified', $role->getDimension());
     }
 
     public function testInputFromParameters()

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -230,7 +230,7 @@ class PermissionsTest extends TestCase
         // Split role into format {$type}:{$value}
         // Permission must have value
         $this->assertFalse($object->isValid(['read("member:")']));
-        $this->assertEquals('Role "member" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
+        $this->assertEquals('Role "member" must have an ID value.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("user:")']));
         $this->assertEquals('Role "user" must have an ID value.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("team:")']));
@@ -247,24 +247,24 @@ class PermissionsTest extends TestCase
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading special chars
         $this->assertFalse($object->isValid([Permission::read(Role::user('_1234'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
-        $this->assertFalse($object->isValid([Permission::read(Role::user('-1234'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
-        $this->assertFalse($object->isValid([Permission::read(Role::user('.1234'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertEquals('Role "user" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::team('-1234'))]));
+        $this->assertEquals('Role "team" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::member('.1234'))]));
+        $this->assertEquals('Role "member" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // No unsupported special characters
         $this->assertFalse($object->isValid([Permission::read(Role::user('12$4'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertEquals('Role "user" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::user('12&4'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertEquals('Role "user" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::user('ab(124'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertEquals('Role "user" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // Shorter than 36 chars
         $this->assertTrue($object->isValid([Permission::read(Role::user(ID::custom('aaaaaaaabbbbbbbbccccccccddddddddeeee')))]));
         $this->assertFalse($object->isValid([Permission::read(Role::user(ID::custom('aaaaaaaabbbbbbbbccccccccddddddddeeeee')))]));
-        $this->assertEquals("Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char", $object->getDescription());
+        $this->assertEquals('Role "user" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertFalse($object->isValid(['update("memmber:1234")']));
@@ -276,7 +276,7 @@ class PermissionsTest extends TestCase
 
         // Team permission
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('_abcd')))]));
-        $this->assertEquals("Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char", $object->getDescription());
+        $this->assertEquals('Role "team" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd/')))]));
         $this->assertEquals('Dimension must not be empty.', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom(''),'abcd'))]));
@@ -286,9 +286,9 @@ class PermissionsTest extends TestCase
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd'), 'e/fgh'))]));
         $this->assertEquals('Only one dimension can be provided.', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('ab&cd3'), 'efgh'))]));
-        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertEquals('Role "team" identifier value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd'), 'ef*gh'))]));
-        $this->assertEquals('Dimension must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertEquals('Role "team" dimension value is invalid: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // Permission-list length must be valid
         $object = new Permissions(100);

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -42,11 +42,9 @@ class PermissionsTest extends TestCase
         $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::create(Role::team(ID::custom('123abc'), 'edit'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['create("member:123abc")'];
-        $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::create(Role::guests())];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['create("status:verified")'];
+        $document['$permissions'] = [Permission::create(Role::users('verified'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
 
         $document['$permissions'] = [Permission::read(Role::any())];
@@ -59,11 +57,9 @@ class PermissionsTest extends TestCase
         $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::read(Role::team(ID::custom('123abc'), 'viewer'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['read("member:123abc")'];
-        $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::read(Role::guests())];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['read("status:verified")'];
+        $document['$permissions'] = [Permission::read(Role::users('verified'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
 
         $document['$permissions'] = [Permission::update(Role::any())];
@@ -76,11 +72,9 @@ class PermissionsTest extends TestCase
         $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::update(Role::team(ID::custom('123abc'), 'edit'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['update("member:123abc")'];
-        $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::update(Role::guests())];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['update("status:verified")'];
+        $document['$permissions'] = [Permission::update(Role::users('verified'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
 
         $document['$permissions'] = [Permission::delete(Role::any())];
@@ -93,11 +87,9 @@ class PermissionsTest extends TestCase
         $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::delete(Role::team(ID::custom('123abc'), 'edit'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['delete("member:123abc")'];
-        $this->assertTrue($object->isValid($document->getPermissions()));
         $document['$permissions'] = [Permission::delete(Role::guests())];
         $this->assertTrue($object->isValid($document->getPermissions()));
-        $document['$permissions'] = ['delete("status:verified")'];
+        $document['$permissions'] = [Permission::delete(Role::users('verified'))];
         $this->assertTrue($object->isValid($document->getPermissions()));
     }
 
@@ -152,9 +144,9 @@ class PermissionsTest extends TestCase
         $this->assertTrue($object->isValid($document->getPermissions()));
 
         $document['$permissions'] = [
-            Permission::read(Role::status('verified')),
-            Permission::create(Role::status('verified')),
-            Permission::update(Role::status('verified')),
+            Permission::read(Role::users('verified')),
+            Permission::create(Role::users('verified')),
+            Permission::update(Role::users('verified')),
         ];
         $this->assertTrue($object->isValid($document->getPermissions()));
     }
@@ -208,74 +200,65 @@ class PermissionsTest extends TestCase
 
         // Permissions must be of type string
         $this->assertFalse($object->isValid([0, 1.5]));
-        $this->assertEquals('Permission must be of type string.', $object->getDescription());
+        $this->assertEquals('Every permission must be of type string.', $object->getDescription());
         $this->assertFalse($object->isValid([false, []]));
-        $this->assertEquals('Permission must be of type string.', $object->getDescription());
+        $this->assertEquals('Every permission must be of type string.', $object->getDescription());
         $this->assertFalse($object->isValid([['a']]));
-        $this->assertEquals('Permission must be of type string.', $object->getDescription());
+        $this->assertEquals('Every permission must be of type string.', $object->getDescription());
 
         // Wildcard character unsupported
         $this->assertFalse($object->isValid(['*']));
         $this->assertEquals('Wildcard permission "*" has been replaced. Use "any" instead.', $object->getDescription());
 
-        // Role prefix values unsupported without method
-        $this->assertFalse($object->isValid(['role:all']));
-
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "role:all".', $object->getDescription());
-        $this->assertFalse($object->isValid(['role:guest']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "role:guest".', $object->getDescription());
-        $this->assertFalse($object->isValid(['role:member']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "role:member".', $object->getDescription());
-
         // Role prefix values deprecated
-        $this->assertTrue($object->isValid(['read("role:all")']));
-        $this->assertEquals('Permissions using the "role:" prefix have been deprecated. Use "users", "guests", or "any" instead.', $object->getDescription());
-        $this->assertTrue($object->isValid(['create("role:guest")']));
-        $this->assertEquals('Permissions using the "role:" prefix have been deprecated. Use "users", "guests", or "any" instead.', $object->getDescription());
-        $this->assertTrue($object->isValid(['update("role:member")']));
-        $this->assertEquals('Permissions using the "role:" prefix have been deprecated. Use "users", "guests", or "any" instead.', $object->getDescription());
+        $this->assertFalse($object->isValid(['read("role:all")']));
+        $this->assertEquals('Permissions using the "role:" prefix have been replaced. Use "users", "guests", or "any" instead.', $object->getDescription());
+        $this->assertFalse($object->isValid(['create("role:guest")']));
+        $this->assertEquals('Permissions using the "role:" prefix have been replaced. Use "users", "guests", or "any" instead.', $object->getDescription());
+        $this->assertFalse($object->isValid(['update("role:member")']));
+        $this->assertEquals('Permissions using the "role:" prefix have been replaced. Use "users", "guests", or "any" instead.', $object->getDescription());
 
         // Only contains a single ':'
         $this->assertFalse($object->isValid(['user1234']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "user1234".', $object->getDescription());
+        $this->assertEquals('Invalid permission string format: "user1234".', $object->getDescription());
         $this->assertFalse($object->isValid(['user::1234']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "user::1234".', $object->getDescription());
+        $this->assertEquals('Invalid permission string format: "user::1234".', $object->getDescription());
         $this->assertFalse($object->isValid(['user:123:4']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "user:123:4".', $object->getDescription());
+        $this->assertEquals('Invalid permission string format: "user:123:4".', $object->getDescription());
 
         // Split role into format {$type}:{$value}
         // Permission must have value
         $this->assertFalse($object->isValid(['read("member:")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("member:")".', $object->getDescription());
+        $this->assertEquals('Role "member" is not allowed.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("user:")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("user:")".', $object->getDescription());
+        $this->assertEquals('Role "user" must have an ID value.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("team:")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:")".', $object->getDescription());
+        $this->assertEquals('Role "team" must have an ID value.', $object->getDescription());
 
         // Permission role:$value must be one of: all, guest, member
         $this->assertFalse($object->isValid(['read("anyy")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("anyy")".', $object->getDescription());
+        $this->assertEquals('Role "anyy" is not allowed.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("gguest")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("gguest")".', $object->getDescription());
+        $this->assertEquals('Role "gguest" is not allowed.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("memer:123abc")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("memer:123abc")".', $object->getDescription());
+        $this->assertEquals('Role "memer" is not allowed.', $object->getDescription());
 
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading special chars
-        $this->assertFalse($object->isValid(['read("member:_1234")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("member:_1234")".', $object->getDescription());
-        $this->assertFalse($object->isValid(['read("member:-1234")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("member:-1234")".', $object->getDescription());
-        $this->assertFalse($object->isValid(['read("member:.1234")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("member:.1234")".', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::user('_1234'))]));
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::user('-1234'))]));
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::user('.1234'))]));
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // No unsupported special characters
-        $this->assertFalse($object->isValid(['create("member:12$4")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "create("member:12$4")".', $object->getDescription());
-        $this->assertFalse($object->isValid([Permission::create(Role::user(ID::custom('12&4')))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "create("user:12&4")".', $object->getDescription());
-        $this->assertFalse($object->isValid(['create("member:ab(124")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "create("member:ab(124")".', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::user('12$4'))]));
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::user('12&4'))]));
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
+        $this->assertFalse($object->isValid([Permission::read(Role::user('ab(124'))]));
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // Shorter than 36 chars
         $this->assertTrue($object->isValid([Permission::read(Role::user(ID::custom('aaaaaaaabbbbbbbbccccccccddddddddeeee')))]));
@@ -284,27 +267,27 @@ class PermissionsTest extends TestCase
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertFalse($object->isValid(['update("memmber:1234")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "update("memmber:1234")".', $object->getDescription());
+        $this->assertEquals('Role "memmber" is not allowed.', $object->getDescription());
         $this->assertFalse($object->isValid(['update("tteam:1234")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "update("tteam:1234")".', $object->getDescription());
+        $this->assertEquals('Role "tteam" is not allowed.', $object->getDescription());
         $this->assertFalse($object->isValid(['update("userr:1234")']));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "update("userr:1234")".', $object->getDescription());
+        $this->assertEquals('Role "userr" is not allowed.', $object->getDescription());
 
         // Team permission
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('_abcd')))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:_abcd")".', $object->getDescription());
+        $this->assertEquals("Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char", $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd/')))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:abcd/")".', $object->getDescription());
+        $this->assertEquals('Dimension must not be empty.', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom(''),'abcd'))]));
-        $this->assertEquals('Identifier must not be empty.', $object->getDescription());
+        $this->assertEquals('Role "team" must have an ID value.', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd'), '/efgh'))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:abcd//efgh")".', $object->getDescription());
+        $this->assertEquals('Only one dimension can be provided.', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd'), 'e/fgh'))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:abcd/e/fgh")".', $object->getDescription());
+        $this->assertEquals('Only one dimension can be provided.', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('ab&cd3'), 'efgh'))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:ab&cd3/efgh")".', $object->getDescription());
+        $this->assertEquals('Identifier must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('abcd'), 'ef*gh'))]));
-        $this->assertEquals('Must be of the form "permission("role:id/dimension")", got "read("team:abcd/ef*gh")".', $object->getDescription());
+        $this->assertEquals('Dimension must be a valid key: Parameter must contain at most 36 chars. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can\'t start with a special char', $object->getDescription());
 
         // Permission-list length must be valid
         $object = new Permissions(100);

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -221,11 +221,11 @@ class PermissionsTest extends TestCase
 
         // Only contains a single ':'
         $this->assertFalse($object->isValid(['user1234']));
-        $this->assertEquals('Invalid permission string format: "user1234".', $object->getDescription());
+        $this->assertEquals('Permission "user1234" is not allowed. Must be one of: create, read, update, delete, write.', $object->getDescription());
         $this->assertFalse($object->isValid(['user::1234']));
-        $this->assertEquals('Invalid permission string format: "user::1234".', $object->getDescription());
+        $this->assertEquals('Permission "user::1234" is not allowed. Must be one of: create, read, update, delete, write.', $object->getDescription());
         $this->assertFalse($object->isValid(['user:123:4']));
-        $this->assertEquals('Invalid permission string format: "user:123:4".', $object->getDescription());
+        $this->assertEquals('Permission "user:123:4" is not allowed. Must be one of: create, read, update, delete, write.', $object->getDescription());
 
         // Split role into format {$type}:{$value}
         // Permission must have value

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Tests\Validator;
 
+use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\ID;
 use Utopia\Database\Permission;
@@ -229,7 +230,7 @@ class PermissionsTest extends TestCase
         // Split role into format {$type}:{$value}
         // Permission must have value
         $this->assertFalse($object->isValid(['read("member:")']));
-        $this->assertEquals('Role "member" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "member" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("user:")']));
         $this->assertEquals('Role "user" must have an ID value.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("team:")']));
@@ -237,11 +238,11 @@ class PermissionsTest extends TestCase
 
         // Permission role:$value must be one of: all, guest, member
         $this->assertFalse($object->isValid(['read("anyy")']));
-        $this->assertEquals('Role "anyy" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "anyy" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("gguest")']));
-        $this->assertEquals('Role "gguest" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "gguest" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
         $this->assertFalse($object->isValid(['read("memer:123abc")']));
-        $this->assertEquals('Role "memer" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "memer" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
 
         // team:$value, member:$value and user:$value must have valid Key for $value
         // No leading special chars
@@ -267,11 +268,11 @@ class PermissionsTest extends TestCase
 
         // Permission role must begin with one of: member, role, team, user
         $this->assertFalse($object->isValid(['update("memmber:1234")']));
-        $this->assertEquals('Role "memmber" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "memmber" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
         $this->assertFalse($object->isValid(['update("tteam:1234")']));
-        $this->assertEquals('Role "tteam" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "tteam" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
         $this->assertFalse($object->isValid(['update("userr:1234")']));
-        $this->assertEquals('Role "userr" is not allowed.', $object->getDescription());
+        $this->assertEquals('Role "userr" is not allowed. Must be one of: ' . \implode(', ', Database::ROLES) . '.', $object->getDescription());
 
         // Team permission
         $this->assertFalse($object->isValid([Permission::read(Role::team(ID::custom('_abcd')))]));


### PR DESCRIPTION
- Remove regex matching permissions/roles
- Return specific error messages for invalid permissions/roles
- Improve permissions/roles string parsing
- Make status a dimension instead of role for consistency
  - `status:verified`-> `users/verified` 
- Add optional status param to `user` and `users` role helpers
- Remove all legacy roles to avoid future migrations