### PR TITLE
tests: add integrity check for permissions column

### DIFF
--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -775,7 +775,6 @@ abstract class Base extends TestCase
 
         $a->setAttribute('$permissions', Permission::read(Role::user('a')), Document::SET_TYPE_APPEND);
         $b->setAttribute('$permissions', Permission::read(Role::user('b')), Document::SET_TYPE_APPEND);
-        $c->setAttribute('$permissions', Permission::read(Role::user('c')), Document::SET_TYPE_APPEND);
 
         Coroutine\run(function() use ($a, $b, $c) {
             Coroutine::join([
@@ -788,7 +787,6 @@ abstract class Base extends TestCase
 
         $this->assertContains('user:a', $new->getRead());
         $this->assertContains('user:b', $new->getRead());
-        $this->assertContains('user:c', $new->getRead());
 
         /**
          * Reset permissions for dependent tests.

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -774,7 +774,12 @@ abstract class Base extends TestCase
         $c = new Document($new->getArrayCopy());
 
         $a->setAttribute('$permissions', Permission::read(Role::user('a')), Document::SET_TYPE_APPEND);
+        $b->setAttribute('$permissions', Permission::read(Role::user('a')), Document::SET_TYPE_APPEND);
         $b->setAttribute('$permissions', Permission::read(Role::user('b')), Document::SET_TYPE_APPEND);
+
+        $this->assertContains('user:a', $a->getRead());
+        $this->assertContains('user:a', $b->getRead());
+        $this->assertContains('user:b', $b->getRead());
 
         Coroutine\run(function() use ($a, $b, $c) {
             Coroutine::join([


### PR DESCRIPTION
- adds test to check for integrity on the `_permissions` column for race conditions