### PR TITLE
tests: metadata integrity

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false">
+    stopOnFailure="true">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/tests/Database/Adapter/MariaDBTest.php
+++ b/tests/Database/Adapter/MariaDBTest.php
@@ -16,6 +16,7 @@ class MariaDBTest extends Base
      * @var Database
      */
     static $database = null;
+    static $id = null;
 
     // TODO@kodumbeats hacky way to identify adapters for tests
     // Remove once all methods are implemented
@@ -42,10 +43,14 @@ class MariaDBTest extends Base
     /**
      * @return Database
      */
-    static function getDatabase(): Database
+    static function getDatabase(bool $fresh = false): Database
     {
-        if(!is_null(self::$database)) {
+        if(!$fresh && !is_null(self::$database)) {
             return self::$database;
+        }
+
+        if(is_null(self::$id)) {
+            self::$id = uniqid();
         }
 
         $dbHost = 'mariadb';
@@ -61,7 +66,11 @@ class MariaDBTest extends Base
 
         $database = new Database(new MariaDB($pdo), $cache);
         $database->setDefaultDatabase('utopiaTests');
-        $database->setNamespace('myapp_'.uniqid());
+        $database->setNamespace('myapp_'.self::$id);
+
+        if ($fresh) {
+            return $database;
+        }
 
         return self::$database = $database;
     }

--- a/tests/Database/Adapter/MongoDBTest.php
+++ b/tests/Database/Adapter/MongoDBTest.php
@@ -22,13 +22,11 @@ use Utopia\Tests\Base;
 
 class MongoDBTest extends Base
 {
-    static $pool = null;
-
     /**
      * @var Database
      */
     static $database = null;
-
+    static $id = null;
 
     // TODO@kodumbeats hacky way to identify adapters for tests
     // Remove once all methods are implemented
@@ -55,10 +53,14 @@ class MongoDBTest extends Base
     /**
      * @return Database
      */
-    static function getDatabase(): Database
+    static function getDatabase(bool $fresh = false): Database
     {
-        if (!is_null(self::$database)) {
+        if (!$fresh && !is_null(self::$database)) {
             return self::$database;
+        }
+
+        if(is_null(self::$id)) {
+            self::$id = uniqid();
         }
 
         $redis = new Redis();
@@ -78,8 +80,11 @@ class MongoDBTest extends Base
 
         $database = new Database(new MongoDBAdapter($client), $cache);
         $database->setDefaultDatabase('utopiaTests');
-        $database->setNamespace('myapp_' . uniqid());
+        $database->setNamespace('myapp_' . self::$id);
 
+        if ($fresh) {
+            return $database;
+        }
 
         return self::$database = $database;
     }

--- a/tests/Database/Adapter/MySQLTest.php
+++ b/tests/Database/Adapter/MySQLTest.php
@@ -17,6 +17,7 @@ class MySQLTest extends Base
      * @var Database
      */
     static $database = null;
+    static $id = null;
 
     // TODO@kodumbeats hacky way to identify adapters for tests
     // Remove once all methods are implemented
@@ -52,10 +53,14 @@ class MySQLTest extends Base
     /**
      * @return Database
      */
-    static function getDatabase(): Database
+    static function getDatabase(bool $fresh = false): Database
     {
-        if(!is_null(self::$database)) {
+        if(!$fresh && !is_null(self::$database)) {
             return self::$database;
+        }
+
+        if(is_null(self::$id)) {
+            self::$id = uniqid();
         }
 
         $dbHost = 'mysql';
@@ -73,7 +78,11 @@ class MySQLTest extends Base
 
         $database = new Database(new MySQL($pdo), $cache);
         $database->setDefaultDatabase('utopiaTests');
-        $database->setNamespace('myapp_'.uniqid());
+        $database->setNamespace('myapp_'.self::$id);
+
+        if ($fresh) {
+            return $database;
+        }
 
         return self::$database = $database;
     }


### PR DESCRIPTION
This PR adds a test to simulate a known race condition for our metadata.

![Bildschirmfoto 2022-09-05 um 22 09 36](https://user-images.githubusercontent.com/1759475/188508503-90d73fc3-62e3-4574-b514-04abc88c285c.png)
![Bildschirmfoto 2022-09-05 um 22 09 51](https://user-images.githubusercontent.com/1759475/188508499-1d683863-9d30-4c18-80dd-561314c28568.png)

Content of `__metadata.attributes`:

```json
[
   {
      "$id":"e",
      "key":"e",
      "type":"string",
      "size":128,
      "required":true,
      "default":null,
      "signed":true,
      "array":false,
      "format":null,
      "formatOptions":[],
      "filters":[]
   }
]
```


