### PR TITLE
Fix: Improve count

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1520,6 +1520,7 @@ class Database
             throw new Exception("Collection not found");
         }
 
+        $queries = Query::groupByType($queries)['filters'];
         $queries = self::convertQueries($collection, $queries);
 
         return $this->adapter->count($collection->getId(), $queries, $max);


### PR DESCRIPTION
Currently we do this filtering of queries in before running count() method in Appwrite. Problem is, we have a lot of duplicate code because of that. Also there is no reason why you would need non-filter (order, for example) queries when counting.

Addresses: https://github.com/appwrite/appwrite/pull/3702#discussion_r958287285

- [x] Existing tests must pass