### PR TITLE
Deprecate metadata method

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -336,20 +336,7 @@ class Database
     {
         $this->adapter->create($name);
         $this->setDefaultDatabase($name);
-        $this->createMetadata();
-
-        return true;
-    }
-
-    /**
-     * Create Metadata collection.
-     * @return bool
-     * @throws LimitException
-     * @throws AuthorizationException
-     * @throws StructureException
-     */
-    public function createMetadata(): bool
-    {
+        
         /**
          * Create array of attribute documents
          * @var Document[] $attributes


### PR DESCRIPTION
This method is called from inside `create()` and is no longer needed as a standalone method.