### PR TITLE
add event, triggers and listeners support

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -83,6 +83,8 @@ class Database
     const EVENT_DOCUMENT_READ = 'document_read';
     const EVENT_DOCUMENT_UPDATE = 'document_update';
     const EVENT_DOCUMENT_DELETE = 'document_delete';
+    const EVENT_DOCUMENT_COUNT = 'document_count';
+    const EVENT_DOCUMENT_SUM = 'document_sum';
 
     const EVENT_ATTRIBUTE_CREATE = 'attribute_create';
     const EVENT_ATTRIBUTE_UPDATE = 'attribute_update';
@@ -1527,7 +1529,9 @@ class Database
         $queries = Query::groupByType($queries)['filters'];
         $queries = self::convertQueries($collection, $queries);
 
-        return $this->adapter->count($collection->getId(), $queries, $max);
+        $count = $this->adapter->count($collection->getId(), $queries, $max);
+        $this->trigger(self::EVENT_DOCUMENT_COUNT, $count);
+        return $count;
     }
 
     /**
@@ -1552,7 +1556,9 @@ class Database
         }
 
         $queries = self::convertQueries($collection, $queries);
-        return $this->adapter->sum($collection->getId(), $attribute, $queries, $max);
+        $sum = $this->adapter->sum($collection->getId(), $attribute, $queries, $max);
+        $this->trigger(self::EVENT_DOCUMENT_SUM, $sum);
+        return $sum;
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -322,7 +322,13 @@ class Database
         return $this;
     }
 
-    public function silent(callable $callback) {
+    /**
+     * Silent event generation for all the calls inside the callback
+     *
+     * @param callable $callback
+     * @return mixed
+     */
+    public function silent(callable $callback): mixed {
         $previous = $this->silentEvents;
         $this->silentEvents = true;
         $result = $callback();

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -495,7 +495,7 @@ class Database
      */
     public function createCollection(string $id, array $attributes = [], array $indexes = []): Document 
     {
-        $collection = $this->silent(fn () => $this->getCollection($id));
+        $collection = $this->silent(fn() => $this->getCollection($id));
         if (!$collection->isEmpty() && $id !== self::METADATA){
             throw new Duplicate('Collection ' . $id . ' Exists!');
         }
@@ -556,7 +556,7 @@ class Database
      */
     public function getCollection(string $id): Document
     {
-        $collection = $this->silent(fn () => $this->getDocument(self::METADATA, $id));
+        $collection = $this->silent(fn() => $this->getDocument(self::METADATA, $id));
         $this->trigger(self::EVENT_COLLECTION_READ, $collection);
         return $collection;
     }
@@ -574,7 +574,7 @@ class Database
     {
         Authorization::disable();
 
-        $result = $this->silent(fn() =>$this->find(self::METADATA, [
+        $result = $this->silent(fn() => $this->find(self::METADATA, [
             Query::limit($limit),
             Query::offset($offset)
         ]));
@@ -597,7 +597,7 @@ class Database
         $this->adapter->deleteCollection($id);
         
         $collection = $this->silent(fn() => $this->getDocument(self::METADATA, $id));
-        $deleted = $this->silent(fn()=>$this->deleteDocument(self::METADATA, $id));
+        $deleted = $this->silent(fn() => $this->deleteDocument(self::METADATA, $id));
         $this->trigger(self::EVENT_COLLECTION_DELETE, $collection);
         return $deleted;
     }
@@ -706,7 +706,7 @@ class Database
         $attribute = $this->adapter->createAttribute($collection->getId(), $id, $type, $size, $signed, $array);
 
         if ($collection->getId() !== self::METADATA) {
-            $this->silent(fn()=>$this->updateDocument(self::METADATA, $collection->getId(), $collection));
+            $this->silent(fn() => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
         }
 
         $this->trigger(self::EVENT_ATTRIBUTE_CREATE, $attribute);
@@ -793,7 +793,7 @@ class Database
     private function updateAttributeMeta(string $collection, string $id, callable $updateCallback): void
     {
         // Load
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         $attributes = $collection->getAttribute('attributes', []);
 
@@ -810,7 +810,7 @@ class Database
         $collection->setAttribute('attributes', $attributes, Document::SET_TYPE_ASSIGN);
 
         if ($collection->getId() !== self::METADATA) {
-            $this->silent(fn()=>$this->updateDocument(self::METADATA, $collection->getId(), $collection));
+            $this->silent(fn() => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
         }
 
         $this->trigger(self::EVENT_ATTRIBUTE_UPDATE, $attributes[$attributeIndex]);
@@ -1037,7 +1037,7 @@ class Database
         $collection->setAttribute('attributes', $attributes);
 
         if ($collection->getId() !== self::METADATA) {
-            $this->silent(fn()=>$this->updateDocument(self::METADATA, $collection->getId(), $collection));
+            $this->silent(fn() => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
         }
 
         $deleted = $this->adapter->deleteAttribute($collection->getId(), $id);
@@ -1056,7 +1056,7 @@ class Database
      */
     public function renameAttribute(string $collection, string $old, string $new): bool
     {
-        $collection = $this->silent(fn() =>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
         $attributes = $collection->getAttribute('attributes', []);
         $indexes = $collection->getAttribute('indexes', []);
 
@@ -1093,7 +1093,7 @@ class Database
         $collection->setAttribute('indexes', $indexes);
 
         if ($collection->getId() !== self::METADATA) {
-            $this->silent(fn()=>$this->updateDocument(self::METADATA, $collection->getId(), $collection));
+            $this->silent(fn() => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
         }
 
         $renamed = $this->adapter->renameAttribute($collection->getId(), $old, $new);
@@ -1167,7 +1167,7 @@ class Database
             throw new Exception('Missing attributes');
         }
 
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         // index IDs are case insensitive
         $indexes = $collection->getAttribute('indexes', []);
@@ -1218,7 +1218,7 @@ class Database
         ]), Document::SET_TYPE_APPEND);
 
         if ($collection->getId() !== self::METADATA) {
-            $this->silent(fn()=>$this->updateDocument(self::METADATA, $collection->getId(), $collection));
+            $this->silent(fn() => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
         }
 
         $this->trigger(self::EVENT_INDEX_CREATE, $index);
@@ -1235,7 +1235,7 @@ class Database
      */
     public function deleteIndex(string $collection, string $id): bool
     {
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         $indexes = $collection->getAttribute('indexes', []);
 
@@ -1250,7 +1250,7 @@ class Database
         $collection->setAttribute('indexes', $indexes);
 
         if ($collection->getId() !== self::METADATA) {
-            $this->silent(fn()=>$this->updateDocument(self::METADATA, $collection->getId(), $collection));
+            $this->silent(fn() => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
         }
 
         $deleted = $this->adapter->deleteIndex($collection->getId(), $id);
@@ -1276,7 +1276,7 @@ class Database
             throw new Exception('test exception: ' . $collection . ':' . $id);
         }
 
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
         $document = null;
         $cache = null;
 
@@ -1330,7 +1330,7 @@ class Database
      */
     public function createDocument(string $collection, Document $document): Document
     {
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         $time = DateTime::now();
 
@@ -1375,8 +1375,8 @@ class Database
         $time = DateTime::now();
         $document->setAttribute('$updatedAt', $time);
 
-        $old = Authorization::skip(fn() => $this->silent(fn()=>$this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $old = Authorization::skip(fn() => $this->silent(fn() => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
 
@@ -1416,8 +1416,8 @@ class Database
     {
         $validator = new Authorization(self::PERMISSION_DELETE);
 
-        $document = Authorization::skip(fn() => $this->silent(fn()=>$this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $document = Authorization::skip(fn() => $this->silent(fn() => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         if ($collection->getId() !== self::METADATA
             && !$validator->isValid($document->getDelete())) {
@@ -1467,7 +1467,7 @@ class Database
      */
     public function find(string $collection, array $queries = []): array
     {
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         $grouped = Query::groupByType($queries);
         /** @var Query[] */ $filters = $grouped['filters'];
@@ -1535,7 +1535,7 @@ class Database
      */
     public function count(string $collection, array $queries = [], int $max = 0): int
     {
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         if ($collection->isEmpty()) {
             throw new Exception("Collection not found");
@@ -1564,7 +1564,7 @@ class Database
      */
     public function sum(string $collection, string $attribute, array $queries = [], int $max = 0)
     {
-        $collection = $this->silent(fn()=>$this->getCollection($collection));
+        $collection = $this->silent(fn() => $this->getCollection($collection));
 
         if ($collection->isEmpty()) {
             throw new Exception("Collection not found");

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -66,7 +66,7 @@ class Database
     const TTL = 60 * 60 * 24; // 24 hours
 
     // Events
-    const EVENT_CREATE_DATABASE = 'create_database';
+    const EVENT_DATABASE_CREATE = 'database_create';
     const EVENT_DELETE_DATABASE = 'delete_database';
     const EVENT_CREATE_COLLECTION = 'create_collection';
     const EVENT_DELETE_COLLECTION = 'delete_collection';

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -66,13 +66,14 @@ class Database
     const TTL = 60 * 60 * 24; // 24 hours
 
     // Events
+    const EVENT_ALL = '*';
     const EVENT_DATABASE_CREATE = 'database_create';
-    const EVENT_DELETE_DATABASE = 'delete_database';
-    const EVENT_CREATE_COLLECTION = 'create_collection';
-    const EVENT_DELETE_COLLECTION = 'delete_collection';
-    const EVENT_CREATE_DOCUMENT = 'create_document';
-    const EVENT_UPDATE_DOCUMENT = 'update_document';
-    const EVENT_DELETE_DOCUMENT = 'delete_document';
+    const EVENT_DATABASE_DELETE = 'database_delete';
+    const EVENT_COLLECTION_CREATE = 'collection_delete';
+    const EVENT_COLLECTION_DELETE = 'collection_delete';
+    const EVENT_DOCUMENT_CREATE = 'document_create';
+    const EVENT_DOCUMENT_UPDATE = 'document_update';
+    const EVENT_DOCUMENT_DELETE = 'document_delete';
 
     /**
      * @var Adapter
@@ -306,7 +307,7 @@ class Database
      */
     protected function trigger(string $event, mixed $args = null): void
     {
-        foreach ($this->listeners['*'] as $callback) {
+        foreach ($this->listeners[self::EVENT_ALL] as $callback) {
             call_user_func($event, $args);
         }
 
@@ -406,7 +407,7 @@ class Database
 
         $this->createCollection(self::METADATA, $attributes);
 
-        $this->trigger(self::EVENT_CREATE_DATABASE, $name);
+        $this->trigger(self::EVENT_DATABASE_CREATE, $name);
         return true;
     }
 
@@ -444,7 +445,7 @@ class Database
     public function delete(string $name): bool
     {
         $deleted = $this->adapter->delete($name);
-        $this->trigger(self::EVENT_DELETE_DATABASE, ['name' => $name, 'deleted' => $deleted]);
+        $this->trigger(self::EVENT_DATABASE_DELETE, ['name' => $name, 'deleted' => $deleted]);
         return $deleted;
     }
 
@@ -506,7 +507,7 @@ class Database
         }
 
         $createdCollection = $this->createDocument(self::METADATA, $collection);
-        $this->trigger(self::EVENT_CREATE_COLLECTION, $createdCollection);
+        $this->trigger(self::EVENT_COLLECTION_CREATE, $createdCollection);
         return $createdCollection;
     }
 
@@ -558,7 +559,7 @@ class Database
         $this->adapter->deleteCollection($id);
 
         $deleted = $this->deleteDocument(self::METADATA, $id);
-        $this->trigger(self::EVENT_DELETE_COLLECTION, ['id' => $id, 'deleted' => $deleted]);
+        $this->trigger(self::EVENT_COLLECTION_DELETE, ['id' => $id, 'deleted' => $deleted]);
         return $deleted;
     }
 
@@ -1292,7 +1293,7 @@ class Database
 
         $document = $this->decode($collection, $document);
         
-        $this->trigger(self::EVENT_CREATE_DOCUMENT, $document);
+        $this->trigger(self::EVENT_DOCUMENT_CREATE, $document);
         return $document;
     }
 
@@ -1338,7 +1339,7 @@ class Database
 
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id);
 
-        $this->trigger(self::EVENT_UPDATE_DOCUMENT, $document);
+        $this->trigger(self::EVENT_DOCUMENT_UPDATE, $document);
         return $document;
     }
 
@@ -1367,7 +1368,7 @@ class Database
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id);
 
         $deleted = $this->adapter->deleteDocument($collection->getId(), $id);
-        $this->trigger(self::EVENT_DELETE_DOCUMENT, ['id' => $id, 'collection' => $collection, 'deleted' => $deleted]);
+        $this->trigger(self::EVENT_DOCUMENT_DELETE, ['id' => $id, 'collection' => $collection, 'deleted' => $deleted]);
         return $deleted;
     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -70,7 +70,6 @@ class Database
     
     const EVENT_DATABASE_LIST = 'database_list';
     const EVENT_DATABASE_CREATE = 'database_create';
-    const EVENT_DATABASE_READ = 'database_read';
     const EVENT_DATABASE_DELETE = 'database_delete';
     
     const EVENT_COLLECTION_LIST = 'collection_list';
@@ -328,11 +327,11 @@ class Database
     protected function trigger(string $event, mixed $args = null): void
     {
         foreach ($this->listeners[self::EVENT_ALL] as $callback) {
-            call_user_func($event, $args);
+            call_user_func($callback, $event, $args);
         }
 
         foreach(($this->listeners[$event] ?? []) as $callback) {
-            call_user_func($event, $args);
+            call_user_func($callback, $event, $args);
         }
     }
 
@@ -799,6 +798,7 @@ class Database
         if ($collection->getId() !== self::METADATA) {
             $this->updateDocument(self::METADATA, $collection->getId(), $collection);
         }
+
         $this->trigger(self::EVENT_ATTRIBUTE_UPDATE, $attributes[$attributeIndex]);
     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -53,7 +53,7 @@ class Database
     ];
 
     // Collections
-    const METADATA = 'metadata';
+    const METADATA = '_metadata';
 
     // Cursor
     const CURSOR_BEFORE = 'before';

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1515,7 +1515,7 @@ class Database
      */
     public function findOne(string $collection, array $queries = []): bool|Document
     {
-        $results = $this->find($collection, \array_merge([Query::limit(1)], $queries));
+        $results = $this->silent(fn() => $this->find($collection, \array_merge([Query::limit(1)], $queries)));
         $found = \reset($results);
         $this->trigger(self::EVENT_DOCUMENT_FIND, $found);
         return $found;

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3225,8 +3225,11 @@ abstract class Base extends TestCase
             $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
             $database->updateAttributeRequired($collectionId, 'attr1', true);
             $database->renameAttribute($collectionId, 'attr1', 'attr2');
-            $database->createIndex($collectionId, 'index1', Database::INDEX_KEY, ['attr2']);
-            $database->renameIndex($collectionId, 'index1', 'index2');
+            
+            $indexId1 = 'index1_' . uniqid();
+            $indexId2 = 'index2_' . uniqid();
+            $database->createIndex($collectionId, $indexId1, Database::INDEX_KEY, ['attr2']);
+            $database->renameIndex($collectionId, $indexId1, $indexId2);
             $document = $database->createDocument($collectionId, new Document([
                 '$id' => 'doc1',
                 'attr2' => 10,
@@ -3243,7 +3246,7 @@ abstract class Base extends TestCase
             $database->count($collectionId);
             $database->sum($collectionId, 'attr2');
             
-            $database->deleteIndex($collectionId, 'index2');
+            $database->deleteIndex($collectionId, $indexId2);
             $database->deleteDocument($collectionId, 'doc1');
             $database->deleteAttribute($collectionId, 'attr2');
             $database->deleteCollection($collectionId);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3223,7 +3223,7 @@ abstract class Base extends TestCase
             $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
             $database->updateAttributeRequired($collectionId, 'attr1', true);
             $indexId1 = 'index10_' . uniqid();
-            $database->createIndex($collectionId, $indexId1, Database::INDEX_KEY, ['attr2']);
+            $database->createIndex($collectionId, $indexId1, Database::INDEX_KEY, ['attr1']);
             $document = $database->createDocument($collectionId, new Document([
                 '$id' => 'doc1',
                 'attr1' => 10,
@@ -3233,16 +3233,16 @@ abstract class Base extends TestCase
                     Permission::read(Role::any()),
                 ],
             ]));
-            $database->updateDocument($collectionId, 'doc1', $document->setAttribute('attr2', 15));
+            $database->updateDocument($collectionId, 'doc1', $document->setAttribute('attr1', 15));
             $database->getDocument($collectionId, 'doc1');
             $database->find($collectionId);
             $database->findOne($collectionId);
             $database->count($collectionId);
-            $database->sum($collectionId, 'attr2');
+            $database->sum($collectionId, 'attr1');
             
             $database->deleteIndex($collectionId, $indexId1);
             $database->deleteDocument($collectionId, 'doc1');
-            $database->deleteAttribute($collectionId, 'attr2');
+            $database->deleteAttribute($collectionId, 'attr1');
             $database->deleteCollection($collectionId);
             $database->delete('hellodb');
         });

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3192,9 +3192,7 @@ abstract class Base extends TestCase
                 Database::EVENT_COLLECTION_READ,
                 Database::EVENT_ATTRIBUTE_CREATE,
                 Database::EVENT_ATTRIBUTE_UPDATE,
-                Database::EVENT_ATTRIBUTE_UPDATE,
                 Database::EVENT_INDEX_CREATE,
-                Database::EVENT_INDEX_RENAME,
                 Database::EVENT_DOCUMENT_CREATE,
                 Database::EVENT_DOCUMENT_UPDATE,
                 Database::EVENT_DOCUMENT_READ,
@@ -3224,15 +3222,11 @@ abstract class Base extends TestCase
             $database->getCollection($collectionId);
             $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
             $database->updateAttributeRequired($collectionId, 'attr1', true);
-            $database->renameAttribute($collectionId, 'attr1', 'attr2');
-            
-            $indexId1 = 'index1_' . uniqid();
-            $indexId2 = 'index2_' . uniqid();
+            $indexId1 = 'index10_' . uniqid();
             $database->createIndex($collectionId, $indexId1, Database::INDEX_KEY, ['attr2']);
-            $database->renameIndex($collectionId, $indexId1, $indexId2);
             $document = $database->createDocument($collectionId, new Document([
                 '$id' => 'doc1',
-                'attr2' => 10,
+                'attr1' => 10,
                 '$permissions' => [
                     Permission::delete(Role::any()),
                     Permission::update(Role::any()),
@@ -3246,7 +3240,7 @@ abstract class Base extends TestCase
             $database->count($collectionId);
             $database->sum($collectionId, 'attr2');
             
-            $database->deleteIndex($collectionId, $indexId2);
+            $database->deleteIndex($collectionId, $indexId1);
             $database->deleteDocument($collectionId, 'doc1');
             $database->deleteAttribute($collectionId, 'attr2');
             $database->deleteCollection($collectionId);

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3184,6 +3184,8 @@ abstract class Base extends TestCase
     public function testEvents()
     {
         Authorization::skip(function() {
+            $database = static::getDatabase();
+
             $events = [
                 Database::EVENT_DATABASE_CREATE,
                 Database::EVENT_DATABASE_LIST,
@@ -3206,12 +3208,15 @@ abstract class Base extends TestCase
                 Database::EVENT_COLLECTION_DELETE,
                 Database::EVENT_DATABASE_DELETE,
             ];
-            $database = static::getDatabase();
             $database->on(Database::EVENT_ALL, function($event, $data) use (&$events) {
                 $this->assertEquals(array_shift($events), $event);
             });
     
-            $database->create('hellodb');
+            if($this->getDatabase()->getAdapter()->getSupportForSchemas()) {
+                $database->create('hellodb');
+            } else {
+                array_shift($events);
+            }
             $database->list();
     
             $database->setDefaultDatabase($this->testDatabase);
@@ -3222,7 +3227,7 @@ abstract class Base extends TestCase
             $database->getCollection($collectionId);
             $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
             $database->updateAttributeRequired($collectionId, 'attr1', true);
-            $indexId1 = 'index10_' . uniqid();
+            $indexId1 = 'index2_' . uniqid();
             $database->createIndex($collectionId, $indexId1, Database::INDEX_KEY, ['attr1']);
             $document = $database->createDocument($collectionId, new Document([
                 '$id' => 'doc1',

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3183,68 +3183,67 @@ abstract class Base extends TestCase
 
     public function testEvents()
     {
-        Authorization::disable();
-        Authorization::setDefaultStatus(false);
-        $events = [
-            Database::EVENT_DATABASE_CREATE,
-            Database::EVENT_DATABASE_LIST,
-            Database::EVENT_COLLECTION_CREATE,
-            Database::EVENT_COLLECTION_LIST,
-            Database::EVENT_COLLECTION_READ,
-            Database::EVENT_ATTRIBUTE_CREATE,
-            Database::EVENT_ATTRIBUTE_UPDATE,
-            Database::EVENT_ATTRIBUTE_UPDATE,
-            Database::EVENT_INDEX_CREATE,
-            Database::EVENT_INDEX_RENAME,
-            Database::EVENT_DOCUMENT_CREATE,
-            Database::EVENT_DOCUMENT_UPDATE,
-            Database::EVENT_DOCUMENT_READ,
-            Database::EVENT_DOCUMENT_FIND,
-            Database::EVENT_DOCUMENT_FIND,
-            Database::EVENT_DOCUMENT_COUNT,
-            Database::EVENT_DOCUMENT_SUM,
-            Database::EVENT_INDEX_DELETE,
-            Database::EVENT_DOCUMENT_DELETE,
-            Database::EVENT_ATTRIBUTE_DELETE,
-            Database::EVENT_COLLECTION_DELETE,
-            Database::EVENT_DATABASE_DELETE,
-        ];
-
-        $database = static::getDatabase();
-        $database->on(Database::EVENT_ALL, function($event, $data) use (&$events) {
-            $this->assertEquals(array_shift($events), $event);
+        Authorization::skip(function() {
+            $events = [
+                Database::EVENT_DATABASE_CREATE,
+                Database::EVENT_DATABASE_LIST,
+                Database::EVENT_COLLECTION_CREATE,
+                Database::EVENT_COLLECTION_LIST,
+                Database::EVENT_COLLECTION_READ,
+                Database::EVENT_ATTRIBUTE_CREATE,
+                Database::EVENT_ATTRIBUTE_UPDATE,
+                Database::EVENT_ATTRIBUTE_UPDATE,
+                Database::EVENT_INDEX_CREATE,
+                Database::EVENT_INDEX_RENAME,
+                Database::EVENT_DOCUMENT_CREATE,
+                Database::EVENT_DOCUMENT_UPDATE,
+                Database::EVENT_DOCUMENT_READ,
+                Database::EVENT_DOCUMENT_FIND,
+                Database::EVENT_DOCUMENT_FIND,
+                Database::EVENT_DOCUMENT_COUNT,
+                Database::EVENT_DOCUMENT_SUM,
+                Database::EVENT_INDEX_DELETE,
+                Database::EVENT_DOCUMENT_DELETE,
+                Database::EVENT_ATTRIBUTE_DELETE,
+                Database::EVENT_COLLECTION_DELETE,
+                Database::EVENT_DATABASE_DELETE,
+            ];
+            $database = static::getDatabase();
+            $database->on(Database::EVENT_ALL, function($event, $data) use (&$events) {
+                $this->assertEquals(array_shift($events), $event);
+            });
+    
+            $database->create('hellodb');
+            $database->list();
+    
+            $database->setDefaultDatabase($this->testDatabase);
+    
+            $collectionId = ID::unique();
+            $database->createCollection($collectionId);
+            $database->listCollections();
+            $database->getCollection($collectionId);
+            $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
+            $database->updateAttributeRequired($collectionId, 'attr1', true);
+            $database->renameAttribute($collectionId, 'attr1', 'attr2');
+            $database->createIndex($collectionId, 'index1', Database::INDEX_KEY, ['attr2']);
+            $database->renameIndex($collectionId, 'index1', 'index2');
+            $document = $database->createDocument($collectionId, new Document([
+                '$id' => 'doc1',
+                'attr2' => 10
+            ]));
+            $database->updateDocument($collectionId, 'doc1', $document->setAttribute('attr2', 15));
+            $database->getDocument($collectionId, 'doc1');
+            $database->find($collectionId);
+            $database->findOne($collectionId);
+            $database->count($collectionId);
+            $database->sum($collectionId, 'attr2');
+            
+            $database->deleteIndex($collectionId, 'index2');
+            $database->deleteDocument($collectionId, 'doc1');
+            $database->deleteAttribute($collectionId, 'attr2');
+            $database->deleteCollection($collectionId);
+            $database->delete('hellodb');
         });
-
-        $database->create('hellodb');
-        $database->list();
-
-        $database->setDefaultDatabase($this->testDatabase);
-
-        $collectionId = ID::unique();
-        $database->createCollection($collectionId);
-        $database->listCollections();
-        $database->getCollection($collectionId);
-        $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
-        $database->updateAttributeRequired($collectionId, 'attr1', true);
-        $database->renameAttribute($collectionId, 'attr1', 'attr2');
-        $database->createIndex($collectionId, 'index1', Database::INDEX_KEY, ['attr2']);
-        $database->renameIndex($collectionId, 'index1', 'index2');
-        $document = $database->createDocument($collectionId, new Document([
-            '$id' => 'doc1',
-            'attr2' => 10
-        ]));
-        $database->updateDocument($collectionId, 'doc1', $document->setAttribute('attr2', 15));
-        $database->getDocument($collectionId, 'doc1');
-        $database->find($collectionId);
-        $database->findOne($collectionId);
-        $database->count($collectionId);
-        $database->sum($collectionId, 'attr2');
-        
-        $database->deleteIndex($collectionId, 'index2');
-        $database->deleteDocument($collectionId, 'doc1');
-        $database->deleteAttribute($collectionId, 'attr2');
-        $database->deleteCollection($collectionId);
-        $database->delete('hellodb');
 
     }
 }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3229,7 +3229,12 @@ abstract class Base extends TestCase
             $database->renameIndex($collectionId, 'index1', 'index2');
             $document = $database->createDocument($collectionId, new Document([
                 '$id' => 'doc1',
-                'attr2' => 10
+                'attr2' => 10,
+                '$permissions' => [
+                    Permission::delete(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::read(Role::any()),
+                ],
             ]));
             $database->updateDocument($collectionId, 'doc1', $document->setAttribute('attr2', 15));
             $database->getDocument($collectionId, 'doc1');


### PR DESCRIPTION
- Introduces events and listeners on the database functions
- Each function will generate relevant events
- All event constants are added in the Database class
- Relevant tests added in the base test
- Revert `metadata` back to `_metadata`