### PR TITLE
Replaced group by with distinct

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -894,10 +894,9 @@ class MariaDB extends Adapter
         $sqlWhere = !empty($where) ? 'where ' . implode(' AND ', $where) : '';
 
         $sql = "
-            SELECT table_main.*
+            SELECT DISTINCT _uid, table_main.*
             FROM {$this->getSQLTable($name)} as table_main
             " . $sqlWhere . "
-            GROUP BY _uid
             {$order}
             LIMIT :offset, :limit;
         ";


### PR DESCRIPTION
After the permission-related changes in the database, the join queries in Appwrite and Utopia have been replaced with subqueries, thus eliminating the need for GROUP BY.