### PR TITLE
Allow querying float attribute with integer values

### DIFF
--- a/src/Database/Validator/Query.php
+++ b/src/Database/Validator/Query.php
@@ -124,10 +124,17 @@ class Query extends Validator
         $attributeType = $attributeSchema['type'];
 
         foreach ($values as $value) {
-            $condition = match ($attributeType) {
-                Database::VAR_DATETIME => gettype($value) === Database::VAR_STRING,
-                default => gettype($value) === $attributeType
-            };
+            switch ($attributeType) {
+                case Database::VAR_DATETIME:
+                    $condition = gettype($value) === Database::VAR_STRING;
+                    break;
+                case Database::VAR_FLOAT:
+                    $condition = (gettype($value) === Database::VAR_FLOAT || gettype($value) === Database::VAR_INTEGER);
+                    break;
+                default:
+                    $condition = gettype($value) === $attributeType;
+                    break;
+            }
 
             if (!$condition) {
                 $this->message = 'Query type does not match expected: ' . $attributeType;

--- a/tests/Database/Validator/QueryTest.php
+++ b/tests/Database/Validator/QueryTest.php
@@ -110,8 +110,9 @@ class QueryTest extends TestCase
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('equal("$id", ["Iron Man", "Ant Man"])')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('notEqual("title", ["Iron Man", "Ant Man"])')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('equal("description", "Best movie ever")')));
-        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('greaterThan("rating", 4)')), $validator->getDescription());
+        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('greaterThan("rating", 4)')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('lessThan("price", 6.50)')));
+        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('lessThanEqual("price", 6)')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('contains("tags", "action")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('cursorAfter("docId")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('cursorBefore("docId")')));


### PR DESCRIPTION
Currently you can not query a float attribute with an integer value, but you can set one. This PR allows you to pass an integer or float value in a query

Fixes https://github.com/appwrite/appwrite/issues/4340