### PR TITLE
Fixed No Error when Creating a Document with value 0 for array attribute

### DIFF
--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -278,7 +278,7 @@ class Structure extends Validator
             }
 
             if($array) { // Validate attribute type for arrays - format for arrays handled separately
-                if($required == false && empty($value)) { // Allow both null and [] for optional arrays
+                if($required == false && (is_array($value) || is_null($value))) { // Allow both null and [] for optional arrays
                     continue;
                 }
                 if(!is_array($value)) {

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -278,7 +278,7 @@ class Structure extends Validator
             }
 
             if($array) { // Validate attribute type for arrays - format for arrays handled separately
-                if($required == false && (is_array($value) || is_null($value))) { // Allow both null and [] for optional arrays
+                if ($required == false && ((is_array($value) && empty($value)) || is_null($value))) { // Allow both null and [] for optional arrays
                     continue;
                 }
                 if(!is_array($value)) {


### PR DESCRIPTION
When creating a document, no error is thrown if you pass 0 to the optional array field. This PR fixes that issue.

Closes https://github.com/appwrite/appwrite/issues/5013