### PR TITLE
Update Database to have a timestamp property

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6,6 +6,7 @@ use Exception;
 use Throwable;
 use Utopia\Cache\Cache;
 use Utopia\Database\Exception\Authorization as AuthorizationException;
+use Utopia\Database\Exception\Conflict as ConflictException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
 use Utopia\Database\Exception\Structure as StructureException;
@@ -234,6 +235,12 @@ class Database
     protected bool $silentEvents = false;
 
     /**
+     * Timestamp for the current request
+     * @var ?\DateTime
+     */
+    protected ?\DateTime $timestamp = null;
+
+    /**
      * @param Adapter $adapter
      * @param Cache $cache
      */
@@ -358,6 +365,26 @@ class Database
         foreach(($this->listeners[$event] ?? []) as $callback) {
             call_user_func($callback, $event, $args);
         }
+    }
+
+    /**
+     * Executes $callback with $timestamp set to $requestTimestamp
+     * 
+     * @template T
+     * @param ?\DateTime $requestTimestamp
+     * @param callable(): T $callback
+     * @return T
+     */
+    function withRequestTimestamp(?\DateTime $requestTimestamp, callable $callback): mixed
+    {
+        $previous = $this->timestamp;
+        $this->timestamp = $requestTimestamp;
+        try {
+            $result = $callback();
+        } finally {
+            $this->timestamp = $previous;
+        }
+        return $result;
     }
 
     /**
@@ -1475,6 +1502,12 @@ class Database
             throw new AuthorizationException($validator->getDescription());
         }
 
+        // Check if document was updated after the request timestamp
+        $oldUpdatedAt = new \DateTime($old->getUpdatedAt());
+        if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
+            throw new ConflictException('Document was updated after the request timestamp');
+        }
+
         $document = $this->encode($collection, $document);
 
         $validator = new Structure($collection);
@@ -1635,6 +1668,12 @@ class Database
             throw new AuthorizationException($validator->getDescription());
         }
 
+        // Check if document was updated after the request timestamp
+        $oldUpdatedAt = new \DateTime($document->getUpdatedAt());
+        if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
+            throw new ConflictException('Document was updated after the request timestamp');
+        }
+
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id . ':*');
 
         $deleted = $this->adapter->deleteDocument($collection->getId(), $id);
@@ -1683,7 +1722,7 @@ class Database
         $collection = $this->silent(fn() => $this->getCollection($collection));
 
         $grouped = Query::groupByType($queries);
-        /** @var $filters Query[] */ $filters = $grouped['filters'];
+        /** @var Query[] $filters */ $filters = $grouped['filters'];
         /** @var Query[] $selections */ $selections = $grouped['selections'];
         /** @var int $limit */ $limit = $grouped['limit'];
         /** @var int $offset */ $offset = $grouped['offset'];

--- a/src/Database/Exception/Conflict.php
+++ b/src/Database/Exception/Conflict.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Utopia\Database\Exception;
+
+class Conflict extends \Exception
+{
+}


### PR DESCRIPTION
The timestamp property is then used to provide context for
when the request was initially made so that a Conflict
exception can be thrown if a Document was updated or
deleted after the initial request timestamp.

There were 3 options in how to add this timestamp:

1. Add the timestamp to the updateDocument() function
2. Add setTimestamp() and resetTimestamp()
3. Add a withRequestTimestamp() function

The problem with option 1 is that it would pollute the signature and
make it messy.

The problem with option 2 is it adds a global state that developers
would need to make sure to reset. Not doing so can lead to unexpected
behavior.

Option 3 will require modifying places were we want to use the request
timestamp, but this explicitness is best for maintainability.