### PR TITLE
Add `startsWith` and `endsWith` operator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
         "utopia-php/mongo": "0.0.2"
     },
     "require-dev": {
-        "ext-pdo": "*",
-        "ext-redis": "*",
-        "ext-mongodb": "*",
         "fakerphp/faker": "^1.14",
         "phpunit/phpunit": "^9.4",
         "mongodb/mongodb": "1.8.0",

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -59,9 +59,9 @@ abstract class Adapter
      *
      * @param string $namespace
      *
+     * @return bool
      * @throws Exception
      *
-     * @return bool
      */
     public function setNamespace(string $namespace): bool
     {
@@ -79,9 +79,9 @@ abstract class Adapter
      *
      * Get namespace of current set scope
      *
+     * @return string
      * @throws Exception
      *
-     * @return string
      */
     public function getNamespace(): string
     {
@@ -118,9 +118,9 @@ abstract class Adapter
      *
      * Get Database from current scope
      *
+     * @return string
      * @throws Exception
      *
-     * @return string
      */
     public function getDefaultDatabase(): string
     {
@@ -188,45 +188,45 @@ abstract class Adapter
 
     /**
      * Delete Collection
-     * 
+     *
      * @param string $name
-     * 
+     *
      * @return bool
      */
     abstract public function deleteCollection(string $name): bool;
 
     /**
      * Create Attribute
-     * 
+     *
      * @param string $collection
      * @param string $id
      * @param string $type
      * @param int $size
      * @param bool $array
-     * 
+     *
      * @return bool
      */
     abstract public function createAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool;
 
     /**
      * Update Attribute
-     * 
+     *
      * @param string $collection
      * @param string $id
      * @param string $type
      * @param int $size
      * @param bool $array
-     * 
+     *
      * @return bool
      */
     abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool;
 
     /**
      * Delete Attribute
-     * 
+     *
      * @param string $collection
      * @param string $id
-     * 
+     *
      * @return bool
      */
     abstract public function deleteAttribute(string $collection, string $id): bool;
@@ -335,7 +335,7 @@ abstract class Adapter
 
     /**
      * Sum an attribute
-     * 
+     *
      * @param string $collection
      * @param string $attribute
      * @param Query[] $queries
@@ -347,7 +347,7 @@ abstract class Adapter
 
     /**
      * Count Documents
-     * 
+     *
      * @param string $collection
      * @param Query[] $queries
      * @param int $max
@@ -358,55 +358,56 @@ abstract class Adapter
 
     /**
      * Get max STRING limit
-     * 
+     *
      * @return int
      */
     abstract public function getLimitForString(): int;
 
     /**
      * Get max INT limit
-     * 
+     *
      * @return int
      */
     abstract public function getLimitForInt(): int;
 
     /**
      * Get maximum attributes limit.
-     * 
+     *
      * @return int
      */
     abstract public function getLimitForAttributes(): int;
 
     /**
      * Get maximum index limit.
-     * 
+     *
      * @return int
      */
     abstract public function getLimitForIndexes(): int;
 
     /**
      * Is schemas supported?
-     * 
+     *
      * @return bool
      */
     abstract public function getSupportForSchemas(): bool;
+
     /**
      * Is index supported?
-     * 
+     *
      * @return bool
      */
     abstract public function getSupportForIndex(): bool;
 
     /**
      * Is unique index supported?
-     * 
+     *
      * @return bool
      */
     abstract public function getSupportForUniqueIndex(): bool;
 
     /**
      * Is fulltext index supported?
-     * 
+     *
      * @return bool
      */
     abstract public function getSupportForFulltextIndex(): bool;
@@ -421,7 +422,7 @@ abstract class Adapter
 
     /**
      * Does the adapter handle casting?
-     * 
+     *
      * @return bool
      */
     abstract public function getSupportForCasting(): bool;
@@ -435,7 +436,7 @@ abstract class Adapter
 
     /**
      * Get current attribute count from collection document
-     * 
+     *
      * @param Document $collection
      * @return int
      */
@@ -443,7 +444,7 @@ abstract class Adapter
 
     /**
      * Get current index count from collection document
-     * 
+     *
      * @param Document $collection
      * @return int
      */
@@ -476,7 +477,7 @@ abstract class Adapter
      * Byte requirement varies based on column type and size.
      * Needed to satisfy MariaDB/MySQL row width limit.
      * Return 0 when no restrictions apply to row width
-     * 
+     *
      * @param Document $collection
      * @return int
      */
@@ -484,16 +485,16 @@ abstract class Adapter
 
     /**
      * Get list of keywords that cannot be used
-     * 
+     *
      * @return string[]
      */
     abstract public function getKeywords(): array;
 
     /**
      * Filter Keys
-     * 
-     * @throws Exception
+     *
      * @return string
+     * @throws Exception
      */
     public function filter(string $value): string
     {
@@ -501,6 +502,33 @@ abstract class Adapter
 
         if (\is_null($value)) {
             throw new Exception('Failed to filter key');
+        }
+
+        return $value;
+    }
+
+    public function escapeWildcards(string $value): string
+    {
+        $wildcards = [
+            '%',
+            '_',
+            '[',
+            ']',
+            '^',
+            '-',
+            '.',
+            '*',
+            '+',
+            '?',
+            '(',
+            ')',
+            '{',
+            '}',
+            '|'
+        ];
+
+        foreach ($wildcards as $wildcard) {
+            $value = \str_replace($wildcard, "\\$wildcard", $value);
         }
 
         return $value;

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -795,6 +795,8 @@ class MariaDB extends SQL
 
             $attributeIndex = 0;
             foreach ($query->getValues() as $key => $value) {
+                $value = $this->getSQLValue($query->getMethod(), $value);
+
                 $bindKey = 'key_' . $attributeIndex;
                 $stmt->bindValue(':attribute_' . $i . '_' . $key . '_' . $bindKey, $value, $this->getPDOType($value));
                 $attributeIndex++;
@@ -1074,7 +1076,7 @@ class MariaDB extends SQL
                 /**
                  * Prepend wildcard by default on the back.
                  */
-                $value = "'{$value}*'";
+                $value = $this->getSQLValue($method, $value);
 
                 return 'MATCH(' . $attribute . ') AGAINST(' . $this->getPDO()->quote($value) . ' IN BOOLEAN MODE)';
             default:

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -34,6 +34,7 @@ class Mongo extends Adapter
         '$or',
         '$and',
         '$match',
+        '$regex',
     ];
 
     protected Client $client;
@@ -941,7 +942,7 @@ class Mongo extends Adapter
     {
         $filters = [];
 
-        foreach ($queries as $i => $query) {
+        foreach ($queries as $query) {
             if ($query->getAttribute() === '$id') {
                 $query->setAttribute('_uid');
             }
@@ -961,22 +962,24 @@ class Mongo extends Adapter
                 case Query::TYPE_IS_NULL:
                 case Query::TYPE_IS_NOT_NULL:
                     $value = null;
-
                     break;
                 default:
-                    $value = count($query->getValues()) > 1
-                        ? $query->getValues()
-                        : $query->getValues()[0];
-
+                    $value = $this->getQueryValue(
+                        $query->getMethod(),
+                        count($query->getValues()) > 1
+                            ? $query->getValues()
+                            : $query->getValues()[0]
+                    );
                     break;
             }
 
-            if (is_array($value) && $operator === '$eq') {
+            if ($operator == '$eq' && \is_array($value)) {
                 $filters[$attribute]['$in'] = $value;
-            } elseif ($operator === '$in') {
+            } else if ($operator == '$ne' && \is_array($value)) {
+                $filters[$attribute]['$nin'] = $value;
+            } else if($operator == '$in') {
                 $filters[$attribute]['$in'] = $query->getValues();
-            } elseif ($operator === '$search') {
-                // only one fulltext index per mongo collection, so attribute not necessary
+            } else if ($operator == '$search') {
                 $filters['$text'][$operator] = $value;
             } else {
                 $filters[$attribute][$operator] = $value;
@@ -998,37 +1001,41 @@ class Mongo extends Adapter
         switch ($operator) {
             case Query::TYPE_EQUAL:
                 return '$eq';
-
             case Query::TYPE_NOTEQUAL:
                 return '$ne';
-
             case Query::TYPE_LESSER:
                 return '$lt';
-
             case Query::TYPE_LESSEREQUAL:
                 return '$lte';
-
             case Query::TYPE_GREATER:
                 return '$gt';
-
             case Query::TYPE_GREATEREQUAL:
                 return '$gte';
-
             case Query::TYPE_CONTAINS:
                 return '$in';
-
             case Query::TYPE_SEARCH:
                 return '$search';
-
             case Query::TYPE_IS_NULL:
                 return '$eq';
-
             case Query::TYPE_IS_NOT_NULL:
                 return '$ne';
+            case Query::TYPE_STARTS_WITH:
+            case Query::TYPE_ENDS_WITH:
+                return '$regex';
 
             default:
                 throw new Exception('Unknown Operator:' . $operator);
         }
+    }
+
+    protected function getQueryValue(string $method, mixed $value): mixed
+    {
+        return match ($method) {
+            Query::TYPE_STARTS_WITH => $value.'.*',
+            Query::TYPE_ENDS_WITH => '.*'.$value,
+            default => $value,
+        };
+
     }
 
     /**

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1037,11 +1037,16 @@ class Mongo extends Adapter
 
     protected function getQueryValue(string $method, mixed $value): mixed
     {
-        return match ($method) {
-            Query::TYPE_STARTS_WITH => $value.'.*',
-            Query::TYPE_ENDS_WITH => '.*'.$value,
-            default => $value,
-        };
+        switch ($method) {
+            case Query::TYPE_STARTS_WITH:
+                $value = $this->escapeWildcards($value);
+                return $value.'.*';
+            case Query::TYPE_ENDS_WITH:
+                $value = $this->escapeWildcards($value);
+                return '.*'.$value;
+            default:
+                return $value;
+        }
 
     }
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -800,6 +800,8 @@ class Postgres extends SQL
             }
             $attributeIndex = 0;
             foreach ($query->getValues() as $key => $value) {
+                $value = $this->getSQLValue($query->getMethod(), $value);
+
                 $bindKey = 'key_' . $attributeIndex;
                 $stmt->bindValue(':attribute_' . $i . '_' . $key . '_' . $bindKey, $value, $this->getPDOType($value));
                 $attributeIndex++;
@@ -1065,7 +1067,8 @@ class Postgres extends SQL
                 /**
                  * Prepend wildcard by default on the back.
                  */
-                $value = "'{$value}*'";
+                $value = $this->getSQLValue($operator, $value);
+
                 return "to_tsvector(regexp_replace({$attribute}, '[^\w]+',' ','g')) @@ to_tsquery(trim(REGEXP_REPLACE({$value}, '\|+','|','g'),'|'))";
 
             default:

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -685,32 +685,36 @@ abstract class SQL extends Adapter
         switch ($method) {
             case Query::TYPE_EQUAL:
                 return '=';
-
             case Query::TYPE_NOTEQUAL:
                 return '!=';
-
             case Query::TYPE_LESSER:
                 return '<';
-
             case Query::TYPE_LESSEREQUAL:
                 return '<=';
-
             case Query::TYPE_GREATER:
                 return '>';
-
             case Query::TYPE_GREATEREQUAL:
                 return '>=';
-
             case Query::TYPE_IS_NULL:
                 return 'IS NULL';
-
             case Query::TYPE_IS_NOT_NULL:
                 return 'IS NOT NULL';
-
+            case Query::TYPE_STARTS_WITH:
+            case Query::TYPE_ENDS_WITH:
+                return 'LIKE';
             default:
                 throw new Exception('Unknown method:' . $method);
-                break;
         }
+    }
+
+    protected function getSQLValue(string $method, mixed $value)
+    {
+        return match($method) {
+            Query::TYPE_STARTS_WITH => "$value%",
+            Query::TYPE_ENDS_WITH => "%$value",
+            Query::TYPE_SEARCH => "'$value*'",
+            default => $value
+        };
     }
 
     /**

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -736,12 +736,19 @@ abstract class SQL extends Adapter
 
     protected function getSQLValue(string $method, mixed $value)
     {
-        return match($method) {
-            Query::TYPE_STARTS_WITH => "$value%",
-            Query::TYPE_ENDS_WITH => "%$value",
-            Query::TYPE_SEARCH => "'$value*'",
-            default => $value
-        };
+        switch ($method) {
+            case Query::TYPE_STARTS_WITH:
+                $value = $this->escapeWildcards($value);
+                return "$value%";
+            case Query::TYPE_ENDS_WITH:
+                $value = $this->escapeWildcards($value);
+                return "%$value";
+            case Query::TYPE_SEARCH:
+                $value = $this->escapeWildcards($value);
+                return "'$value*'";
+            default:
+                return $value;
+        }
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -17,6 +17,8 @@ class Query
     const TYPE_SEARCH = 'search';
     const TYPE_IS_NULL = 'isNull';
     const TYPE_IS_NOT_NULL = 'isNotNull';
+    const TYPE_STARTS_WITH = 'startsWith';
+    const TYPE_ENDS_WITH = 'endsWith';
 
     // Order methods
     const TYPE_ORDERDESC = 'orderDesc';
@@ -145,7 +147,9 @@ class Query
             self::TYPE_CURSORAFTER,
             self::TYPE_CURSORBEFORE,
             self::TYPE_IS_NULL,
-            self::TYPE_IS_NOT_NULL => true,
+            self::TYPE_IS_NOT_NULL,
+            self::TYPE_STARTS_WITH,
+            self::TYPE_ENDS_WITH => true,
             default => false,
         };
 
@@ -302,6 +306,8 @@ class Query
             case self::TYPE_SEARCH:
             case self::TYPE_IS_NULL:
             case self::TYPE_IS_NOT_NULL:
+            case self::TYPE_STARTS_WITH:
+            case self::TYPE_ENDS_WITH:
                 $attribute = $parsedParams[0] ?? '';
                 if (count($parsedParams) < 2) {
                     return new self($method, $attribute);
@@ -554,6 +560,16 @@ class Query
     public static function isNotNull(string $attribute): self
     {
         return new self(self::TYPE_IS_NOT_NULL, $attribute);
+    }
+
+    public static function startsWith(string $attribute, string $value): self
+    {
+        return new self(self::TYPE_STARTS_WITH, $attribute, [$value]);
+    }
+
+    public static function endsWith(string $attribute, string $value): self
+    {
+        return new self(self::TYPE_ENDS_WITH, $attribute, [$value]);
     }
 
     /**

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -1993,6 +1993,24 @@ abstract class Base extends TestCase
         $this->assertEquals(1, count($documents));
     }
 
+    public function testFindStartsWith()
+    {
+        $documents = static::getDatabase()->find('movies', [
+            Query::startsWith('name', 'Work'),
+        ]);
+
+        $this->assertEquals(2, count($documents));
+    }
+
+    public function testFindEndsWith()
+    {
+        $documents = static::getDatabase()->find('movies', [
+            Query::endsWith('name', 'Marvel'),
+        ]);
+
+        $this->assertEquals(1, count($documents));
+    }
+
     /**
      * @depends testFind
      */

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4,6 +4,7 @@ namespace Utopia\Tests;
 
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Utopia\Database\Adapter\SQL;
 use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
@@ -2021,6 +2022,27 @@ abstract class Base extends TestCase
     {
         $documents = static::getDatabase()->find('movies', [
             Query::startsWith('name', 'Work'),
+        ]);
+
+        $this->assertEquals(2, count($documents));
+
+        if ($this->getDatabase()->getAdapter() instanceof SQL) {
+            $documents = static::getDatabase()->find('movies', [
+                Query::startsWith('name', '%ork'),
+            ]);
+        } else {
+            $documents = static::getDatabase()->find('movies', [
+                Query::startsWith('name', '.*ork'),
+            ]);
+        }
+
+        $this->assertEquals(0, count($documents));
+    }
+
+    public function testFindStartsWithWords()
+    {
+        $documents = static::getDatabase()->find('movies', [
+            Query::startsWith('name', 'Work in Progress'),
         ]);
 
         $this->assertEquals(2, count($documents));

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -163,6 +163,18 @@ class QueryTest extends TestCase
         $this->assertEquals('isNotNull', $query->getMethod());
         $this->assertEquals('director', $query->getAttribute());
         $this->assertEquals([], $query->getValues());
+
+        $query = Query::parse('startsWith("director", "Quentin")');
+
+        $this->assertEquals('startsWith', $query->getMethod());
+        $this->assertEquals('director', $query->getAttribute());
+        $this->assertEquals(['Quentin'], $query->getValues());
+
+        $query = Query::parse('endsWith("director", "Tarantino")');
+
+        $this->assertEquals('endsWith', $query->getMethod());
+        $this->assertEquals('director', $query->getAttribute());
+        $this->assertEquals(['Tarantino'], $query->getValues());
     }
 
     public function testParseV2()

--- a/tests/Database/Validator/QueryTest.php
+++ b/tests/Database/Validator/QueryTest.php
@@ -120,6 +120,8 @@ class QueryTest extends TestCase
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('orderDesc("title")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('isNull("title")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('isNotNull("title")')));
+        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('startsWith("title", "Fro)')));
+        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('endsWith("title", "Zen")')));
     }
 
     public function testInvalidMethod()


### PR DESCRIPTION
## What's new

- Added startsWith and endsWith query operators that match the start or end of a string. 
- Uses the `LIKE` operator for SQL
- Uses the `$regex` opearator for Mongo.

## Tests

Added new tests