### PR TITLE
Fix Database->withRequestTimestamp() to make it public

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -375,7 +375,7 @@ class Database
      * @param callable(): T $callback
      * @return T
      */
-    function withRequestTimestamp(?\DateTime $requestTimestamp, callable $callback): mixed
+    public function withRequestTimestamp(?\DateTime $requestTimestamp, callable $callback): mixed
     {
         $previous = $this->timestamp;
         $this->timestamp = $requestTimestamp;


### PR DESCRIPTION
The default visibility is public, but we should be consistently explicit.