### PR TITLE
Allow adding hooks to pre/post process documents

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1784,8 +1784,6 @@ class Database
 
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id . ':*');
 
-        $document = $this->process(self::HOOK_PRE_DELETE, $collection, $document);
-
         $deleted = $this->adapter->deleteDocument($collection->getId(), $id);
 
         $document = $this->process(self::HOOK_POST_DELETE, $collection, $document);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1800,7 +1800,6 @@ class Database
      *
      * @return bool
      * @throws Exception
-     * @throws Exception
      */
     public function deleteCachedCollection(string $collection): bool
     {
@@ -1814,7 +1813,6 @@ class Database
      * @param string $id
      *
      * @return bool
-     * @throws Exception
      * @throws Exception
      */
     public function deleteCachedDocument(string $collection, string $id): bool

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3786,4 +3786,74 @@ abstract class Base extends TestCase
             $database->delete('hellodb');
         });
     }
+
+    public function testHooks(): void
+    {
+        Authorization::skip(function () {
+            $database = static::getDatabase();
+            $collectionId = ID::unique();
+            $database->createCollection($collectionId);
+            $database->createAttribute($collectionId, 'attr1', Database::VAR_INTEGER, 2, false);
+
+            $database->hook([
+                Database::HOOK_POST_CREATE,
+                Database::HOOK_POST_READ,
+                Database::HOOK_POST_LIST,
+                Database::HOOK_POST_UPDATE,
+                Database::HOOK_POST_DELETE
+            ], function (Document $collection, Document $document) {
+                return $document->removeAttribute('$internalId');
+            });
+
+            $database->hook([
+                Database::HOOK_PRE_CREATE,
+                Database::HOOK_PRE_UPDATE
+            ], function (Document $collection, Document $document) use ($collectionId) {
+                if ($collection->getId() === $collectionId) {
+                    return $document->setAttribute('attr1', $document->getAttribute('attr1') + 1);
+                }
+                return $document;
+            });
+
+            $document = $database->createDocument($collectionId, new Document([
+                '$id' => 'doc1',
+                'attr1' => 10,
+                '$permissions' => [
+                    Permission::delete(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::read(Role::any()),
+                ],
+            ]));
+
+            $this->assertEquals(11, $document->getAttribute('attr1'));
+            $this->assertArrayNotHasKey('$internalId', $document);
+
+            $database->updateDocument($collectionId, 'doc1', $document->setAttribute('attr1', 15));
+
+            $this->assertEquals(16, $document->getAttribute('attr1'));
+            $this->assertArrayNotHasKey('$internalId', $document);
+
+            $database->hook([Database::HOOK_PRE_CREATE], null);
+
+            $document = $database->createDocument($collectionId, new Document([
+                '$id' => 'doc2',
+                'attr1' => 10,
+                '$permissions' => [
+                    Permission::delete(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::read(Role::any()),
+                ],
+            ]));
+
+            $this->assertEquals(10, $document->getAttribute('attr1'));
+            $this->assertArrayNotHasKey('$internalId', $document);
+
+            $database->hook([Database::HOOK_POST_READ], null);
+
+            $document = $database->getDocument($collectionId, 'doc2');
+
+            $this->assertEquals(10, $document->getAttribute('attr1'));
+            $this->assertArrayHasKey('$internalId', $document);
+        });
+    }
 }


### PR DESCRIPTION
## What's changed

- Allow adding hooks via `hook(array $hooks, callable $callback)` function
- Allow pre/post-processing documents
- Available hooks:
    - Pre-create
    - Post-create
    - Post-read
    - Post-list
    - Pre-update
    - Post-update
    - Post-delete
- Will allow things like removing `$internalId` and adding `$collectionId` globally, as well for nested children instead of just the root document.

## Test Plan

- Added hooks tests