### PR TITLE
Fix: Between query

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1283,16 +1283,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.5",
+            "version": "9.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5"
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/86e761949019ae83f49240b2f2123fb5ab3b2fc5",
-                "reference": "86e761949019ae83f49240b2f2123fb5ab3b2fc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
                 "shasum": ""
             },
             "require": {
@@ -1365,7 +1365,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.5"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
             },
             "funding": [
                 {
@@ -1381,7 +1382,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-09T06:34:10+00:00"
+            "time": "2023-03-27T11:43:46+00:00"
         },
         {
             "name": "psr/container",
@@ -2672,5 +2673,5 @@
         "ext-redis": "*",
         "ext-mongodb": "*"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -338,7 +338,6 @@ class Query
             case self::TYPE_SEARCH:
             case self::TYPE_IS_NULL:
             case self::TYPE_IS_NOT_NULL:
-            case self::TYPE_BETWEEN:
             case self::TYPE_STARTS_WITH:
             case self::TYPE_ENDS_WITH:
                 $attribute = $parsedParams[0] ?? '';
@@ -347,6 +346,8 @@ class Query
                 }
                 return new self($method, $attribute, \is_array($parsedParams[1]) ? $parsedParams[1] : [$parsedParams[1]]);
 
+            case self::TYPE_BETWEEN:
+                return new self($method, $parsedParams[0], [$parsedParams[1], $parsedParams[2]]);
             case self::TYPE_SELECT:
                 return new self($method, values: $parsedParams[0]);
             case self::TYPE_ORDERASC:

--- a/tests/Database/QueryTest.php
+++ b/tests/Database/QueryTest.php
@@ -181,6 +181,20 @@ class QueryTest extends TestCase
         $this->assertEquals('', $query->getAttribute());
         $this->assertEquals('title', $query->getValues()[0]);
         $this->assertEquals('director', $query->getValues()[1]);
+
+        $query = Query::parse('between("age", 15, 18)');
+
+        $this->assertEquals('between', $query->getMethod());
+        $this->assertEquals('age', $query->getAttribute());
+        $this->assertEquals(15, $query->getValues()[0]);
+        $this->assertEquals(18, $query->getValues()[1]);
+
+        $query = Query::parse('between("lastUpdate", "DATE1", "DATE2")');
+
+        $this->assertEquals('between', $query->getMethod());
+        $this->assertEquals('lastUpdate', $query->getAttribute());
+        $this->assertEquals('DATE1', $query->getValues()[0]);
+        $this->assertEquals('DATE2', $query->getValues()[1]);
     }
 
     public function testParseV2(): void
@@ -437,6 +451,8 @@ class QueryTest extends TestCase
         $this->assertTrue(Query::isMethod('cursorBefore'));
         $this->assertTrue(Query::isMethod('isNull'));
         $this->assertTrue(Query::isMethod('isNotNull'));
+        $this->assertTrue(Query::isMethod('between'));
+        $this->assertTrue(Query::isMethod('select'));
 
         $this->assertTrue(Query::isMethod(Query::TYPE_EQUAL));
         $this->assertTrue(Query::isMethod(Query::TYPE_NOTEQUAL));
@@ -454,6 +470,8 @@ class QueryTest extends TestCase
         $this->assertTrue(Query::isMethod(QUERY::TYPE_CURSORBEFORE));
         $this->assertTrue(Query::isMethod(QUERY::TYPE_IS_NULL));
         $this->assertTrue(Query::isMethod(QUERY::TYPE_IS_NOT_NULL));
+        $this->assertTrue(Query::isMethod(QUERY::TYPE_BETWEEN));
+        $this->assertTrue(Query::isMethod(QUERY::TYPE_SELECT));
 
         /*
         Tests for aliases if we enable them:

--- a/tests/Database/Validator/QueryTest.php
+++ b/tests/Database/Validator/QueryTest.php
@@ -120,8 +120,8 @@ class QueryTest extends TestCase
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('orderDesc("title")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('isNull("title")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('isNotNull("title")')));
-        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('between("price", [1.5, 10.9])')));
-        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('between("birthDay",["2024-01-01","2023-01-01"])')));
+        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('between("price", 1.5, 10.9)')));
+        $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('between("birthDay","2024-01-01", "2023-01-01")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('startsWith("title", "Fro")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('endsWith("title", "Zen")')));
         $this->assertEquals(true, $validator->isValid(DatabaseQuery::parse('select(["title", "description"])')));


### PR DESCRIPTION
Between query parser supported syntax `between("age", [15, 18])`. Now it supports `between("age", 15, 18)`