### PR TITLE
Ensure relation type is correct when creating two-way relationship

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1443,6 +1443,14 @@ class Database
             ],
         ]);
 
+        $relationType = match ($type) {
+            self::RELATION_ONE_TO_MANY => self::RELATION_MANY_TO_ONE,
+            self::RELATION_MANY_TO_ONE => self::RELATION_ONE_TO_MANY,
+            self::RELATION_MANY_TO_MANY => self::RELATION_MANY_TO_MANY,
+            self::RELATION_ONE_TO_ONE => self::RELATION_ONE_TO_ONE,
+            default => throw new Exception('Invalid relation type'),
+        };
+
         $twoWayRelationship = new Document([
             '$id' => ID::custom($twoWayKey),
             'key' => $twoWayKey,
@@ -1451,7 +1459,7 @@ class Database
             'default' => null,
             'options' => [
                 'relatedCollection' => $collection->getId(),
-                'relationType' => $type,
+                'relationType' => $relationType,
                 'twoWay' => $twoWay,
                 'twoWayKey' => $id,
                 'onDelete' => $onDelete,

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -5165,7 +5165,7 @@ abstract class Base extends TestCase
                 $this->assertEquals('customer', $attribute['$id']);
                 $this->assertEquals('customer', $attribute['key']);
                 $this->assertEquals('customer', $attribute['options']['relatedCollection']);
-                $this->assertEquals(Database::RELATION_ONE_TO_MANY, $attribute['options']['relationType']);
+                $this->assertEquals(Database::RELATION_MANY_TO_ONE, $attribute['options']['relationType']);
                 $this->assertEquals(true, $attribute['options']['twoWay']);
                 $this->assertEquals('accounts', $attribute['options']['twoWayKey']);
             }
@@ -6000,7 +6000,7 @@ abstract class Base extends TestCase
                 $this->assertEquals('products', $attribute['$id']);
                 $this->assertEquals('products', $attribute['key']);
                 $this->assertEquals('product', $attribute['options']['relatedCollection']);
-                $this->assertEquals(Database::RELATION_MANY_TO_ONE, $attribute['options']['relationType']);
+                $this->assertEquals(Database::RELATION_ONE_TO_MANY, $attribute['options']['relationType']);
                 $this->assertEquals(true, $attribute['options']['twoWay']);
                 $this->assertEquals('store', $attribute['options']['twoWayKey']);
             }


### PR DESCRIPTION
For a many to one on the parent side, the child should be one to many. Similarly, for a one to many on the parent side, the child should be many to one.