### PR TITLE
feat: collection level permissions

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="true">
+    stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false">
+    stopOnFailure="true">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2825,16 +2825,19 @@ class Database
             $document = $this->silent(fn () => $this->updateDocumentRelationships($collection, $old, $document));
         }
 
-        $document = $this->adapter->updateDocument($collection->getId(), $document);
+        $this->adapter->updateDocument($collection->getId(), $document);
 
-        if ($this->resolveRelationships) {
-            $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
-        }
+        // TODO: `updateDocumentRelationships` removes the attributes, and for 1-1 relations, it also removes the id that is needed for 1-1 relationships
+        // if ($this->resolveRelationships) {
+        //     $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
+        // }
 
-        $document = $this->decode($collection, $document);
+        // $document = $this->decode($collection, $document);
 
         $this->purgeRelatedDocuments($collection, $id);
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id . ':*');
+
+        $document = $this->silent(fn () => $this->getDocument($collection->getId(), $document->getId()));
 
         $this->trigger(self::EVENT_DOCUMENT_UPDATE, $document);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2827,17 +2827,14 @@ class Database
 
         $this->adapter->updateDocument($collection->getId(), $document);
 
-        // TODO: `updateDocumentRelationships` removes the attributes, and for 1-1 relations, it also removes the id that is needed for 1-1 relationships
-        // if ($this->resolveRelationships) {
-        //     $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
-        // }
+        if ($this->resolveRelationships) {
+            $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
+        }
 
-        // $document = $this->decode($collection, $document);
+        $document = $this->decode($collection, $document);
 
         $this->purgeRelatedDocuments($collection, $id);
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id . ':*');
-
-        $document = $this->silent(fn () => $this->getDocument($collection->getId(), $document->getId()));
 
         $this->trigger(self::EVENT_DOCUMENT_UPDATE, $document);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3528,8 +3528,7 @@ class Database
                 ]);
 
                 foreach ($junctions as $document) {
-                    $this->skipRelationships(fn () =>
-                    $this->deleteDocument(
+                    $this->skipRelationships(fn () => $this->deleteDocument(
                         $junction,
                         $document->getId()
                     ));
@@ -3555,8 +3554,7 @@ class Database
                     break;
                 }
                 foreach ($value as $relation) {
-                    $this->skipRelationships(fn () =>
-                    $this->deleteDocument(
+                    $this->skipRelationships(fn () => $this->deleteDocument(
                         $relatedCollection->getId(),
                         $relation->getId()
                     ));
@@ -3573,8 +3571,7 @@ class Database
                 ]);
 
                 foreach ($value as $relation) {
-                    $this->skipRelationships(fn () =>
-                    $this->deleteDocument(
+                    $this->skipRelationships(fn () => $this->deleteDocument(
                         $relatedCollection->getId(),
                         $relation->getId()
                     ));

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3541,7 +3541,7 @@ class Database
     {
         switch ($relationType) {
             case Database::RELATION_ONE_TO_ONE:
-                if ($document !== null) {
+                if ($value !== null) {
                     $this->skipRelationships(fn () =>
                     $this->deleteDocument(
                         $relatedCollection->getId(),

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3905,11 +3905,9 @@ class Database
             throw new Exception("Collection not found");
         }
 
-        if ($collection->getAttribute('documentSecurity', true) === false) {
-            $authorization = new Authorization(self::PERMISSION_READ);
-            if ($authorization->isValid($collection->getRead())) {
-                $skipAuth = true;
-            }
+        $authorization = new Authorization(self::PERMISSION_READ);
+        if ($authorization->isValid($collection->getRead())) {
+            $skipAuth = true;
         }
 
         $queries = Query::groupByType($queries)['filters'];

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2140,6 +2140,7 @@ class Database
             $cacheKey .= ':*';
         }
 
+        //TODO: fix cache with relationships
         // if ($cache = $this->cache->load($cacheKey, self::TTL)) {
         //     $document = new Document($cache);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3541,11 +3541,13 @@ class Database
     {
         switch ($relationType) {
             case Database::RELATION_ONE_TO_ONE:
-                $this->skipRelationships(fn () =>
-                $this->deleteDocument(
-                    $relatedCollection->getId(),
-                    $value->getId()
-                ));
+                if ($document !== null) {
+                    $this->skipRelationships(fn () =>
+                    $this->deleteDocument(
+                        $relatedCollection->getId(),
+                        $value->getId()
+                    ));
+                }
                 break;
             case Database::RELATION_ONE_TO_MANY:
                 if ($side === Database::RELATION_SIDE_CHILD) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2116,7 +2116,10 @@ class Database
             $document = new Document($cache);
 
             if ($collection->getId() !== self::METADATA) {
-                if (!$validator->isValid($collection->getRead()) || ($documentSecurity && !$validator->isValid($document->getRead()))) {
+                if (!$validator->isValid([
+                    ...$collection->getRead(),
+                    ...($documentSecurity ? $document->getRead() : [])
+                ])) {
                     return new Document();
                 }
             }
@@ -2134,7 +2137,10 @@ class Database
         }
 
         if ($collection->getId() !== self::METADATA) {
-            if (!$validator->isValid($collection->getRead()) || ($documentSecurity && !$validator->isValid($document->getRead()))) {
+            if (!$validator->isValid([
+                ...$collection->getRead(),
+                ...($documentSecurity ? $document->getRead() : [])
+            ])) {
                 return new Document();
             }
         }
@@ -2764,7 +2770,11 @@ class Database
 
         if ($collection->getId() !== self::METADATA) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
-            if (!$validator->isValid($collection->getUpdate()) || ($documentSecurity && !$validator->isValid($old->getUpdate()))) {
+
+            if (!$validator->isValid([
+                ...$collection->getUpdate(),
+                ...($documentSecurity ? $old->getUpdate() : [])
+            ])) {
                 throw new AuthorizationException($validator->getDescription());
             }
         }
@@ -3296,7 +3306,10 @@ class Database
 
         if ($collection->getId() !== self::METADATA) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
-            if (!$validator->isValid($collection->getDelete()) || ($documentSecurity && !$validator->isValid($document->getDelete()))) {
+            if (!$validator->isValid([
+                ...$collection->getDelete(),
+                ...($documentSecurity ? $document->getDelete() : [])
+            ])) {
                 throw new AuthorizationException($validator->getDescription());
             }
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2827,10 +2827,14 @@ class Database
 
         $this->adapter->updateDocument($collection->getId(), $document);
 
+        if ($this->resolveRelationships) {
+            $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
+        }
+
+        $document = $this->decode($collection, $document);
+
         $this->purgeRelatedDocuments($collection, $id);
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id . ':*');
-
-        $document = $this->silent(fn() => $this->getDocument($collection->getId(), $document->getId()));
 
         $this->trigger(self::EVENT_DOCUMENT_UPDATE, $document);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -606,6 +606,8 @@ class Database
      * @param string $id
      * @param array<Document> $attributes
      * @param array<Document> $indexes
+     * @param array<string> $permissions
+     * @param bool $documentSecurity
      *
      * @return Document
      * @throws DuplicateException
@@ -3613,8 +3615,7 @@ class Database
 
         $relationships = \array_filter(
             $collection->getAttribute('attributes', []),
-            fn (Document $attribute) =>
-            $attribute->getAttribute('type') === self::VAR_RELATIONSHIP
+            fn (Document $attribute) => $attribute->getAttribute('type') === self::VAR_RELATIONSHIP
         );
 
         $grouped = Query::groupByType($queries);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -374,7 +374,6 @@ class Database
      * Silent event generation for all the calls inside the callback
      *
      * @template T
-     * @param ?\DateTime $requestTimestamp
      * @param callable(): T $callback
      * @return T
      */
@@ -394,7 +393,6 @@ class Database
      * Skip relationships for all the calls inside the callback
      *
      * @template T
-     * @param ?\DateTime $requestTimestamp
      * @param callable(): T $callback
      * @return T
      */

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2827,14 +2827,10 @@ class Database
 
         $this->adapter->updateDocument($collection->getId(), $document);
 
-        if ($this->resolveRelationships) {
-            $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
-        }
-
-        $document = $this->decode($collection, $document);
-
         $this->purgeRelatedDocuments($collection, $id);
         $this->cache->purge('cache-' . $this->getNamespace() . ':' . $collection->getId() . ':' . $id . ':*');
+
+        $document = $this->silent(fn() => $this->getDocument($collection->getId(), $document->getId()));
 
         $this->trigger(self::EVENT_DOCUMENT_UPDATE, $document);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -616,10 +616,7 @@ class Database
     public function createCollection(string $id, array $attributes = [], array $indexes = [], array $permissions = null, bool $documentSecurity = true): Document
     {
         $permissions ??= [
-            Permission::read(Role::any()),
             Permission::create(Role::any()),
-            Permission::update(Role::any()),
-            Permission::delete(Role::any()),
         ];
 
         $validator = new Permissions();

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -681,8 +681,6 @@ class Database
      * Update Collections Permissions.
      *
      * @param string $id
-     * @param array<Document> $attributes
-     * @param array<Document> $indexes
      * @param array<string> $permissions
      * @param bool $documentSecurity
      *
@@ -2145,22 +2143,22 @@ class Database
             $cacheKey .= ':*';
         }
 
-        if ($cache = $this->cache->load($cacheKey, self::TTL)) {
-            $document = new Document($cache);
+        // if ($cache = $this->cache->load($cacheKey, self::TTL)) {
+        //     $document = new Document($cache);
 
-            if ($collection->getId() !== self::METADATA) {
-                if (!$validator->isValid([
-                    ...$collection->getRead(),
-                    ...($documentSecurity ? $document->getRead() : [])
-                ])) {
-                    return new Document();
-                }
-            }
+        //     if ($collection->getId() !== self::METADATA) {
+        //         if (!$validator->isValid([
+        //             ...$collection->getRead(),
+        //             ...($documentSecurity ? $document->getRead() : [])
+        //         ])) {
+        //             return new Document();
+        //         }
+        //     }
 
-            $this->trigger(self::EVENT_DOCUMENT_READ, $document);
+        //     $this->trigger(self::EVENT_DOCUMENT_READ, $document);
 
-            return $document;
-        }
+        //     return $document;
+        // }
 
         $document = $this->adapter->getDocument($collection->getId(), $id, $queries);
         $document->setAttribute('$collection', $collection->getId());

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -154,7 +154,6 @@ class Authorization extends Validator
      * Skips authorization for the code to be executed inside the callback
      *
      * @template T
-     * @param ?\DateTime $requestTimestamp
      * @param callable(): T $callback
      * @return T
      */

--- a/src/Database/Validator/Authorization.php
+++ b/src/Database/Validator/Authorization.php
@@ -153,8 +153,10 @@ class Authorization extends Validator
      *
      * Skips authorization for the code to be executed inside the callback
      *
-     * @param callable $callback
-     * @return mixed
+     * @template T
+     * @param ?\DateTime $requestTimestamp
+     * @param callable(): T $callback
+     * @return T
      */
     public static function skip(callable $callback): mixed
     {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10453,12 +10453,11 @@ abstract class Base extends TestCase
         $this->assertTrue($document->isEmpty());
     }
 
-        /**
+    /**
      * @depends testCollectionPermissionsRelationshipsCreateWorks
      * @param array<Document> $data
-     * @return array<Document>
      */
-    public function testCollectionPermissionsRelationshipsFindWorks(array $data)
+    public function testCollectionPermissionsRelationshipsFindWorks(array $data): void
     {
         [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -9971,6 +9971,49 @@ abstract class Base extends TestCase
         $this->assertEquals($doc1->getId(), $doc2->getAttribute('$symbols_coll.ection8')[0]->getId());
     }
 
+    public function testCollectionUpdate(): Document
+    {
+        $collection = static::getDatabase()->createCollection('collectionSecurity', permissions: [
+            Permission::create(Role::users()),
+            Permission::read(Role::users()),
+            Permission::update(Role::users()),
+            Permission::delete(Role::users())
+        ], documentSecurity: false);
+
+        $this->assertInstanceOf(Document::class, $collection);
+
+        $collection = static::getDatabase()->getCollection('collectionSecurity');
+
+        $this->assertFalse($collection->getAttribute('documentSecurity'));
+        $this->assertIsArray($collection->getPermissions());
+        $this->assertCount(4, $collection->getPermissions());
+
+        $collection = static::getDatabase()->updateCollection('collectionSecurity', [], true);
+
+        $this->assertTrue($collection->getAttribute('documentSecurity'));
+        $this->assertIsArray($collection->getPermissions());
+        $this->assertEmpty($collection->getPermissions());
+
+        $collection = static::getDatabase()->getCollection('collectionSecurity');
+
+        $this->assertTrue($collection->getAttribute('documentSecurity'));
+        $this->assertIsArray($collection->getPermissions());
+        $this->assertEmpty($collection->getPermissions());
+
+        return $collection;
+    }
+
+    /**
+     * @depends testCollectionUpdate
+     */
+    public function testCollectionUpdatePermissionsThrowException(Document $collection): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        static::getDatabase()->updateCollection($collection->getId(), permissions: [
+            'i dont work'
+        ], documentSecurity: false);
+    }
+
     public function testCollectionPermissions(): Document
     {
         $collection = static::getDatabase()->createCollection('collectionSecurity', permissions: [

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10115,6 +10115,43 @@ abstract class Base extends TestCase
         $this->assertEmpty($documents);
     }
 
+        /**
+     * @param array<Document> $data
+     * @depends testCollectionPermissionsCreateWorks
+     */
+    public function testCollectionPermissionsCountWorks(array $data): array
+    {
+        [$collection, $document] = $data;
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::users()->toString());
+
+        $count = static::getDatabase()->count(
+            $collection->getId()
+        );
+
+        $this->assertNotEmpty($count);
+
+        return $data;
+    }
+
+    /**
+     * @param array<Document> $data
+     * @depends testCollectionPermissionsCreateWorks
+     */
+    public function testCollectionPermissionsCountThrowsException(array $data): void
+    {
+        [$collection, $document] = $data;
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
+        $count = static::getDatabase()->count(
+            $collection->getId()
+        );
+        $this->assertEmpty($count);
+    }
+
     /**
      * @param array<Document> $data
      * @depends testCollectionPermissionsCreateWorks

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -9999,6 +9999,7 @@ abstract class Base extends TestCase
 
     /**
      * @depends testCollectionPermissions
+     * @return array<Document>
      */
     public function testCollectionPermissionsCreateWorks(Document $collection): array
     {
@@ -10040,8 +10041,9 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsGetWorks(array $data): array
     {
@@ -10061,8 +10063,8 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsCreateWorks
+     * @param array<Document> $data
      */
     public function testCollectionPermissionsGetThrowsException(array $data): void
     {
@@ -10080,8 +10082,9 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsFindWorks(array $data): array
     {
@@ -10089,6 +10092,14 @@ abstract class Base extends TestCase
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::users()->toString());
+
+        $documents = static::getDatabase()->find(
+            $collection->getId()
+        );
+        $this->assertNotEmpty($documents);
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('random')->toString());
 
         $documents = static::getDatabase()->find(
             $collection->getId()
@@ -10115,9 +10126,10 @@ abstract class Base extends TestCase
         $this->assertEmpty($documents);
     }
 
-        /**
-     * @param array<Document> $data
+    /**
      * @depends testCollectionPermissionsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsCountWorks(array $data): array
     {
@@ -10153,8 +10165,9 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsUpdateWorks(array $data): array
     {
@@ -10226,6 +10239,9 @@ abstract class Base extends TestCase
         ));
     }
 
+    /**
+     * @return array<Document>
+     */
     public function testCollectionPermissionsRelationships(): array
     {
         $collection = static::getDatabase()->createCollection('collectionSecurity.Parent', permissions: [
@@ -10299,8 +10315,9 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsRelationships
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsRelationshipsCreateWorks(array $data): array
     {
@@ -10351,8 +10368,8 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsRelationships
+     * @param array<Document> $data
      */
     public function testCollectionPermissionsRelationshipsCreateThrowsException(array $data): void
     {
@@ -10373,8 +10390,9 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsRelationshipsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsRelationshipsGetWorks(array $data): array
     {
@@ -10413,8 +10431,9 @@ abstract class Base extends TestCase
     }
 
     /**
-     * @param array<Document> $data
      * @depends testCollectionPermissionsRelationshipsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
      */
     public function testCollectionPermissionsRelationshipsUpdateWorks(array $data): array
     {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10401,7 +10401,7 @@ abstract class Base extends TestCase
      */
     public function testCollectionPermissionsRelationshipsGetWorks(array $data): array
     {
-        [$collection, $document] = $data;
+        [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::users()->toString());
@@ -10440,7 +10440,7 @@ abstract class Base extends TestCase
      */
     public function testCollectionPermissionsRelationshipsGetThrowsException(array $data): void
     {
-        [$collection, $document] = $data;
+        [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::any()->toString());
@@ -10517,11 +10517,30 @@ abstract class Base extends TestCase
         Authorization::cleanRoles();
         Authorization::setRole(Role::users()->toString());
 
-        $this->assertInstanceOf(Document::class, static::getDatabase()->updateDocument(
+        $document = static::getDatabase()->updateDocument(
+            $collection->getId(),
+            $document->getId(),
+            $document
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
+        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertCount(2, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('random')->toString());
+
+        $document = static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),
             $document->setAttribute('test', 'ipsum')
-        ));
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
+        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertCount(1, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
 
         return $data;
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10453,6 +10453,58 @@ abstract class Base extends TestCase
         $this->assertTrue($document->isEmpty());
     }
 
+        /**
+     * @depends testCollectionPermissionsRelationshipsCreateWorks
+     * @param array<Document> $data
+     * @return array<Document>
+     */
+    public function testCollectionPermissionsRelationshipsFindWorks(array $data)
+    {
+        [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::users()->toString());
+
+        $documents = static::getDatabase()->find(
+            $collection->getId()
+        );
+
+        $this->assertIsArray($documents);
+        $this->assertCount(1, $documents);
+        $document = $documents[0];
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
+        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertCount(2, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertFalse($document->isEmpty());
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('random')->toString());
+
+        $documents = static::getDatabase()->find(
+            $collection->getId()
+        );
+
+        $this->assertIsArray($documents);
+        $this->assertCount(1, $documents);
+        $document = $documents[0];
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
+        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertCount(1, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertFalse($document->isEmpty());
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('unknown')->toString());
+
+        $documents = static::getDatabase()->find(
+            $collection->getId()
+        );
+
+        $this->assertIsArray($documents);
+        $this->assertCount(0, $documents);
+    }
+
     /**
      * @depends testCollectionPermissionsRelationshipsCreateWorks
      * @param array<Document> $data

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10083,6 +10083,42 @@ abstract class Base extends TestCase
      * @param array<Document> $data
      * @depends testCollectionPermissionsCreateWorks
      */
+    public function testCollectionPermissionsFindWorks(array $data): array
+    {
+        [$collection, $document] = $data;
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::users()->toString());
+
+        $documents = static::getDatabase()->find(
+            $collection->getId()
+        );
+        $this->assertNotEmpty($documents);
+
+        return $data;
+    }
+
+    /**
+     * @param array<Document> $data
+     * @depends testCollectionPermissionsCreateWorks
+     */
+    public function testCollectionPermissionsFindThrowsException(array $data): void
+    {
+        [$collection, $document] = $data;
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
+        $documents = static::getDatabase()->find(
+            $collection->getId()
+        );
+        $this->assertEmpty($documents);
+    }
+
+    /**
+     * @param array<Document> $data
+     * @depends testCollectionPermissionsCreateWorks
+     */
     public function testCollectionPermissionsUpdateWorks(array $data): array
     {
         [$collection, $document] = $data;

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10034,7 +10034,8 @@ abstract class Base extends TestCase
             '$id' => ID::unique(),
             '$permissions' => [
                 Permission::read(Role::any()),
-                Permission::update(Role::any())
+                Permission::update(Role::any()),
+                Permission::delete(Role::any())
             ],
             'test' => 'lorem ipsum'
         ]));

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -9973,7 +9973,7 @@ abstract class Base extends TestCase
 
     public function testCollectionUpdate(): Document
     {
-        $collection = static::getDatabase()->createCollection('collectionSecurity', permissions: [
+        $collection = static::getDatabase()->createCollection('collectionUpdate', permissions: [
             Permission::create(Role::users()),
             Permission::read(Role::users()),
             Permission::update(Role::users()),
@@ -9982,19 +9982,19 @@ abstract class Base extends TestCase
 
         $this->assertInstanceOf(Document::class, $collection);
 
-        $collection = static::getDatabase()->getCollection('collectionSecurity');
+        $collection = static::getDatabase()->getCollection('collectionUpdate');
 
         $this->assertFalse($collection->getAttribute('documentSecurity'));
         $this->assertIsArray($collection->getPermissions());
         $this->assertCount(4, $collection->getPermissions());
 
-        $collection = static::getDatabase()->updateCollection('collectionSecurity', [], true);
+        $collection = static::getDatabase()->updateCollection('collectionUpdate', [], true);
 
         $this->assertTrue($collection->getAttribute('documentSecurity'));
         $this->assertIsArray($collection->getPermissions());
         $this->assertEmpty($collection->getPermissions());
 
-        $collection = static::getDatabase()->getCollection('collectionSecurity');
+        $collection = static::getDatabase()->getCollection('collectionUpdate');
 
         $this->assertTrue($collection->getAttribute('documentSecurity'));
         $this->assertIsArray($collection->getPermissions());

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10516,30 +10516,24 @@ abstract class Base extends TestCase
         Authorization::cleanRoles();
         Authorization::setRole(Role::users()->toString());
 
-        $document = static::getDatabase()->updateDocument(
+        static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),
             $document
         );
 
-        $this->assertInstanceOf(Document::class, $document);
-        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
-        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
-        $this->assertCount(2, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertTrue(true);
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::user('random')->toString());
 
-        $document = static::getDatabase()->updateDocument(
+        static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),
             $document->setAttribute('test', 'ipsum')
         );
 
-        $this->assertInstanceOf(Document::class, $document);
-        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
-        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
-        $this->assertCount(1, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertTrue(true);
 
         return $data;
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10401,7 +10401,7 @@ abstract class Base extends TestCase
      */
     public function testCollectionPermissionsRelationshipsGetWorks(array $data): array
     {
-        [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
+        [$collection, $document] = $data;
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::users()->toString());
@@ -10440,7 +10440,7 @@ abstract class Base extends TestCase
      */
     public function testCollectionPermissionsRelationshipsGetThrowsException(array $data): void
     {
-        [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
+        [$collection, $document] = $data;
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::any()->toString());

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10507,6 +10507,42 @@ abstract class Base extends TestCase
     /**
      * @depends testCollectionPermissionsRelationshipsCreateWorks
      * @param array<Document> $data
+     */
+    public function testCollectionPermissionsRelationshipsCountWorks(array $data): void
+    {
+        [$collection, $collectionOneToOne, $collectionOneToMany, $document] = $data;
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::users()->toString());
+
+        $documents = static::getDatabase()->count(
+            $collection->getId()
+        );
+
+        $this->assertEquals(1, $documents);
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('random')->toString());
+
+        $documents = static::getDatabase()->count(
+            $collection->getId()
+        );
+
+        $this->assertEquals(1, $documents);
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('unknown')->toString());
+
+        $documents = static::getDatabase()->count(
+            $collection->getId()
+        );
+
+        $this->assertEquals(0, $documents);
+    }
+
+    /**
+     * @depends testCollectionPermissionsRelationshipsCreateWorks
+     * @param array<Document> $data
      * @return array<Document>
      */
     public function testCollectionPermissionsRelationshipsUpdateWorks(array $data): array

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -10221,7 +10221,7 @@ abstract class Base extends TestCase
         Authorization::setRole(Role::any()->toString());
 
         $this->expectException(AuthorizationException::class);
-        $document = static::getDatabase()->deleteDocument(
+        static::getDatabase()->deleteDocument(
             $collection->getId(),
             $document->getId()
         );
@@ -10254,7 +10254,7 @@ abstract class Base extends TestCase
             Permission::read(Role::users()),
             Permission::update(Role::users()),
             Permission::delete(Role::users())
-        ], documentSecurity: false);
+        ], documentSecurity: true);
 
         $this->assertInstanceOf(Document::class, $collection);
 
@@ -10271,7 +10271,7 @@ abstract class Base extends TestCase
             Permission::read(Role::users()),
             Permission::update(Role::users()),
             Permission::delete(Role::users())
-        ], documentSecurity: false);
+        ], documentSecurity: true);
 
         $this->assertInstanceOf(Document::class, $collectionOneToOne);
 
@@ -10296,7 +10296,7 @@ abstract class Base extends TestCase
             Permission::read(Role::users()),
             Permission::update(Role::users()),
             Permission::delete(Role::users())
-        ], documentSecurity: false);
+        ], documentSecurity: true);
 
         $this->assertInstanceOf(Document::class, $collectionOneToMany);
 
@@ -10359,7 +10359,7 @@ abstract class Base extends TestCase
                 ], [
                     '$id' => ID::unique(),
                     '$permissions' => [
-                        Permission::read(Role::user('random')),
+                        Permission::read(Role::user('torsten')),
                         Permission::update(Role::user('random')),
                         Permission::delete(Role::user('random'))
                     ],
@@ -10410,7 +10410,25 @@ abstract class Base extends TestCase
             $collection->getId(),
             $document->getId()
         );
+
         $this->assertInstanceOf(Document::class, $document);
+        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
+        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertCount(2, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertFalse($document->isEmpty());
+
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::user('random')->toString());
+
+        $document = static::getDatabase()->getDocument(
+            $collection->getId(),
+            $document->getId()
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertInstanceOf(Document::class, $document->getAttribute(Database::RELATION_ONE_TO_ONE));
+        $this->assertIsArray($document->getAttribute(Database::RELATION_ONE_TO_MANY));
+        $this->assertCount(1, $document->getAttribute(Database::RELATION_ONE_TO_MANY));
         $this->assertFalse($document->isEmpty());
 
         return $data;


### PR DESCRIPTION
- implements `documentSecurity` to collections
- respect `documentSecurity` on all CRUD operations