### PR TITLE
Don't exceed max depth for relationships

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2369,7 +2369,12 @@ class Database
                     break;
                 case Database::RELATION_MANY_TO_ONE:
                     if ($side === Database::RELATION_SIDE_PARENT) {
-                        if (\is_null($value) || $skipFetch) {
+                        if ($skipFetch || $this->relationshipFetchDepth === Database::RELATION_MAX_DEPTH) {
+                            $document->removeAttribute($key);
+                            break;
+                        }
+
+                        if (\is_null($value)) {
                             break;
                         }
                         $this->relationshipFetchDepth++;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2328,10 +2328,11 @@ class Database
                     break;
                 case Database::RELATION_ONE_TO_MANY:
                     if ($side === Database::RELATION_SIDE_CHILD) {
-                        if (!$twoWay) {
+                        if (!$twoWay || $this->relationshipFetchDepth === Database::RELATION_MAX_DEPTH || $skipFetch) {
                             $document->removeAttribute($key);
+                            break;
                         }
-                        if ($twoWay && !\is_null($value) && !$skipFetch) {
+                        if (!\is_null($value)) {
                             $this->relationshipFetchDepth++;
                             $this->relationshipFetchMap[] = $relationship;
 
@@ -2345,7 +2346,7 @@ class Database
                         break;
                     }
 
-                    if ($twoWay && ($this->relationshipFetchDepth === Database::RELATION_MAX_DEPTH || $skipFetch)) {
+                    if ($this->relationshipFetchDepth === Database::RELATION_MAX_DEPTH || $skipFetch) {
                         break;
                     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2307,15 +2307,12 @@ class Database
 
             switch ($relationType) {
                 case Database::RELATION_ONE_TO_ONE:
-                    if (\is_null($value)) {
+                    if ($skipFetch || $twoWay && ($this->relationshipFetchDepth === Database::RELATION_MAX_DEPTH)) {
+                        $document->removeAttribute($key);
                         break;
                     }
 
-                    if ($skipFetch) {
-                        $document->removeAttribute($key);
-                    }
-
-                    if ($twoWay && ($this->relationshipFetchDepth === Database::RELATION_MAX_DEPTH || $skipFetch)) {
+                    if (\is_null($value)) {
                         break;
                     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -9245,51 +9245,56 @@ abstract class Base extends TestCase
         $this->assertEquals(true, $bird3->isEmpty());
     }
 
-    public function testExceedMaxDepth(): void
+    public function testExceedMaxDepthOneToMany(): void
     {
         if (!static::getDatabase()->getAdapter()->getSupportForRelationships()) {
             $this->expectNotToPerformAssertions();
             return;
         }
 
-        static::getDatabase()->createCollection('level1');
-        static::getDatabase()->createCollection('level2');
-        static::getDatabase()->createCollection('level3');
-        static::getDatabase()->createCollection('level4');
+        $level1Collection = 'level1OneToMany';
+        $level2Collection = 'level2OneToMany';
+        $level3Collection = 'level3OneToMany';
+        $level4Collection = 'level4OneToMany';
+
+        static::getDatabase()->createCollection($level1Collection);
+        static::getDatabase()->createCollection($level2Collection);
+        static::getDatabase()->createCollection($level3Collection);
+        static::getDatabase()->createCollection($level4Collection);
 
         static::getDatabase()->createRelationship(
-            collection: 'level1',
-            relatedCollection: 'level2',
+            collection: $level1Collection,
+            relatedCollection: $level2Collection,
             type: Database::RELATION_ONE_TO_MANY,
             twoWay: true,
         );
         static::getDatabase()->createRelationship(
-            collection: 'level2',
-            relatedCollection: 'level3',
+            collection: $level2Collection,
+            relatedCollection: $level3Collection,
             type: Database::RELATION_ONE_TO_MANY,
             twoWay: true,
         );
         static::getDatabase()->createRelationship(
-            collection: 'level3',
-            relatedCollection: 'level4',
+            collection: $level3Collection,
+            relatedCollection: $level4Collection,
             type: Database::RELATION_ONE_TO_MANY,
             twoWay: true,
         );
 
         // Exceed create depth
-        $level1 = static::getDatabase()->createDocument('level1', new Document([
+        $level1 = static::getDatabase()->createDocument($level1Collection, new Document([
             '$id' => 'level1',
             '$permissions' => [
                 Permission::read(Role::any()),
                 Permission::update(Role::any()),
             ],
-            'level2' => [
+            $level2Collection => [
                 [
                     '$id' => 'level2',
-                    'level3' => [
+                    $level3Collection => [
                         [
                             '$id' => 'level3',
-                            'level4' => [
+                            $level4Collection => [
                                 [
                                     '$id' => 'level4',
                                 ],
@@ -9299,32 +9304,32 @@ abstract class Base extends TestCase
                 ],
             ],
         ]));
-        $this->assertEquals(1, count($level1['level2']));
-        $this->assertEquals('level2', $level1['level2'][0]->getId());
-        $this->assertEquals(1, count($level1['level2'][0]['level3']));
-        $this->assertEquals('level3', $level1['level2'][0]['level3'][0]->getId());
-        $this->assertArrayNotHasKey('level4', $level1['level2'][0]['level3'][0]);
+        $this->assertEquals(1, count($level1[$level2Collection]));
+        $this->assertEquals('level2', $level1[$level2Collection][0]->getId());
+        $this->assertEquals(1, count($level1[$level2Collection][0][$level3Collection]));
+        $this->assertEquals('level3', $level1[$level2Collection][0][$level3Collection][0]->getId());
+        $this->assertArrayNotHasKey('level4', $level1[$level2Collection][0][$level3Collection][0]);
 
         // Exceed fetch depth
-        $level1 = static::getDatabase()->getDocument('level1', 'level1');
-        $this->assertEquals(1, count($level1['level2']));
-        $this->assertEquals('level2', $level1['level2'][0]->getId());
-        $this->assertEquals(1, count($level1['level2'][0]['level3']));
-        $this->assertEquals('level3', $level1['level2'][0]['level3'][0]->getId());
-        $this->assertArrayNotHasKey('level4', $level1['level2'][0]['level3'][0]);
+        $level1 = static::getDatabase()->getDocument($level1Collection, 'level1');
+        $this->assertEquals(1, count($level1[$level2Collection]));
+        $this->assertEquals('level2', $level1[$level2Collection][0]->getId());
+        $this->assertEquals(1, count($level1[$level2Collection][0][$level3Collection]));
+        $this->assertEquals('level3', $level1[$level2Collection][0][$level3Collection][0]->getId());
+        $this->assertArrayNotHasKey($level4Collection, $level1[$level2Collection][0][$level3Collection][0]);
 
 
         // Exceed update depth
         $level1 = static::getDatabase()->updateDocument(
-            'level1',
+            $level1Collection,
             'level1',
             $level1
-            ->setAttribute('level2', [new Document([
+            ->setAttribute($level2Collection, [new Document([
                 '$id' => 'level2new',
-                'level3' => [
+                $level3Collection => [
                     [
                         '$id' => 'level3new',
-                        'level4' => [
+                        $level4Collection => [
                             [
                                 '$id' => 'level4new',
                             ],
@@ -9333,11 +9338,149 @@ abstract class Base extends TestCase
                 ],
             ])])
         );
-        $this->assertEquals(1, count($level1['level2']));
-        $this->assertEquals('level2new', $level1['level2'][0]->getId());
-        $this->assertEquals(1, count($level1['level2'][0]['level3']));
-        $this->assertEquals('level3new', $level1['level2'][0]['level3'][0]->getId());
-        $this->assertArrayNotHasKey('level4', $level1['level2'][0]['level3'][0]);
+        $this->assertEquals(1, count($level1[$level2Collection]));
+        $this->assertEquals('level2new', $level1[$level2Collection][0]->getId());
+        $this->assertEquals(1, count($level1[$level2Collection][0][$level3Collection]));
+        $this->assertEquals('level3new', $level1[$level2Collection][0][$level3Collection][0]->getId());
+        $this->assertArrayNotHasKey($level4Collection, $level1[$level2Collection][0][$level3Collection][0]);
+    }
+
+    public function testExceedMaxDepthOneToOne(): void
+    {
+        if (!static::getDatabase()->getAdapter()->getSupportForRelationships()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $level1Collection = 'level1OneToOne';
+        $level2Collection = 'level2OneToOne';
+        $level3Collection = 'level3OneToOne';
+        $level4Collection = 'level4OneToOne';
+
+        static::getDatabase()->createCollection($level1Collection);
+        static::getDatabase()->createCollection($level2Collection);
+        static::getDatabase()->createCollection($level3Collection);
+        static::getDatabase()->createCollection($level4Collection);
+
+        static::getDatabase()->createRelationship(
+            collection: $level1Collection,
+            relatedCollection: $level2Collection,
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+        );
+        static::getDatabase()->createRelationship(
+            collection: $level2Collection,
+            relatedCollection: $level3Collection,
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+        );
+        static::getDatabase()->createRelationship(
+            collection: $level3Collection,
+            relatedCollection: $level4Collection,
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+        );
+
+        // Exceed create depth
+        $level1 = static::getDatabase()->createDocument($level1Collection, new Document([
+            '$id' => 'level1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+            ],
+            $level2Collection => [
+                '$id' => 'level2',
+                $level3Collection => [
+                    '$id' => 'level3',
+                    $level4Collection => [
+                        '$id' => 'level4',
+                    ],
+                ],
+            ],
+        ]));
+        $this->assertArrayHasKey($level2Collection, $level1);
+        $this->assertEquals('level2', $level1[$level2Collection]->getId());
+        $this->assertArrayHasKey($level3Collection, $level1[$level2Collection]);
+        $this->assertEquals('level3', $level1[$level2Collection][$level3Collection]->getId());
+        $this->assertArrayNotHasKey($level4Collection, $level1[$level2Collection][$level3Collection]);
+
+        // Confirm the 4th level document exists
+        $level3 = static::getDatabase()->getDocument($level3Collection, 'level3');
+
+        $this->assertArrayHasKey($level4Collection, $level3);
+        $this->assertEquals('level4', $level3[$level4Collection]->getId());
+
+        // Exceed fetch depth
+        $level1 = static::getDatabase()->getDocument($level1Collection, 'level1');
+        $this->assertArrayHasKey($level2Collection, $level1);
+        $this->assertEquals('level2', $level1[$level2Collection]->getId());
+        $this->assertArrayHasKey($level3Collection, $level1[$level2Collection]);
+        $this->assertEquals('level3', $level1[$level2Collection][$level3Collection]->getId());
+        $this->assertArrayNotHasKey($level4Collection, $level1[$level2Collection][$level3Collection]);
+    }
+
+    public function testExceedMaxDepthOneToOneNull(): void
+    {
+        if (!static::getDatabase()->getAdapter()->getSupportForRelationships()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $level1Collection = 'level1OneToOneNull';
+        $level2Collection = 'level2OneToOneNull';
+        $level3Collection = 'level3OneToOneNull';
+        $level4Collection = 'level4OneToOneNull';
+
+        static::getDatabase()->createCollection($level1Collection);
+        static::getDatabase()->createCollection($level2Collection);
+        static::getDatabase()->createCollection($level3Collection);
+        static::getDatabase()->createCollection($level4Collection);
+
+        static::getDatabase()->createRelationship(
+            collection: $level1Collection,
+            relatedCollection: $level2Collection,
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+        );
+        static::getDatabase()->createRelationship(
+            collection: $level2Collection,
+            relatedCollection: $level3Collection,
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+        );
+        static::getDatabase()->createRelationship(
+            collection: $level3Collection,
+            relatedCollection: $level4Collection,
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+        );
+
+        $level1 = static::getDatabase()->createDocument($level1Collection, new Document([
+            '$id' => 'level1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+            ],
+            $level2Collection => [
+                '$id' => 'level2',
+                $level3Collection => [
+                    '$id' => 'level3',
+                ],
+            ],
+        ]));
+        $this->assertArrayHasKey($level2Collection, $level1);
+        $this->assertEquals('level2', $level1[$level2Collection]->getId());
+        $this->assertArrayHasKey($level3Collection, $level1[$level2Collection]);
+        $this->assertEquals('level3', $level1[$level2Collection][$level3Collection]->getId());
+        $this->assertArrayNotHasKey($level4Collection, $level1[$level2Collection][$level3Collection]);
+
+        // Exceed fetch depth
+        $level1 = static::getDatabase()->getDocument($level1Collection, 'level1');
+        $this->assertArrayHasKey($level2Collection, $level1);
+        $this->assertEquals('level2', $level1[$level2Collection]->getId());
+        $this->assertArrayHasKey($level3Collection, $level1[$level2Collection]);
+        $this->assertEquals('level3', $level1[$level2Collection][$level3Collection]->getId());
+        $this->assertArrayNotHasKey($level4Collection, $level1[$level2Collection][$level3Collection]);
     }
 
     public function testCreateRelationshipMissingCollection(): void


### PR DESCRIPTION
Before this, if a document had a 1 to 1, parent-sided many-to-one, or child-sided one-to-many relationship, the nested document's ID would still be included in the result even if the user didn't have access to the nested document. This clears the attribute so that the document ID is excluded from the result.

This PR depends on:

* https://github.com/utopia-php/database/pull/262

We should merge the dependant to main and then change this one to merge to main.