### PR TITLE
Fix: $permissions returns as object rather than array

### DIFF
--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -79,7 +79,7 @@ class Document extends ArrayObject
      */
     public function getPermissions(): array
     {
-        return \array_unique($this->getAttribute('$permissions', []));
+        return \array_values(\array_unique($this->getAttribute('$permissions', [])));
     }
 
     /**

--- a/src/Database/Helpers/Permission.php
+++ b/src/Database/Helpers/Permission.php
@@ -170,7 +170,7 @@ class Permission
                 }
             }
         }
-        return $mutated;
+        return \array_values(\array_unique($mutated));
     }
 
     /**

--- a/tests/Database/PermissionTest.php
+++ b/tests/Database/PermissionTest.php
@@ -293,6 +293,7 @@ class PermissionTest extends TestCase
             'update("user:123")',
             'delete("user:123")'
         ];
+
         $parsed = Permission::aggregate($permissions, Database::PERMISSIONS);
         $this->assertEquals(['read("any")',
             'read("user:123")',

--- a/tests/Database/PermissionTest.php
+++ b/tests/Database/PermissionTest.php
@@ -284,5 +284,20 @@ class PermissionTest extends TestCase
 
         $parsed = Permission::aggregate($permissions, [Database::PERMISSION_UPDATE, Database::PERMISSION_DELETE]);
         $this->assertEquals(['update("any")', 'delete("any")'], $parsed);
+
+        $permissions = [
+            'read("any")',
+            'read("user:123")',
+            'read("user:123")',
+            'write("user:123")',
+            'update("user:123")',
+            'delete("user:123")'
+        ];
+        $parsed = Permission::aggregate($permissions, Database::PERMISSIONS);
+        $this->assertEquals(['read("any")',
+            'read("user:123")',
+            'create("user:123")',
+            'update("user:123")',
+            'delete("user:123")'], $parsed);
     }
 }

--- a/tests/Database/PermissionTest.php
+++ b/tests/Database/PermissionTest.php
@@ -295,10 +295,12 @@ class PermissionTest extends TestCase
         ];
 
         $parsed = Permission::aggregate($permissions, Database::PERMISSIONS);
-        $this->assertEquals(['read("any")',
+        $this->assertEquals([
+            'read("any")',
             'read("user:123")',
             'create("user:123")',
             'update("user:123")',
-            'delete("user:123")'], $parsed);
+            'delete("user:123")',
+        ], $parsed);
     }
 }

--- a/tests/Database/Validator/PermissionsTest.php
+++ b/tests/Database/Validator/PermissionsTest.php
@@ -303,7 +303,7 @@ class PermissionsTest extends TestCase
       */
     public function testDuplicateMethods(): void
     {
-        $object = new Permissions();
+        $validator = new Permissions();
 
         $user = ID::unique();
 
@@ -328,13 +328,15 @@ class PermissionsTest extends TestCase
                 new Document(['name' => 'z']),
             ]
         ]);
-        $this->assertTrue($object->isValid($document->getPermissions()));
+        $this->assertTrue($validator->isValid($document->getPermissions()));
         $permissions = $document->getPermissions();
         $this->assertEquals(5, count($permissions));
-        $this->assertEquals('read("any")', $permissions[0]);
-        $this->assertEquals('read("user:' . $user . '")', $permissions[1]);
-        $this->assertEquals('write("user:' . $user . '")', $permissions[2]);
-        $this->assertEquals('update("user:' . $user . '")', $permissions[3]);
-        $this->assertEquals('delete("user:' . $user . '")', $permissions[4]);
+        $this->assertEquals([
+            'read("any")',
+            'read("user:' . $user . '")',
+            'write("user:' . $user . '")',
+            'update("user:' . $user . '")',
+            'delete("user:' . $user . '")',
+        ], $permissions);
     }
 }


### PR DESCRIPTION
## What does this do

Fixes [#5661](https://github.com/appwrite/appwrite/issues/5661)

## Testing 

Unit and E2E testing