### PR TITLE
No Exception when no change in update document function 

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2855,8 +2855,8 @@ class Database
         }
 
         $time = DateTime::now();
-
         $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
@@ -2865,7 +2865,9 @@ class Database
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
             $skipPermission = true;
+            //compare if the document any changes
             foreach ($document as $key=>$value) {
+                //skip the nested documents as they will be checked later in recursions.
                 if ($old->getAttribute($key) instanceof Document) {
                     continue;
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3086,16 +3086,16 @@ class Database
                             $removedDocuments = \array_diff($oldIds, $newIds);
 
                             foreach ($removedDocuments as $relation) {
-                                $relation = $this->skipRelationships(fn () => Authorization::skip(fn () => $this->getDocument(
+                                $relation = $this->skipRelationships(fn () => $this->getDocument(
                                     $relatedCollection->getId(),
                                     $relation
-                                )));
+                                ));
 
-                                $this->skipRelationships(fn () => Authorization::skip(fn () =>$this->updateDocument(
+                                $this->skipRelationships(fn () => $this->updateDocument(
                                     $relatedCollection->getId(),
                                     $relation->getId(),
                                     $relation->setAttribute($twoWayKey, null)
-                                ))); //removing relationship from 10 id document in collection B by updating it.
+                                ));
                             }
 
                             foreach ($value as $relation) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2994,7 +2994,7 @@ abstract class Base extends TestCase
                 Permission::delete(Role::any()),
             ],
             'string' => 'text📝',
-            'integer' => 5,
+            'integer' => 6,
             'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
@@ -10764,7 +10764,6 @@ abstract class Base extends TestCase
     public function testCollectionPermissionsUpdateThrowsException(array $data): void
     {
         [$collection, $document] = $data;
-
         Authorization::cleanRoles();
         Authorization::setRole(Role::any()->toString());
 
@@ -10772,7 +10771,7 @@ abstract class Base extends TestCase
         $document = static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),
-            $document->setAttribute('test', 'ipsum')
+            $document->setAttribute('test', 'lorem')
         );
     }
 


### PR DESCRIPTION
We should not throw authorization exception when there is no change in update document coming document. 
This is required for Relationships as we need to allow users to update document of related collection. 