### PR TITLE
No Exception when no change in update document function 

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2791,7 +2791,6 @@ class Database
         }
 
         $time = DateTime::now();
-        $document->setAttribute('$updatedAt', $time);
 
         $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
         $collection = $this->silent(fn () => $this->getCollection($collection));
@@ -2801,13 +2800,25 @@ class Database
         if ($collection->getId() !== self::METADATA) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
-            if (!$validator->isValid([
+            $skipPermission = true;
+            foreach ($document as $key=>$value) {
+                if ($old->getAttribute($key) instanceof Document) {
+                    continue;
+                }
+                if ($old->getAttribute($key) !== $value) {
+                    $skipPermission = false;
+                    break;
+                }
+            }
+            if (!$skipPermission && !$validator->isValid([
                 ...$collection->getUpdate(),
                 ...($documentSecurity ? $old->getUpdate() : [])
             ])) {
                 throw new AuthorizationException($validator->getDescription());
             }
         }
+
+        $document->setAttribute('$updatedAt', $time);
 
         // Check if document was updated after the request timestamp
         $oldUpdatedAt = new \DateTime($old->getUpdatedAt());
@@ -3010,16 +3021,16 @@ class Database
                             $removedDocuments = \array_diff($oldIds, $newIds);
 
                             foreach ($removedDocuments as $relation) {
-                                $relation = $this->skipRelationships(fn () => $this->getDocument(
+                                $relation = $this->skipRelationships(fn () => Authorization::skip(fn () => $this->getDocument(
                                     $relatedCollection->getId(),
                                     $relation
-                                ));
+                                )));
 
-                                $this->skipRelationships(fn () => $this->updateDocument(
+                                $this->skipRelationships(fn () => Authorization::skip(fn () =>$this->updateDocument(
                                     $relatedCollection->getId(),
                                     $relation->getId(),
                                     $relation->setAttribute($twoWayKey, null)
-                                ));
+                                ))); //removing relationship from 10 id document in collection B by updating it.
                             }
 
                             foreach ($value as $relation) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2791,8 +2791,8 @@ class Database
         }
 
         $time = DateTime::now();
-
         $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
@@ -2801,7 +2801,9 @@ class Database
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
             $skipPermission = true;
+            //compare if the document any changes
             foreach ($document as $key=>$value) {
+                //skip the nested documents as they will be checked later in recursions.
                 if ($old->getAttribute($key) instanceof Document) {
                     continue;
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3021,16 +3021,16 @@ class Database
                             $removedDocuments = \array_diff($oldIds, $newIds);
 
                             foreach ($removedDocuments as $relation) {
-                                $relation = $this->skipRelationships(fn () => Authorization::skip(fn () => $this->getDocument(
+                                $relation = $this->skipRelationships(fn () => $this->getDocument(
                                     $relatedCollection->getId(),
                                     $relation
-                                )));
+                                ));
 
-                                $this->skipRelationships(fn () => Authorization::skip(fn () =>$this->updateDocument(
+                                $this->skipRelationships(fn () => $this->updateDocument(
                                     $relatedCollection->getId(),
                                     $relation->getId(),
                                     $relation->setAttribute($twoWayKey, null)
-                                ))); //removing relationship from 10 id document in collection B by updating it.
+                                ));
                             }
 
                             foreach ($value as $relation) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2729,7 +2729,7 @@ abstract class Base extends TestCase
                 Permission::delete(Role::any()),
             ],
             'string' => 'text📝',
-            'integer' => 5,
+            'integer' => 6,
             'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
@@ -10597,7 +10597,6 @@ abstract class Base extends TestCase
     public function testCollectionPermissionsUpdateThrowsException(array $data): void
     {
         [$collection, $document] = $data;
-
         Authorization::cleanRoles();
         Authorization::setRole(Role::any()->toString());
 
@@ -10605,7 +10604,7 @@ abstract class Base extends TestCase
         $document = static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),
-            $document->setAttribute('test', 'ipsum')
+            $document->setAttribute('test', 'lorem')
         );
     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2739,6 +2739,47 @@ abstract class Base extends TestCase
         return $document;
     }
 
+
+    /**
+     * @depends testCreateDocument
+     */
+    public function testNoChangeUpdateDocumentWithoutPermission(Document $document): Document
+    {
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
+
+        $document = static::getDatabase()->createDocument('documents', new Document([
+            'string' => 'text📝',
+            'integer' => 5,
+            'bigint' => 8589934592, // 2^33
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+        ]));
+        Authorization::cleanRoles();
+        //no changes in document
+        $documentToUpdate = new Document([
+            '$id' => ID::custom($document->getId()),
+            'string' => 'text📝',
+            'integer' => 5,
+            'bigint' => 8589934592, // 2^33
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+            '$collection' => 'documents',
+        ]);
+        $documentToUpdate->setAttribute('$createdAt', $document->getAttribute('$createdAt'));
+        $documentToUpdate->setAttribute('$updatedAt', $document->getAttribute('$updatedAt'));
+        $updatedDocument = static::getDatabase()->updateDocument('documents', $document->getId(), $documentToUpdate);
+
+
+        // Document should be updated without any problem and without any authorization exception as there is no change in document.
+        $this->assertEquals(true, $updatedDocument->getUpdatedAt() > $document->getUpdatedAt());
+
+        return $document;
+    }
+
     public function testExceptionAttributeLimit(): void
     {
         if ($this->getDatabase()->getLimitForAttributes() > 0) {


### PR DESCRIPTION
We should not throw authorization exception when there is no change in update document coming document.
This is required for Relationships as we need to allow users to update document of related collection.