### PR TITLE
No Exception when no change in update document function

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2791,7 +2791,6 @@ class Database
         }
 
         $time = DateTime::now();
-        $document->setAttribute('$updatedAt', $time);
 
         $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
         $collection = $this->silent(fn () => $this->getCollection($collection));
@@ -2801,13 +2800,25 @@ class Database
         if ($collection->getId() !== self::METADATA) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
-            if (!$validator->isValid([
+            $skipPermission = true;
+            foreach ($document as $key=>$value) {
+                if ($old->getAttribute($key) instanceof Document) {
+                    continue;
+                }
+                if ($old->getAttribute($key) !== $value) {
+                    $skipPermission = false;
+                    break;
+                }
+            }
+            if (!$skipPermission && !$validator->isValid([
                 ...$collection->getUpdate(),
                 ...($documentSecurity ? $old->getUpdate() : [])
             ])) {
                 throw new AuthorizationException($validator->getDescription());
             }
         }
+
+        $document->setAttribute('$updatedAt', $time);
 
         // Check if document was updated after the request timestamp
         $oldUpdatedAt = new \DateTime($old->getUpdatedAt());
@@ -3010,16 +3021,16 @@ class Database
                             $removedDocuments = \array_diff($oldIds, $newIds);
 
                             foreach ($removedDocuments as $relation) {
-                                $relation = $this->skipRelationships(fn () => $this->getDocument(
+                                $relation = $this->skipRelationships(fn () => Authorization::skip(fn () => $this->getDocument(
                                     $relatedCollection->getId(),
                                     $relation
-                                ));
+                                )));
 
-                                $this->skipRelationships(fn () => $this->updateDocument(
+                                $this->skipRelationships(fn () => Authorization::skip(fn () =>$this->updateDocument(
                                     $relatedCollection->getId(),
                                     $relation->getId(),
                                     $relation->setAttribute($twoWayKey, null)
-                                ));
+                                ))); //removing relationship from 10 id document in collection B by updating it.
                             }
 
                             foreach ($value as $relation) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2801,9 +2801,9 @@ class Database
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
             $skipPermission = true;
-            //compare if the document any changes
+            // Compare if the document has any changes
             foreach ($document as $key=>$value) {
-                //skip the nested documents as they will be checked later in recursions.
+                // Skip the nested documents as they will be checked later in recursions.
                 if ($old->getAttribute($key) instanceof Document) {
                     continue;
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2796,7 +2796,7 @@ class Database
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
-        $skipPermission = true;
+        $shouldUpdate = false;
 
         if ($collection->getId() !== self::METADATA) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
@@ -2808,11 +2808,11 @@ class Database
                     continue;
                 }
                 if ($old->getAttribute($key) !== $value) {
-                    $skipPermission = false;
+                    $shouldUpdate = true;
                     break;
                 }
             }
-            if (!$skipPermission && !$validator->isValid([
+            if ($shouldUpdate && !$validator->isValid([
                 ...$collection->getUpdate(),
                 ...($documentSecurity ? $old->getUpdate() : [])
             ])) {
@@ -2820,7 +2820,7 @@ class Database
             }
         }
 
-        if (!$skipPermission) {
+        if ($shouldUpdate) {
             $document->setAttribute('$updatedAt', $time);
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2791,8 +2791,8 @@ class Database
         }
 
         $time = DateTime::now();
-
         $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
@@ -2801,7 +2801,9 @@ class Database
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
             $skipPermission = true;
+            //compare if the document any changes
             foreach ($document as $key=>$value) {
+                //skip the nested documents as they will be checked later in recursions.
                 if ($old->getAttribute($key) instanceof Document) {
                     continue;
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2804,10 +2804,11 @@ class Database
             // Compare if the document has any changes
             foreach ($document as $key=>$value) {
                 // Skip the nested documents as they will be checked later in recursions.
-                if ($old->getAttribute($key) instanceof Document) {
+                $oldAttributeValue = $old->getAttribute($key);
+                if ($oldAttributeValue instanceof Document) {
                     continue;
                 }
-                if ($old->getAttribute($key) !== $value) {
+                if ($oldAttributeValue !== $value) {
                     $shouldUpdate = true;
                     break;
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2820,7 +2820,7 @@ class Database
             }
         }
 
-        if(!$skipPermission){
+        if (!$skipPermission) {
             $document->setAttribute('$updatedAt', $time);
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2796,11 +2796,11 @@ class Database
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
+        $skipPermission = true;
 
         if ($collection->getId() !== self::METADATA) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
 
-            $skipPermission = true;
             // Compare if the document has any changes
             foreach ($document as $key=>$value) {
                 // Skip the nested documents as they will be checked later in recursions.
@@ -2820,7 +2820,9 @@ class Database
             }
         }
 
-        $document->setAttribute('$updatedAt', $time);
+        if(!$skipPermission){
+            $document->setAttribute('$updatedAt', $time);
+        }
 
         // Check if document was updated after the request timestamp
         $oldUpdatedAt = new \DateTime($old->getUpdatedAt());

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3021,16 +3021,16 @@ class Database
                             $removedDocuments = \array_diff($oldIds, $newIds);
 
                             foreach ($removedDocuments as $relation) {
-                                $relation = $this->skipRelationships(fn () => Authorization::skip(fn () => $this->getDocument(
+                                $relation = $this->skipRelationships(fn () => $this->getDocument(
                                     $relatedCollection->getId(),
                                     $relation
-                                )));
+                                ));
 
-                                $this->skipRelationships(fn () => Authorization::skip(fn () =>$this->updateDocument(
+                                $this->skipRelationships(fn () => $this->updateDocument(
                                     $relatedCollection->getId(),
                                     $relation->getId(),
                                     $relation->setAttribute($twoWayKey, null)
-                                ))); //removing relationship from 10 id document in collection B by updating it.
+                                ));
                             }
 
                             foreach ($value as $relation) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -78,9 +78,10 @@ abstract class Base extends TestCase
     public function testCreatedAtUpdatedAt(): void
     {
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('created_at'));
-
+        static::getDatabase()->createAttribute('created_at','title', Database::VAR_STRING, 100, false);
         $document = static::getDatabase()->createDocument('created_at', new Document([
             '$id' => ID::custom('uid123'),
+
             '$permissions' => [
                 Permission::read(Role::any()),
                 Permission::create(Role::any()),
@@ -2774,8 +2775,8 @@ abstract class Base extends TestCase
         $updatedDocument = static::getDatabase()->updateDocument('documents', $document->getId(), $documentToUpdate);
 
 
-        // Document should be updated without any problem and without any authorization exception as there is no change in document.
-        $this->assertEquals(true, $updatedDocument->getUpdatedAt() > $document->getUpdatedAt());
+        // Document should not be updated as there is no change. It should also not throw any authorization exception without any permission because of no change.
+        $this->assertEquals($updatedDocument->getUpdatedAt(),$document->getUpdatedAt());
 
         return $document;
     }
@@ -3526,6 +3527,7 @@ abstract class Base extends TestCase
         $document = static::getDatabase()->getDocument('created_at', 'uid123');
         $this->assertEquals(true, !$document->isEmpty());
         sleep(1);
+        $document->setAttribute('title','new title');
         static::getDatabase()->updateDocument('created_at', 'uid123', $document);
         $document = static::getDatabase()->getDocument('created_at', 'uid123');
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -78,7 +78,7 @@ abstract class Base extends TestCase
     public function testCreatedAtUpdatedAt(): void
     {
         $this->assertInstanceOf('Utopia\Database\Document', static::getDatabase()->createCollection('created_at'));
-        static::getDatabase()->createAttribute('created_at','title', Database::VAR_STRING, 100, false);
+        static::getDatabase()->createAttribute('created_at', 'title', Database::VAR_STRING, 100, false);
         $document = static::getDatabase()->createDocument('created_at', new Document([
             '$id' => ID::custom('uid123'),
 
@@ -2776,7 +2776,7 @@ abstract class Base extends TestCase
 
 
         // Document should not be updated as there is no change. It should also not throw any authorization exception without any permission because of no change.
-        $this->assertEquals($updatedDocument->getUpdatedAt(),$document->getUpdatedAt());
+        $this->assertEquals($updatedDocument->getUpdatedAt(), $document->getUpdatedAt());
 
         return $document;
     }
@@ -3527,7 +3527,7 @@ abstract class Base extends TestCase
         $document = static::getDatabase()->getDocument('created_at', 'uid123');
         $this->assertEquals(true, !$document->isEmpty());
         sleep(1);
-        $document->setAttribute('title','new title');
+        $document->setAttribute('title', 'new title');
         static::getDatabase()->updateDocument('created_at', 'uid123', $document);
         $document = static::getDatabase()->getDocument('created_at', 'uid123');
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2746,9 +2746,7 @@ abstract class Base extends TestCase
      */
     public function testNoChangeUpdateDocumentWithoutPermission(Document $document): Document
     {
-        Authorization::cleanRoles();
         Authorization::setRole(Role::any()->toString());
-
 
         $document = static::getDatabase()->createDocument('documents', new Document([
             'string' => 'text📝',
@@ -2758,22 +2756,9 @@ abstract class Base extends TestCase
             'boolean' => true,
             'colors' => ['pink', 'green', 'blue'],
         ]));
-        Authorization::cleanRoles();
-        // No changes in document
-        $documentToUpdate = new Document([
-            '$id' => ID::custom($document->getId()),
-            'string' => 'text📝',
-            'integer' => 5,
-            'bigint' => 8589934592, // 2^33
-            'float' => 5.55,
-            'boolean' => true,
-            'colors' => ['pink', 'green', 'blue'],
-            '$collection' => 'documents',
-        ]);
-        $documentToUpdate->setAttribute('$createdAt', $document->getAttribute('$createdAt'));
-        $documentToUpdate->setAttribute('$updatedAt', $document->getAttribute('$updatedAt'));
-        $updatedDocument = static::getDatabase()->updateDocument('documents', $document->getId(), $documentToUpdate);
 
+        Authorization::cleanRoles();
+        $updatedDocument = static::getDatabase()->updateDocument('documents', $document->getId(), $document);
 
         // Document should not be updated as there is no change. It should also not throw any authorization exception without any permission because of no change.
         $this->assertEquals($updatedDocument->getUpdatedAt(), $document->getUpdatedAt());

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2729,7 +2729,7 @@ abstract class Base extends TestCase
                 Permission::delete(Role::any()),
             ],
             'string' => 'text📝',
-            'integer' => 5,
+            'integer' => 6,
             'bigint' => 8589934592, // 2^33
             'float' => 5.55,
             'boolean' => true,
@@ -10597,7 +10597,6 @@ abstract class Base extends TestCase
     public function testCollectionPermissionsUpdateThrowsException(array $data): void
     {
         [$collection, $document] = $data;
-
         Authorization::cleanRoles();
         Authorization::setRole(Role::any()->toString());
 
@@ -10605,7 +10604,7 @@ abstract class Base extends TestCase
         $document = static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),
-            $document->setAttribute('test', 'ipsum')
+            $document->setAttribute('test', 'lorem')
         );
     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2758,7 +2758,7 @@ abstract class Base extends TestCase
             'colors' => ['pink', 'green', 'blue'],
         ]));
         Authorization::cleanRoles();
-        //no changes in document
+        // No changes in document
         $documentToUpdate = new Document([
             '$id' => ID::custom($document->getId()),
             'string' => 'text📝',

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -2739,6 +2739,47 @@ abstract class Base extends TestCase
         return $document;
     }
 
+
+    /**
+     * @depends testCreateDocument
+     */
+    public function testNoChangeUpdateDocumentWithoutPermission(Document $document): Document
+    {
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
+
+        $document = static::getDatabase()->createDocument('documents', new Document([
+            'string' => 'text📝',
+            'integer' => 5,
+            'bigint' => 8589934592, // 2^33
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+        ]));
+        Authorization::cleanRoles();
+        //no changes in document
+        $documentToUpdate = new Document([
+            '$id' => ID::custom($document->getId()),
+            'string' => 'text📝',
+            'integer' => 5,
+            'bigint' => 8589934592, // 2^33
+            'float' => 5.55,
+            'boolean' => true,
+            'colors' => ['pink', 'green', 'blue'],
+            '$collection' => 'documents',
+        ]);
+        $documentToUpdate->setAttribute('$createdAt', $document->getAttribute('$createdAt'));
+        $documentToUpdate->setAttribute('$updatedAt', $document->getAttribute('$updatedAt'));
+        $updatedDocument = static::getDatabase()->updateDocument('documents', $document->getId(), $documentToUpdate);
+
+
+        // Document should be updated without any problem and without any authorization exception as there is no change in document.
+        $this->assertEquals(true, $updatedDocument->getUpdatedAt() > $document->getUpdatedAt());
+
+        return $document;
+    }
+
     public function testExceptionAttributeLimit(): void
     {
         if ($this->getDatabase()->getLimitForAttributes() > 0) {


### PR DESCRIPTION
We should not throw authorization exception when there is no change in update document coming document.
This is required for Relationships as we need to allow users to update document having related collection with no permission.

Part fix https://github.com/appwrite/appwrite/issues/5404