### PR TITLE
Fix 5871 relationships with non existing documents

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2999,8 +2999,8 @@ class Database
                                 $related = $this->getDocument($relatedCollection->getId(), $value);
                                 if ($related->isEmpty()) {
                                     // If no such document exists in related collection
-                                    // For one-one we need to update the related key to old value, either null if no relation exists or old related document id
-                                    $document->setAttribute($key, ($oldValue instanceof Document && !($oldValue->isEmpty()) ? $oldValue->getId() : null));
+                                    // For one-one we need to update the related key to null if no relation exists
+                                    $document->setAttribute($key, null);
                                 }
                             } elseif ($value instanceof Document) {
                                 $relationId = $this->relateDocuments(
@@ -3024,8 +3024,8 @@ class Database
                                 $related = $this->skipRelationships(fn () => $this->getDocument($relatedCollection->getId(), $value));
                                 if ($related->isEmpty()) {
                                     // If no such document exists in related collection
-                                    // For one-one we need to update the related key to old value, either null if no relation exists or old related document id
-                                    $document->setAttribute($key, ($oldValue instanceof Document && !($oldValue->isEmpty()) ? $oldValue->getId() : null));
+                                    // For one-one we need to update the related key to null if no relation exists
+                                    $document->setAttribute($key, null);
                                     break;
                                 }
                                 if (
@@ -3184,9 +3184,9 @@ class Database
                         if (\is_string($value)) {
                             $related = $this->getDocument($relatedCollection->getId(), $value);
                             if ($related->isEmpty()) {
-                                //If no such document exists in related collection
-                                //For one-one we need to update the related key to old value, either null if no relation exists or old related document id
-                                $document->setAttribute($key, ($oldValue instanceof Document && !($oldValue->isEmpty()) ? $oldValue->getId() : null));
+                                // If no such document exists in related collection
+                                // For many-one we need to update the related key to null if no relation exists
+                                $document->setAttribute($key, null);
                             }
                             $this->deleteCachedDocument($relatedCollection->getId(), $value);
                         } elseif ($value instanceof Document) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3177,6 +3177,12 @@ class Database
                         }
 
                         if (\is_string($value)) {
+                            $related = $this->getDocument($relatedCollection->getId(), $value);
+                            if ($related->isEmpty()) {
+                                //If no such document exists in related collection
+                                //For one-one we need to update the related key to old value, either null if no relation exists or old related document id
+                                $document->setAttribute($key, ($oldValue instanceof Document && !($oldValue->isEmpty()) ? $oldValue->getId() : null));
+                            }
                             $this->deleteCachedDocument($relatedCollection->getId(), $value);
                         } elseif ($value instanceof Document) {
                             $related = $this->getDocument($relatedCollection->getId(), $value->getId());

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3022,7 +3022,12 @@ class Database
                         switch (\gettype($value)) {
                             case 'string':
                                 $related = $this->skipRelationships(fn () => $this->getDocument($relatedCollection->getId(), $value));
-
+                                if ($related->isEmpty()) {
+                                    // If no such document exists in related collection
+                                    // For one-one we need to update the related key to old value, either null if no relation exists or old related document id
+                                    $document->setAttribute($key, ($oldValue instanceof Document && !($oldValue->isEmpty()) ? $oldValue->getId() : null));
+                                    break;
+                                }
                                 if (
                                     $oldValue?->getId() !== $value
                                     && $this->skipRelationships(fn () => $this->findOne($relatedCollection->getId(), [

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2998,8 +2998,8 @@ class Database
                             if (\is_string($value)) {
                                 $related = $this->getDocument($relatedCollection->getId(), $value);
                                 if ($related->isEmpty()) {
-                                    //If no such document exists in related collection
-                                    //For one-one we need to update the related key to old value, either null if no relation exists or old related document id
+                                    // If no such document exists in related collection
+                                    // For one-one we need to update the related key to old value, either null if no relation exists or old related document id
                                     $document->setAttribute($key, ($oldValue instanceof Document && !($oldValue->isEmpty()) ? $oldValue->getId() : null));
                                 }
                             } elseif ($value instanceof Document) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4097,9 +4097,9 @@ abstract class Base extends TestCase
 
         // Update a document with non existing related document. It should not get added to the list.
         static::getDatabase()->updateDocument(
-        'person', 
-        'person1', 
-        $person1->setAttribute('library', 'no-library')
+            'person',
+            'person1',
+            $person1->setAttribute('library', 'no-library')
         );
 
         $person1Document = static::getDatabase()->getDocument('person', 'person1');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4527,6 +4527,23 @@ abstract class Base extends TestCase
         $country1 = static::getDatabase()->getDocument('country', 'country1');
         $this->assertEquals('London', $country1->getAttribute('city')->getAttribute('name'));
 
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('country', 'country1', new Document([
+            '$id' => 'country1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'England',
+            '$collection' => 'country',
+            'city' => 'no-city'
+        ]));
+
+        $country1Document = static::getDatabase()->getDocument('country', 'country1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals('city1', $country1Document->getAttribute('city')->getAttribute('$id'));
+
         try {
             static::getDatabase()->deleteDocument('country', 'country1');
             $this->fail('Failed to throw exception');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4104,7 +4104,13 @@ abstract class Base extends TestCase
 
         $person1Document = static::getDatabase()->getDocument('person', 'person1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('null', $person1Document->getAttribute('library'));
+        $this->assertEquals(null, $person1Document->getAttribute('library'));
+
+        static::getDatabase()->updateDocument(
+            'person',
+            'person1',
+            $person1->setAttribute('library', 'library1')
+        );
 
         // Update through create
         $library10 = static::getDatabase()->createDocument('library', new Document([
@@ -4522,12 +4528,12 @@ abstract class Base extends TestCase
         $this->assertEquals('London', $country1->getAttribute('city')->getAttribute('name'));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('country', 'country1', $country1->setAttribute('city', 'no-city'));
+        static::getDatabase()->updateDocument('country', 'country1', $doc->setAttribute('city', 'no-city'));
 
         $country1Document = static::getDatabase()->getDocument('country', 'country1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('null', $country1Document->getAttribute('city'));
-
+        $this->assertEquals(null, $country1Document->getAttribute('city'));
+        static::getDatabase()->updateDocument('country', 'country1', $doc->setAttribute('city', 'city1'));
         try {
             static::getDatabase()->deleteDocument('country', 'country1');
             $this->fail('Failed to throw exception');
@@ -5154,7 +5160,7 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('artist', 'artist1', $artist1->setAttribute('albums', ['album1, no-album']));
+        static::getDatabase()->updateDocument('artist', 'artist1', $artist1->setAttribute('albums', ['album1', 'no-album']));
 
         $artist1Document = static::getDatabase()->getDocument('artist', 'artist1');
         // Assert document does not contain non existing relation document.
@@ -5992,7 +5998,9 @@ abstract class Base extends TestCase
 
         $review1Document = static::getDatabase()->getDocument('review', 'review1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('null', $review1Document->getAttribute('movie'));
+        $this->assertEquals(null, $review1Document->getAttribute('movie'));
+
+        static::getDatabase()->updateDocument('review', 'review1', $review1->setAttribute('movie', 'movie1'));
 
         // Create document with relationship to existing document by ID
         $review10 = static::getDatabase()->createDocument('review', new Document([
@@ -6326,7 +6334,9 @@ abstract class Base extends TestCase
 
         $product1Document = static::getDatabase()->getDocument('product', 'product1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('null', $product1Document->getAttribute('store'));
+        $this->assertEquals(null, $product1Document->getAttribute('store'));
+
+        static::getDatabase()->updateDocument('product', 'product1', $product1->setAttribute('store', 'store1'));
 
         // Create document with relationship with related ID
         static::getDatabase()->createDocument('store', new Document([

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4096,21 +4096,15 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('person', 'person1', new Document([
-            '$id' => 'person1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Person 1',
-            '$collection' => 'person',
-            'library' => 'no-library'
-        ]));
+        static::getDatabase()->updateDocument(
+        'person', 
+        'person1', 
+        $person1->setAttribute('library', 'no-library')
+        );
 
         $person1Document = static::getDatabase()->getDocument('person', 'person1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('library1', $person1Document->getAttribute('library')->getAttribute('$id'));
+        $this->assertEquals('null', $person1Document->getAttribute('library'));
 
         // Update through create
         $library10 = static::getDatabase()->createDocument('library', new Document([
@@ -4528,21 +4522,11 @@ abstract class Base extends TestCase
         $this->assertEquals('London', $country1->getAttribute('city')->getAttribute('name'));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('country', 'country1', new Document([
-            '$id' => 'country1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'England',
-            '$collection' => 'country',
-            'city' => 'no-city'
-        ]));
+        static::getDatabase()->updateDocument('country', 'country1', $country1->setAttribute('city', 'no-city'));
 
         $country1Document = static::getDatabase()->getDocument('country', 'country1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('city1', $country1Document->getAttribute('city')->getAttribute('$id'));
+        $this->assertEquals('null', $country1Document->getAttribute('city'));
 
         try {
             static::getDatabase()->deleteDocument('country', 'country1');
@@ -5170,20 +5154,7 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('artist', 'artist1', new Document([
-            '$id' => 'artist1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Artist 1',
-            '$collection' => 'artist',
-            'albums' => [
-                'album1',
-                'no-album'
-            ]
-        ]));
+        static::getDatabase()->updateDocument('artist', 'artist1', $artist1->setAttribute('albums', ['album1, no-album']));
 
         $artist1Document = static::getDatabase()->getDocument('artist', 'artist1');
         // Assert document does not contain non existing relation document.
@@ -5569,20 +5540,7 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('customer', 'customer1', new Document([
-            '$id' => 'customer1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Customer 1',
-            '$collection' => 'customer',
-            'accounts' => [
-                'account1',
-                'no-account'
-            ]
-        ]));
+        static::getDatabase()->updateDocument('customer', 'customer1', $customer1->setAttribute('accounts', ['account1','no-account']));
 
         $customer1Document = static::getDatabase()->getDocument('customer', 'customer1');
         // Assert document does not contain non existing relation document.
@@ -6030,21 +5988,11 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('review', 'review1', new Document([
-            '$id' => 'review1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Review 1',
-            '$collection' => 'review',
-            'movie' => 'no-movie'
-        ]));
+        static::getDatabase()->updateDocument('review', 'review1', $review1->setAttribute('movie', 'no-movie'));
 
         $review1Document = static::getDatabase()->getDocument('review', 'review1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('movie1', $review1Document->getAttribute('movie')->getAttribute('$id'));
+        $this->assertEquals('null', $review1Document->getAttribute('movie'));
 
         // Create document with relationship to existing document by ID
         $review10 = static::getDatabase()->createDocument('review', new Document([
@@ -6374,21 +6322,11 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('product', 'product1', new Document([
-            '$id' => 'product1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Product 1',
-            '$collection' => 'product',
-            'store' => 'no-store'
-        ]));
+        static::getDatabase()->updateDocument('product', 'product1', $product1->setAttribute('store', 'no-store'));
 
         $product1Document = static::getDatabase()->getDocument('product', 'product1');
         // Assert document does not contain non existing relation document.
-        $this->assertEquals('store1', $product1Document->getAttribute('store')->getAttribute('$id'));
+        $this->assertEquals('null', $product1Document->getAttribute('store'));
 
         // Create document with relationship with related ID
         static::getDatabase()->createDocument('store', new Document([
@@ -6851,20 +6789,7 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('playlist', 'playlist1', new Document([
-            '$id' => 'playlist1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Playlist 1',
-            '$collection' => 'playlist',
-            'songs' => [
-                'song1',
-                'no-song'
-            ]
-        ]));
+        static::getDatabase()->updateDocument('playlist', 'playlist1', $playlist1->setAttribute('songs', ['song1','no-song']));
 
         $playlist1Document = static::getDatabase()->getDocument('playlist', 'playlist1');
         // Assert document does not contain non existing relation document.
@@ -7162,20 +7087,7 @@ abstract class Base extends TestCase
         ]));
 
         // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('students', 'student1', new Document([
-            '$id' => 'student1',
-            '$permissions' => [
-                Permission::read(Role::any()),
-                Permission::update(Role::any()),
-                Permission::delete(Role::any()),
-            ],
-            'name' => 'Student 1',
-            '$collection' => 'students',
-            'classes' => [
-                'class1',
-                'no-class'
-            ]
-        ]));
+        static::getDatabase()->updateDocument('students', 'student1', $student1->setAttribute('classes', ['class1', 'no-class']));
 
         $student1Document = static::getDatabase()->getDocument('students', 'student1');
         // Assert document does not contain non existing relation document.

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4095,6 +4095,23 @@ abstract class Base extends TestCase
             ],
         ]));
 
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('person', 'person1', new Document([
+            '$id' => 'person1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Person 1',
+            '$collection' => 'person',
+            'library' => 'no-library'
+        ]));
+
+        $person1Document = static::getDatabase()->getDocument('person', 'person1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals('library1', $person1Document->getAttribute('library')->getAttribute('$id'));
+
         // Update through create
         $library10 = static::getDatabase()->createDocument('library', new Document([
             '$id' => 'library10',
@@ -5135,6 +5152,26 @@ abstract class Base extends TestCase
             ],
         ]));
 
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('artist', 'artist1', new Document([
+            '$id' => 'artist1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Artist 1',
+            '$collection' => 'artist',
+            'albums' => [
+                'album1',
+                'no-album'
+            ]
+        ]));
+
+        $artist1Document = static::getDatabase()->getDocument('artist', 'artist1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals(1, \count($artist1Document->getAttribute('albums')));
+
         // Create document with relationship with related ID
         static::getDatabase()->createDocument('album', new Document([
             '$id' => 'album2',
@@ -5513,6 +5550,27 @@ abstract class Base extends TestCase
                 ],
             ],
         ]));
+
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('customer', 'customer1', new Document([
+            '$id' => 'customer1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Customer 1',
+            '$collection' => 'customer',
+            'accounts' => [
+                'account1',
+                'no-account'
+            ]
+        ]));
+
+        $customer1Document = static::getDatabase()->getDocument('customer', 'customer1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals(1, \count($customer1Document->getAttribute('accounts')));
+
         // Create document with relationship with related ID
         $account2 = static::getDatabase()->createDocument('account', new Document([
             '$id' => 'account2',
@@ -5954,6 +6012,23 @@ abstract class Base extends TestCase
             ],
         ]));
 
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('review', 'review1', new Document([
+            '$id' => 'review1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Review 1',
+            '$collection' => 'review',
+            'movie' => 'no-movie'
+        ]));
+
+        $review1Document = static::getDatabase()->getDocument('review', 'review1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals('movie1', $review1Document->getAttribute('movie')->getAttribute('$id'));
+
         // Create document with relationship to existing document by ID
         $review10 = static::getDatabase()->createDocument('review', new Document([
             '$id' => 'review10',
@@ -6280,6 +6355,23 @@ abstract class Base extends TestCase
                 'opensAt' => '09:00',
             ],
         ]));
+
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('product', 'product1', new Document([
+            '$id' => 'product1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Product 1',
+            '$collection' => 'product',
+            'store' => 'no-store'
+        ]));
+
+        $product1Document = static::getDatabase()->getDocument('product', 'product1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals('store1', $product1Document->getAttribute('store')->getAttribute('$id'));
 
         // Create document with relationship with related ID
         static::getDatabase()->createDocument('store', new Document([
@@ -6741,6 +6833,26 @@ abstract class Base extends TestCase
             ]
         ]));
 
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('playlist', 'playlist1', new Document([
+            '$id' => 'playlist1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Playlist 1',
+            '$collection' => 'playlist',
+            'songs' => [
+                'song1',
+                'no-song'
+            ]
+        ]));
+
+        $playlist1Document = static::getDatabase()->getDocument('playlist', 'playlist1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals(1, \count($playlist1Document->getAttribute('songs')));
+
         $documents = static::getDatabase()->find('playlist', [
             Query::select(['name']),
             Query::limit(1)
@@ -7031,6 +7143,26 @@ abstract class Base extends TestCase
                 ],
             ],
         ]));
+
+        // Update a document with non existing related document. It should not get added to the list.
+        static::getDatabase()->updateDocument('students', 'student1', new Document([
+            '$id' => 'student1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Student 1',
+            '$collection' => 'students',
+            'classes' => [
+                'class1',
+                'no-class'
+            ]
+        ]));
+
+        $student1Document = static::getDatabase()->getDocument('students', 'student1');
+        // Assert document does not contain non existing relation document.
+        $this->assertEquals(1, \count($student1Document->getAttribute('classes')));
 
         // Create document with relationship with related ID
         static::getDatabase()->createDocument('classes', new Document([


### PR DESCRIPTION
This PR fixes bug in multiple relationships 
- One to One One way
- One to One Two way (Bug was not reproducible but for consistency added code as well)
- One to Many One Way and Two way
- Many to One one way and two way 
- Many to many one way and two way
Fixes https://github.com/appwrite/appwrite/issues/5871

Previously we were getting 500 for one to one two way as the non existing doc needs to be updated in One to One two-way relationship type and non existing doc does not have key.
 Now we are keeping it consistent with other relationship types and skipping non existing doc