### PR TITLE
Fix crud operations permission in update relationships

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2885,10 +2885,6 @@ class Database
             return $attribute['type'] === Database::VAR_RELATIONSHIP;
         });
 
-        $relationships = \array_filter($collection->getAttribute('attributes', []), function ($attribute) {
-            return $attribute['type'] === Database::VAR_RELATIONSHIP;
-        });
-
         $validator = new Authorization(self::PERMISSION_UPDATE);
         $shouldUpdate = false;
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2911,7 +2911,7 @@ class Database
                     // Skip the nested documents as they will be checked later in recursions.
                     if ($oldAttributeValue instanceof Document) {
                         continue;
-                    } elseif (\is_array($oldAttributeValue) && \is_array($value) && !($value instanceof Document)) {
+                    } elseif (\is_array($oldAttributeValue) && \is_array($value)) {
                         if ($compareChanges($value, $oldAttributeValue)) {
                             $isDifferent = true;
                         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3285,12 +3285,11 @@ class Database
                                             $relation->setAttribute($twoWayKey, $document->getId())
                                         );
                                     } else {
-                                        // We need to skip the relationship when updating document so that comparison check does not fail
-                                        $this->skipRelationships(fn () => $this->updateDocument(
+                                        $this->updateDocument(
                                             $relatedCollection->getId(),
                                             $related->getId(),
                                             $relation->setAttribute($twoWayKey, $document->getId())
-                                        ));
+                                        );
                                     }
                                 } else {
                                     throw new DatabaseException('Invalid value for relationship');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -11870,39 +11870,35 @@ abstract class Base extends TestCase
             collection: 'parentRelationTest',
             relatedCollection: 'childRelationTest',
             type: Database::RELATION_ONE_TO_MANY,
-            id: 'childs'
+            id: 'children'
         );
 
         // Create document with relationship with nested data
         $parent = static::getDatabase()->createDocument('parentRelationTest', new Document([
             '$id' => 'parent1',
             'name' => 'Parent 1',
-            'childs' => [
+            'children' => [
                 [
                     '$id' => 'child1',
                     'name' => 'Child 1',
                 ],
             ],
         ]));
-        $this->assertEquals(1, \count($parent['childs']));
-        $updatedParent = static::getDatabase()->updateDocument('parentRelationTest', 'parent1', new Document([
-            '$id' => 'parent1',
-            'name'=>'Parent 1',
-            '$collection' => 'parentRelationTest',
-            'childs' => [
-                new Document([
-                    '$id' => 'child1',
-                    '$collection' => 'childRelationTest'
-                ]),
-                new Document([
-                    '$id' => 'child2',
-                    'name' => 'Child 2',
-                    '$collection' => 'childRelationTest'
-                ]),
-            ]
-        ]));
+        $doc =  static::getDatabase()->skipRelationships(
+            fn () => static::getDatabase()->getDocument('childRelationTest', 'child1')
+        );
+        $this->assertEquals(1, \count($parent['children']));
+        $parent->setAttribute('children', [
+            [
+                '$id' => 'child1',
+            ],
+            [
+                '$id' => 'child2',
+            ],
+        ]);
+        $updatedParent = static::getDatabase()->updateDocument('parentRelationTest', 'parent1', $parent);
 
-        $this->assertEquals(2, \count($updatedParent['childs']));
+        $this->assertEquals(2, \count($updatedParent['children']));
 
         static::getDatabase()->deleteCollection('parentRelationTest');
         static::getDatabase()->deleteCollection('childRelationTest');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -11884,21 +11884,15 @@ abstract class Base extends TestCase
                 ],
             ],
         ]));
-        $doc =  static::getDatabase()->skipRelationships(
-            fn () => static::getDatabase()->getDocument('childRelationTest', 'child1')
-        );
-        $this->assertEquals(1, \count($parent['children']));
+        $this->assertEquals('child1', $parent->getAttribute('children')[0]->getId());
         $parent->setAttribute('children', [
-            [
-                '$id' => 'child1',
-            ],
             [
                 '$id' => 'child2',
             ],
         ]);
         $updatedParent = static::getDatabase()->updateDocument('parentRelationTest', 'parent1', $parent);
 
-        $this->assertEquals(2, \count($updatedParent['children']));
+        $this->assertEquals('child2', $updatedParent->getAttribute('children')[0]->getId());
 
         static::getDatabase()->deleteCollection('parentRelationTest');
         static::getDatabase()->deleteCollection('childRelationTest');


### PR DESCRIPTION
- Skipping authorization for crud operations which are integral parts of logic but not done by the user
- Added a test case.