### PR TITLE
Fallback to $id  when validating select queries

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4515,7 +4515,8 @@ class Database
         $keys = [];
         foreach ($collection->getAttribute('attributes', []) as $attribute) {
             if ($attribute['type'] !== self::VAR_RELATIONSHIP) {
-                $keys[] = $attribute['key'];
+                // Fallback to $id when key property is not present in metadata table for some tables such as Indexes or Attributes
+                $keys[] = $attribute['key'] ?? $attribute['$id'];
             }
         }
 


### PR DESCRIPTION
Metadata tables for indexes and attributes does not have key property so select queries cannot be validated. We need to fallback on  when key property is not present in such cases. This commit fixes that. 
Here's a discussion with Jake on this 
https://github.com/appwrite/appwrite/pull/5885#discussion_r1282509448