### PR TITLE
add checking of nested docs id in comparison check when updating document

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2930,7 +2930,7 @@ class Database
                     $relationType = (string) $relationships[$key]['options']['relationType'];
                     $side = (string) $relationships[$key]['options']['side'];
                     switch($relationType) {
-                        case DATABASE::RELATION_ONE_TO_ONE: {
+                        case Database::RELATION_ONE_TO_ONE: {
                             $oldValue = $old->getAttribute($key) instanceof Document ? $old->getAttribute($key)->getId() : $old->getAttribute($key);
                             if (
                                 (\is_null($old->getAttribute($key)) && !\is_null($value)) ||
@@ -2952,8 +2952,8 @@ class Database
                         case Database::RELATION_ONE_TO_MANY:
                             {
                                 if (
-                                    ($side === DATABASE::RELATION_SIDE_PARENT && $relationType === Database::RELATION_MANY_TO_ONE) ||
-                                    ($side === DATABASE::RELATION_SIDE_CHILD && $relationType === Database::RELATION_ONE_TO_MANY)
+                                    ($side === Database::RELATION_SIDE_PARENT && $relationType === Database::RELATION_MANY_TO_ONE) ||
+                                    ($side === Database::RELATION_SIDE_CHILD && $relationType === Database::RELATION_ONE_TO_MANY)
                                 ) {
                                     if (
                                         (\is_null($old->getAttribute($key)) && !\is_null($value)) ||

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3292,10 +3292,7 @@ abstract class Base extends TestCase
             'name'=>'Parent 1',
             '$collection' => 'parentRelationTest',
             'childs' => [
-                new Document([
-                    '$id' => 'child1',
-                    '$collection' => 'childRelationTest'
-                ]),
+                'child1',
             ]
         ]));
 
@@ -11588,7 +11585,6 @@ abstract class Base extends TestCase
 
         Authorization::cleanRoles();
         Authorization::setRole(Role::users()->toString());
-
         static::getDatabase()->updateDocument(
             $collection->getId(),
             $document->getId(),


### PR DESCRIPTION
This PR checks the nested docs id to the old doc nested docs. 
For example:

If document A is related to document B but we do not have permission to access it, we can still establish a relationship between document A and a different version of document B (let's call it B1). This is because we compare B to its previous version, and B1 to its previous version as well. If there are no changes in B1, then we do not need permission to relate it to document A.