### PR TITLE
Fix `isEmpty` returning true if $id is not selected

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2238,11 +2238,12 @@ class Database
         }
 
         $document = $this->adapter->getDocument($collection->getId(), $id, $queries);
-        $document->setAttribute('$collection', $collection->getId());
 
         if ($document->isEmpty()) {
             return $document;
         }
+
+        $document->setAttribute('$collection', $collection->getId());
 
         if ($collection->getId() !== self::METADATA) {
             if (!$validator->isValid([
@@ -4072,7 +4073,10 @@ class Database
             }
             $node = $this->casting($collection, $node);
             $node = $this->decode($collection, $node, $selections);
-            $node->setAttribute('$collection', $collection->getId());
+
+            if (!$node->isEmpty()) {
+                $node->setAttribute('$collection', $collection->getId());
+            }
         }
 
         $results = $this->applyNestedQueries($results, $nestedQueries, $relationships);

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -371,7 +371,7 @@ class Document extends ArrayObject
      */
     public function isEmpty(): bool
     {
-        return empty($this->getId());
+        return !\count($this);
     }
 
     /**

--- a/tests/Database/Adapter/MariaDBTest.php
+++ b/tests/Database/Adapter/MariaDBTest.php
@@ -58,9 +58,4 @@ class MariaDBTest extends Base
 
         return self::$database = $database;
     }
-
-    public static function killDatabase(): void
-    {
-        self::$database = null;
-    }
 }

--- a/tests/Database/Adapter/MongoDBTest.php
+++ b/tests/Database/Adapter/MongoDBTest.php
@@ -95,9 +95,4 @@ class MongoDBTest extends Base
     {
         $this->assertTrue(true);
     }
-
-    public static function killDatabase(): void
-    {
-        self::$database = null;
-    }
 }

--- a/tests/Database/Adapter/MySQLTest.php
+++ b/tests/Database/Adapter/MySQLTest.php
@@ -69,9 +69,4 @@ class MySQLTest extends Base
 
         return self::$database = $database;
     }
-
-    public static function killDatabase(): void
-    {
-        self::$database = null;
-    }
 }

--- a/tests/Database/Adapter/PostgresTest.php
+++ b/tests/Database/Adapter/PostgresTest.php
@@ -56,9 +56,4 @@ class PostgresTest extends Base
 
         return self::$database = $database;
     }
-
-    public static function killDatabase(): void
-    {
-        self::$database = null;
-    }
 }

--- a/tests/Database/Adapter/SQLiteTest.php
+++ b/tests/Database/Adapter/SQLiteTest.php
@@ -66,9 +66,4 @@ class SQLiteTest extends Base
 
         return self::$database = $database;
     }
-
-    public static function killDatabase(): void
-    {
-        self::$database = null;
-    }
 }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -35,8 +35,6 @@ abstract class Base extends TestCase
      */
     abstract protected static function getDatabase(): Database;
 
-    abstract protected static function killDatabase(): void;
-
     /**
      * @return string
      */
@@ -1056,7 +1054,8 @@ abstract class Base extends TestCase
             Query::select(['string', 'integer']),
         ]);
 
-        $this->assertNotEmpty(true, $document->getId());
+        $this->assertEmpty($document->getId());
+        $this->assertFalse($document->isEmpty());
         $this->assertIsString($document->getAttribute('string'));
         $this->assertEquals('text📝', $document->getAttribute('string'));
         $this->assertIsInt($document->getAttribute('integer'));
@@ -11691,6 +11690,89 @@ abstract class Base extends TestCase
         $this->assertCount(1, $documents);
     }
 
+    public function testEmptyOperatorValues(): void
+    {
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::equal('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Equal queries require at least one value.', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::search('string', null),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::notEqual('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::lessThan('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::lessThanEqual('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::greaterThan('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::greaterThanEqual('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
+        }
+
+        try {
+            static::getDatabase()->findOne('documents', [
+                Query::contains('string', []),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals('Invalid query: Contains queries require at least one value.', $e->getMessage());
+        }
+    }
+
     public function testEvents(): void
     {
         Authorization::skip(function () {
@@ -11781,94 +11863,5 @@ abstract class Base extends TestCase
             $database->deleteCollection($collectionId);
             $database->delete('hellodb');
         });
-    }
-
-    public function testEmptyOperatorValues(): void
-    {
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::equal('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Equal queries require at least one value.', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::search('string', null),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::notEqual('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::lessThan('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::lessThanEqual('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::greaterThan('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::greaterThanEqual('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Query type does not match expected: string', $e->getMessage());
-        }
-
-        try {
-            static::getDatabase()->findOne('documents', [
-                Query::contains('string', []),
-            ]);
-            $this->fail('Failed to throw exception');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals('Invalid query: Contains queries require at least one value.', $e->getMessage());
-        }
-    }
-
-    public function testLast(): void
-    {
-        $this->expectNotToPerformAssertions();
-        static::killDatabase();
     }
 }


### PR DESCRIPTION
Now that select queries do not automatically select internal attributes, a call to `$document->isEmpty()` will return true if using a select query and `$id` was not selected. 

This PR changes the empty check to check if the document has _any_ values set instead of only checking if `$id` is set.