### PR TITLE
fixes edge case in comparison check

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2940,6 +2940,10 @@ class Database
             foreach ($document as $key => $value) {
                 // Skip the nested documents as they will be checked later in recursions.
                 if (\array_key_exists($key, $relationships)) {
+                    // No need to compare nested documents more than max depth.
+                    if (count($this->relationshipWriteStack) >= Database::RELATION_MAX_DEPTH - 1) {
+                        continue;
+                    }
                     $relationType = (string) $relationships[$key]['options']['relationType'];
                     $side = (string) $relationships[$key]['options']['side'];
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3369,7 +3369,7 @@ abstract class Base extends TestCase
                 'level3' => [
                     '$id' => 'level3',
                     '$permissions' => [],
-                    'name' => 'Level haha',
+                    'name' => 'Level 3',
                     'level4' => [
                         '$id' => 'level4',
                         '$permissions' => [],

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3342,11 +3342,11 @@ abstract class Base extends TestCase
             Permission::create(Role::any()),
             Permission::delete(Role::any()),
         ];
-        for($i=1; $i < 6; $i++){
+        for ($i=1; $i < 6; $i++) {
             static::getDatabase()->createCollection("level{$i}", [$attribute], [], $permission);
         }
 
-        for($i = 1; $i < 5; $i++){
+        for ($i = 1; $i < 5; $i++) {
             $collectionId = $i;
             $relatedCollectionId = $i+1;
             static::getDatabase()->createRelationship(
@@ -3382,13 +3382,13 @@ abstract class Base extends TestCase
                                             '$id' => 'level5',
                                             '$permissions' => [],
                                             'name' => 'Level 5',
-                                            
+
                                         ],
                                     ],
-                                    
+
                                 ],
                             ],
-                            
+
                         ],
                     ],
                 ],
@@ -3396,15 +3396,15 @@ abstract class Base extends TestCase
         ]));
 
         $this->assertEquals(1, \count($level1['level2']));
-        
+
         $updateLevel1 = static::getDatabase()->updateDocument('level1', 'level1', $level1);
-        
+
         $this->assertEquals($level1, $updateLevel1);
-        
+
         $this->expectException(AuthorizationException::class);
         static::getDatabase()->updateDocument('level1', 'level1', $level1->setAttribute('name', 'haha'));
 
-        for($i=1; $i < 6; $i++){
+        for ($i=1; $i < 6; $i++) {
             static::getDatabase()->deleteCollection("level{$i}");
         }
     }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -3382,7 +3382,7 @@ abstract class Base extends TestCase
                     ],
                 ],
             ],
-        ]));        
+        ]));
         static::getDatabase()->updateDocument('level1', $level1->getId(), new Document($level1->getArrayCopy()));
         $updatedLevel1 = static::getDatabase()->getDocument('level1', $level1->getId());
         $this->assertEquals($level1, $updatedLevel1);
@@ -3393,7 +3393,7 @@ abstract class Base extends TestCase
         } catch(Exception $e) {
             $this->assertInstanceOf(AuthorizationException::class, $e);
         }
-        $level1->setAttribute('name','Level 1');
+        $level1->setAttribute('name', 'Level 1');
         static::getDatabase()->updateCollection('level3', [
             Permission::read(Role::any()),
             Permission::create(Role::any()),
@@ -3407,7 +3407,7 @@ abstract class Base extends TestCase
         $level2->setAttribute('level3', $level3);
         $level1->setAttribute('level2', $level2);
 
-        $level1 = static::getDatabase()->updateDocument('level1', $level1->getId(), $level1);        
+        $level1 = static::getDatabase()->updateDocument('level1', $level1->getId(), $level1);
         $this->assertEquals('updated value', $level1['level2']['level3']['name']);
 
         for ($i=1; $i < 6; $i++) {


### PR DESCRIPTION
This PR fixes the edge case of comparing nested doc ID only if the nested level is less than MAX DEPTH allowed. 