### PR TITLE
Add test for invalid keys

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2923,7 +2923,7 @@ class Database
         $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
         $document['$collection'] = $old->getAttribute('$collection'); // Make sure user doesn't switch collectionID
         $document['$createdAt'] = $old->getCreatedAt();        // Make sure user doesn't switch createdAt
-        $document['$id'] = $old->getId();    
+        $document['$id'] = $old->getId();
         $document = new Document($document);
 
         $collection = $this->silent(fn () => $this->getCollection($collection));

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2920,6 +2920,11 @@ class Database
 
         $time = DateTime::now();
         $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+        $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
+        $document['$collection'] = $old->getAttribute('$collection'); // Make sure user doesn't switch collectionID
+        $document['$createdAt'] = $old->getCreatedAt();        // Make sure user doesn't switch createdAt
+        $document['$id'] = $old->getId();    
+        $document = new Document($document);
 
         $collection = $this->silent(fn () => $this->getCollection($collection));
         $relationships = \array_filter($collection->getAttribute('attributes', []), function ($attribute) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4481,7 +4481,7 @@ abstract class Base extends TestCase
             ]
         ]));
         $updatedSpecies = static::getDatabase()->getDocument('species', $species->getId());
-        $this->assertEquals($species, $updatedSpecies);    
+        $this->assertEquals($species, $updatedSpecies);
     }
 
     // Relationships
@@ -4986,7 +4986,8 @@ abstract class Base extends TestCase
         $country1Document = static::getDatabase()->getDocument('country', 'country1');
         // Assert document does not contain non existing relation document.
         $this->assertEquals(null, $country1Document->getAttribute('city'));
-        static::getDatabase()->updateDocument('country', 'country1', (new Document($doc->getArrayCopy()))->setAttribute('city','city1'));        try {
+        static::getDatabase()->updateDocument('country', 'country1', (new Document($doc->getArrayCopy()))->setAttribute('city', 'city1'));
+        try {
             static::getDatabase()->deleteDocument('country', 'country1');
             $this->fail('Failed to throw exception');
         } catch (Exception $e) {

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -4981,6 +4981,7 @@ abstract class Base extends TestCase
         $country1 = static::getDatabase()->getDocument('country', 'country1');
         $this->assertEquals('London', $country1->getAttribute('city')->getAttribute('name'));
 
+        // Update a document with non existing related document. It should not get added to the list.
         static::getDatabase()->updateDocument('country', 'country1', (new Document($doc->getArrayCopy()))->setAttribute('city', 'no-city'));
 
         $country1Document = static::getDatabase()->getDocument('country', 'country1');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -23,7 +23,6 @@ use Utopia\Database\Helpers\Role;
 use Utopia\Database\Validator\Authorization;
 use Utopia\Database\Validator\Datetime as DatetimeValidator;
 use Utopia\Database\Validator\Index;
-use Utopia\Database\Validator\Query\Filter;
 use Utopia\Database\Validator\Structure;
 use Utopia\Validator\Range;
 use Utopia\Database\Exception\Structure as StructureException;
@@ -4415,45 +4414,74 @@ abstract class Base extends TestCase
         $this->assertEquals('newCat', $docs[0]['type']);
     }
 
-    public function testNoInvalidKeys(): void
+    public function testNoInvalidKeysWithRelationships(): void
     {
+        if (!static::getDatabase()->getAdapter()->getSupportForRelationships()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
         static::getDatabase()->createCollection('species');
-        static::getDatabase()->createCollection('animals');
+        static::getDatabase()->createCollection('creatures');
+        static::getDatabase()->createCollection('characterstics');
 
         static::getDatabase()->createAttribute('species', 'name', Database::VAR_STRING, 255, true);
-        static::getDatabase()->createAttribute('animals', 'name', Database::VAR_STRING, 255, true);
+        static::getDatabase()->createAttribute('creatures', 'name', Database::VAR_STRING, 255, true);
+        static::getDatabase()->createAttribute('characterstics', 'name', Database::VAR_STRING, 255, true);
 
         static::getDatabase()->createRelationship(
             collection: 'species',
-            relatedCollection: 'animals',
+            relatedCollection: 'creatures',
             type: Database::RELATION_ONE_TO_ONE,
             twoWay: true,
-            id: 'animal',
+            id: 'creature',
+            twoWayKey:'species'
+        );
+        static::getDatabase()->createRelationship(
+            collection: 'creatures',
+            relatedCollection: 'characterstics',
+            type: Database::RELATION_ONE_TO_ONE,
+            twoWay: true,
+            id: 'characterstic',
+            twoWayKey:'creature'
         );
 
         $species = static::getDatabase()->createDocument('species', new Document([
-            '$id' => ID::unique(),
+            '$id' => ID::custom('1'),
             '$permissions' => [
                 Permission::read(Role::any()),
-                Permission::update(Role::any()),
             ],
             'name' => 'Canine',
-            'animal' => [
-                '$id' => ID::unique(),
+            'creature' => [
+                '$id' => ID::custom('1'),
                 '$permissions' => [
                     Permission::read(Role::any()),
                 ],
                 'name' => 'Dog',
+                'characterstic' => [
+                    '$id' => ID::custom('1'),
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                    ],
+                    'name' => 'active',
+                ]
             ]
         ]));
-
-        $this->assertEquals('', $species->getAttribute('animal')->getAttribute('_createdAt', ''));
-        $this->assertEquals('', $species->getAttribute('animal')->getAttribute('_updatedAt', ''));
-
-        $species = static::getDatabase()->updateDocument('species', $species->getId(), $species->setAttribute('name', 'Tiger'));
-
-        $this->assertEquals('', $species->getAttribute('animal')->getAttribute('_createdAt', ''));
-        $this->assertEquals('', $species->getAttribute('animal')->getAttribute('_updatedAt', ''));
+        static::getDatabase()->updateDocument('species', $species->getId(), new Document([
+            '$id' => ID::custom('1'),
+            '$collection' => 'species',
+            'creature' => [
+                '$id' => ID::custom('1'),
+                '$collection' => 'creatures',
+                'characterstic' => [
+                    '$id' => ID::custom('1'),
+                    'name' => 'active',
+                    '$collection' => 'characterstics',
+                ]
+            ]
+        ]));
+        $updatedSpecies = static::getDatabase()->getDocument('species', $species->getId());
+        $this->assertEquals($species, $updatedSpecies);    
     }
 
     // Relationships
@@ -4953,14 +4981,12 @@ abstract class Base extends TestCase
         $country1 = static::getDatabase()->getDocument('country', 'country1');
         $this->assertEquals('London', $country1->getAttribute('city')->getAttribute('name'));
 
-        // Update a document with non existing related document. It should not get added to the list.
-        static::getDatabase()->updateDocument('country', 'country1', $doc->setAttribute('city', 'no-city'));
+        static::getDatabase()->updateDocument('country', 'country1', (new Document($doc->getArrayCopy()))->setAttribute('city', 'no-city'));
 
         $country1Document = static::getDatabase()->getDocument('country', 'country1');
         // Assert document does not contain non existing relation document.
         $this->assertEquals(null, $country1Document->getAttribute('city'));
-        static::getDatabase()->updateDocument('country', 'country1', $doc->setAttribute('city', 'city1'));
-        try {
+        static::getDatabase()->updateDocument('country', 'country1', (new Document($doc->getArrayCopy()))->setAttribute('city','city1'));        try {
             static::getDatabase()->deleteDocument('country', 'country1');
             $this->fail('Failed to throw exception');
         } catch (Exception $e) {


### PR DESCRIPTION
Previously with partial updates we were not merging missing keys which was causing weird problems like createdAt and updatedAt being null. 

This PR fixes that