### PR TITLE
Fix throwing global exception instead of database exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     },
     "require": {
         "ext-pdo": "*",
+        "ext-mbstring": "*",
         "php": ">=8.0",
         "utopia-php/framework": "0.*.*",
         "utopia-php/cache": "0.8.*",

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -671,7 +671,7 @@ abstract class Adapter
     public static function setTimeout(int $milliseconds): void
     {
         if ($milliseconds <= 0) {
-            throw new Exception('Timeout must be greater than 0');
+            throw new DatabaseException('Timeout must be greater than 0');
         }
         self::$timeout = $milliseconds;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2180,7 +2180,7 @@ class Database
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         if ($collection->isEmpty()) {
-            throw new DatabaseException("Collection not found");
+            throw new DatabaseException('Collection not found');
         }
 
         $attributes = $collection->getAttribute('attributes', []);
@@ -4242,7 +4242,6 @@ class Database
 
         $queries = Query::groupByType($queries)['filters'];
         $queries = self::convertQueries($collection, $queries);
-
 
         $getCount = fn () => $this->adapter->count($collection->getId(), $queries, $max);
         $count = $skipAuth ?? false ? Authorization::skip($getCount) : $getCount();

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4046,7 +4046,7 @@ class Database
 
         $validator = new Documents($attributes, $indexes);
         if (!$validator->isValid($queries)) {
-            throw new Exception($validator->getDescription());
+            throw new DatabaseException($validator->getDescription());
         }
 
         $authorization = new Authorization(self::PERMISSION_READ);

--- a/src/Database/Exception/Query.php
+++ b/src/Database/Exception/Query.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Utopia\Database\Exception;
+
+use Utopia\Database\Exception;
+
+class Query extends Exception
+{
+}

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -3,6 +3,7 @@
 namespace Utopia\Database;
 
 use Utopia\Database\Exception as DatabaseException;
+use Utopia\Database\Exception\Query as QueryException;
 
 class Query
 {
@@ -200,7 +201,7 @@ class Query
         $paramsStart = mb_strpos($filter, static::CHAR_PARENTHESES_START);
 
         if ($paramsStart === false) {
-            throw new DatabaseException("Invalid query");
+            throw new QueryException("Invalid query");
         }
 
         $method = mb_substr($filter, 0, $paramsStart);
@@ -211,7 +212,7 @@ class Query
 
         // Check for deprecated query syntax
         if (\str_contains($method, '.')) {
-            throw new DatabaseException("Invalid query method");
+            throw new QueryException("Invalid query method");
         }
 
         $currentParam = ""; // We build param here before pushing when it's ended
@@ -822,7 +823,7 @@ class Query
             try {
                 $parsed[] = Query::parse($query);
             } catch (\Throwable $th) {
-                throw new DatabaseException("Invalid query: ${query}", previous: $th);
+                throw new QueryException("Invalid query: ${query}", previous: $th);
             }
         }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -2,7 +2,6 @@
 
 namespace Utopia\Database;
 
-use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Exception\Query as QueryException;
 
 class Query

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -200,7 +200,7 @@ class Query
         $paramsStart = mb_strpos($filter, static::CHAR_PARENTHESES_START);
 
         if ($paramsStart === false) {
-            throw new QueryException("Invalid query");
+            throw new QueryException('Invalid query');
         }
 
         $method = mb_substr($filter, 0, $paramsStart);
@@ -211,7 +211,7 @@ class Query
 
         // Check for deprecated query syntax
         if (\str_contains($method, '.')) {
-            throw new QueryException("Invalid query method");
+            throw new QueryException('Invalid query method');
         }
 
         $currentParam = ""; // We build param here before pushing when it's ended


### PR DESCRIPTION
- Fix throwing global exception instead of database exception in some cases
- Add query exception so that query specific exceptions can be caught since validation happens in the library now