### PR TITLE
Clone queries when grouping/getting by type so that mutations are not made across references

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -706,7 +706,7 @@ class Query
         $filtered = [];
         foreach ($queries as $query) {
             if (in_array($query->getMethod(), $types, true)) {
-                $filtered[] = $query;
+                $filtered[] = clone $query;
             }
         }
 
@@ -786,11 +786,11 @@ class Query
                     break;
 
                 case Query::TYPE_SELECT:
-                    $selections[] = $query;
+                    $selections[] = clone $query;
                     break;
 
                 default:
-                    $filters[] = $query;
+                    $filters[] = clone $query;
                     break;
             }
         }


### PR DESCRIPTION
E.g. Currently:

```php
$queries = [Query::equal('$id', ['123']];
$filters = Query::groupByType()['filters'];

// Changing the attribute of the query in the original array
$queries[0]->setAttribute('_uid');

// Will change the attribute of the query returned by the `groupByType` method, which is unexpected
$filters[0]->getAttribute() === '_uid'
```

This is an issue from Appwrite because we mutate query attributes in the `find` function and then pass the same query references to the `count` function, which means the values are already mutated. Cloning the queries fixes the issue because changes to one array will not affect the other.