### PR TITLE
Remove postgresql-dev since it's not needed after pdo_pgsql is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN \
   apk update \
   && apk add --no-cache postgresql-libs postgresql-dev make automake autoconf gcc g++ git brotli-dev \
   && docker-php-ext-install opcache pgsql pdo_mysql pdo_pgsql \
+  && apk del postgresql-dev \
   && rm -rf /var/cache/apk/*
 
 # Redis Extension


### PR DESCRIPTION
This cuts the size of the layer (and image) by about 250MB.