### PR TITLE
fetchAll getDocument

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -839,16 +839,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.35",
+            "version": "1.10.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e730e5facb75ffe09dfb229795e8c01a459f26c3"
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e730e5facb75ffe09dfb229795e8c01a459f26c3",
-                "reference": "e730e5facb75ffe09dfb229795e8c01a459f26c3",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5302bb402c57f00fb3c2c015bac86e0827e4b691",
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691",
                 "shasum": ""
             },
             "require": {
@@ -897,7 +897,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-19T15:27:56+00:00"
+            "time": "2023-10-06T14:19:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1182,8 +1182,8 @@ class MariaDB extends SQL
         $stmt->execute();
 
         $result = $stmt->fetchall();
-        if (!empty($document)) {
-            $result = $document[0];
+        if (!empty($result)) {
+            $result = $result[0];
         }
 
         return $result['sum'] ?? 0;
@@ -1242,8 +1242,8 @@ class MariaDB extends SQL
         $stmt->execute();
 
         $result = $stmt->fetchall();
-        if (!empty($document)) {
-            $result = $document[0];
+        if (!empty($result)) {
+            $result = $result[0];
         }
 
         return $result['sum'] ?? 0;

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1181,7 +1181,10 @@ class MariaDB extends SQL
 
         $stmt->execute();
 
-        $result = $stmt->fetch();
+        $result = $stmt->fetchall();
+        if (!empty($document)) {
+            $result = $document[0];
+        }
 
         return $result['sum'] ?? 0;
     }
@@ -1238,7 +1241,10 @@ class MariaDB extends SQL
 
         $stmt->execute();
 
-        $result = $stmt->fetch();
+        $result = $stmt->fetchall();
+        if (!empty($document)) {
+            $result = $document[0];
+        }
 
         return $result['sum'] ?? 0;
     }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -714,6 +714,7 @@ class MariaDB extends SQL
         $permissionsStmt->bindValue(':_uid', $document->getId());
         $permissionsStmt->execute();
         $permissions = $permissionsStmt->fetchAll();
+        $permissionsStmt->closeCursor();
 
         $initial = [];
         foreach (Database::PERMISSIONS as $type) {
@@ -1098,6 +1099,7 @@ class MariaDB extends SQL
         }
 
         $results = $stmt->fetchAll();
+        $stmt->closeCursor();
 
         foreach ($results as $index => $document) {
             if (\array_key_exists('_uid', $document)) {
@@ -1182,6 +1184,7 @@ class MariaDB extends SQL
         $stmt->execute();
 
         $result = $stmt->fetchall();
+        $stmt->closeCursor();
         if (!empty($result)) {
             $result = $result[0];
         }
@@ -1242,6 +1245,7 @@ class MariaDB extends SQL
         $stmt->execute();
 
         $result = $stmt->fetchall();
+        $stmt->closeCursor();
         if (!empty($result)) {
             $result = $result[0];
         }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1183,7 +1183,7 @@ class MariaDB extends SQL
 
         $stmt->execute();
 
-        $result = $stmt->fetchall();
+        $result = $stmt->fetchAll();
         $stmt->closeCursor();
         if (!empty($result)) {
             $result = $result[0];
@@ -1244,7 +1244,7 @@ class MariaDB extends SQL
 
         $stmt->execute();
 
-        $result = $stmt->fetchall();
+        $result = $stmt->fetchAll();
         $stmt->closeCursor();
         if (!empty($result)) {
             $result = $result[0];

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -723,6 +723,7 @@ class Postgres extends SQL
         $permissionsStmt->bindValue(':_uid', $document->getId());
         $permissionsStmt->execute();
         $permissions = $permissionsStmt->fetchAll();
+        $permissionsStmt->closeCursor();
 
         $initial = [];
         foreach (Database::PERMISSIONS as $type) {
@@ -1104,6 +1105,7 @@ class Postgres extends SQL
         }
 
         $results = $stmt->fetchAll();
+        $stmt->closeCursor();
 
         foreach ($results as $index => $document) {
             if (\array_key_exists('_uid', $document)) {

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -82,7 +82,7 @@ abstract class SQL extends Adapter
         $stmt->execute();
 
         $document = $stmt->fetchall();
-        if(!empty($document)){
+        if (!empty($document)) {
             $document = $document[0];
         }
 

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -82,6 +82,7 @@ abstract class SQL extends Adapter
         $stmt->execute();
 
         $document = $stmt->fetchall();
+        $stmt->closeCursor();
         if (!empty($document)) {
             $document = $document[0];
         }
@@ -125,6 +126,7 @@ abstract class SQL extends Adapter
         $stmt->execute();
 
         $document = $stmt->fetchAll();
+        $stmt->closeCursor();
 
         if (empty($document)) {
             return new Document([]);

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -81,7 +81,7 @@ abstract class SQL extends Adapter
 
         $stmt->execute();
 
-        $document = $stmt->fetchall();
+        $document = $stmt->fetchAll();
         $stmt->closeCursor();
         if (!empty($document)) {
             $document = $document[0];

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -132,6 +132,8 @@ abstract class SQL extends Adapter
             return new Document([]);
         }
 
+        $document = $document[0];
+
         if (\array_key_exists('_id', $document)) {
             $document['$internalId'] = $document['_id'];
             unset($document['_id']);

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -81,7 +81,10 @@ abstract class SQL extends Adapter
 
         $stmt->execute();
 
-        $document = $stmt->fetch();
+        $document = $stmt->fetchall();
+        if(!empty($document)){
+            $document = $document[0];
+        }
 
         return (($document[$select] ?? '') === $match) || // case insensitive check
             (($document[strtolower($select)] ?? '') === $match);

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -53,7 +53,7 @@ class SQLite extends MariaDB
 
         $stmt->execute();
 
-        $document = $stmt->fetchall();
+        $document = $stmt->fetchAll();
         $stmt->closeCursor();
         if (!empty($document)) {
             $document = $document[0];

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -53,7 +53,11 @@ class SQLite extends MariaDB
 
         $stmt->execute();
 
-        $document = $stmt->fetch();
+        $document = $stmt->fetchall();
+        $stmt->closeCursor();
+        if (!empty($document)) {
+            $document = $document[0];
+        }
 
         return (($document['name'] ?? '') === "{$this->getNamespace()}_{$collection}");
     }
@@ -495,6 +499,7 @@ class SQLite extends MariaDB
         $permissionsStmt->bindValue(':_uid', $document->getId());
         $permissionsStmt->execute();
         $permissions = $permissionsStmt->fetchAll();
+        $permissionsStmt->closeCursor();
 
         $initial = [];
         foreach (Database::PERMISSIONS as $type) {

--- a/src/Database/Validator/Index.php
+++ b/src/Database/Validator/Index.php
@@ -158,10 +158,6 @@ class Index extends Validator
     public function isValid($value): bool
     {
         foreach ($value->getAttribute('attributes', []) as $attribute) {
-
-            var_dump($attribute);
-
-
             $this->attributes[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute;
         }
 


### PR DESCRIPTION
Cannot execute queries while other unbuffered queries are active. Consider using PDOStatement::fetchAll(). Alternatively, if your code is only ever going to run against mysql, you may enable query buffering by setting the PDO::MYSQL_ATTR_USE_BUFFERED_QUERY attribute.