### PR TITLE
Fix index validation

### DIFF
--- a/src/Database/Validator/Index.php
+++ b/src/Database/Validator/Index.php
@@ -102,7 +102,7 @@ class Index extends Validator
     {
         if ($index->getAttribute('type') === Database::INDEX_FULLTEXT) {
             foreach ($index->getAttribute('attributes', []) as $attribute) {
-                $attribute = $this->attributes[$attribute] ?? new Document();
+                $attribute = $this->attributes[\strtolower($attribute)] ?? new Document();
                 if ($attribute->getAttribute('type', '') !== Database::VAR_STRING) {
                     $this->message = 'Attribute "' . $attribute->getAttribute('key', $attribute->getAttribute('$id')) . '" cannot be part of a FULLTEXT index, must be of type string';
                     return false;
@@ -126,7 +126,7 @@ class Index extends Validator
         $lengths = $index->getAttribute('lengths', []);
 
         foreach ($index->getAttribute('attributes', []) as $attributePosition => $attributeName) {
-            $attribute = $this->attributes[$attributeName];
+            $attribute = $this->attributes[\strtolower($attributeName)];
 
             switch ($attribute->getAttribute('type')) {
                 case Database::VAR_STRING:

--- a/src/Database/Validator/Index.php
+++ b/src/Database/Validator/Index.php
@@ -15,14 +15,22 @@ class Index extends Validator
     /**
      * @var array<Document> $attributes
      */
-    protected array $attributes = [];
+    protected array $attributes;
 
     /**
+     * @param array<Document> $attributes
      * @param int $maxLength
      */
-    public function __construct(int $maxLength)
+    public function __construct(array $attributes, int $maxLength)
     {
         $this->maxLength = $maxLength;
+
+        foreach ($attributes as $attribute) {
+            $this->attributes[$attribute->getAttribute('$id')] = $attribute;
+        }
+        foreach (Database::getInternalAttributes() as $attribute) {
+            $this->attributes[$attribute->getAttribute('$id')] = $attribute;
+        }
     }
 
     /**
@@ -35,131 +43,115 @@ class Index extends Validator
     }
 
     /**
-     * @param Document $collection
+     * @param Document $index
      * @return bool
      */
-    public function checkAttributesNotFound(Document $collection): bool
+    public function checkAttributesNotFound(Document $index): bool
     {
-        foreach ($collection->getAttribute('indexes', []) as $index) {
-            foreach ($index->getAttribute('attributes', []) as $attributeName) {
-                if (!isset($this->attributes[$attributeName])) {
-                    $this->message = 'Invalid index attribute "' . $attributeName . '" not found';
-                    return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param Document $collection
-     * @return bool
-     */
-    public function checkEmptyIndexAttributes(Document $collection): bool
-    {
-        foreach ($collection->getAttribute('indexes', []) as $index) {
-            if (empty($index->getAttribute('attributes', []))) {
-                $this->message = 'No attributes provided for index';
+        foreach ($index->getAttribute('attributes', []) as $attribute) {
+            if (!isset($this->attributes[$attribute])) {
+                $this->message = 'Invalid index attribute "' . $attribute . '" not found';
                 return false;
             }
         }
-
         return true;
     }
 
     /**
-     * @param Document $collection
+     * @param Document $index
      * @return bool
      */
-    public function checkDuplicatedAttributes(Document $collection): bool
+    public function checkEmptyIndexAttributes(Document $index): bool
     {
-        foreach ($collection->getAttribute('indexes', []) as $index) {
-            $attributes = $index->getAttribute('attributes', []);
-            $orders = $index->getAttribute('orders', []);
-            $stack = [];
-            foreach ($attributes as $key => $attribute) {
-                $direction = $orders[$key] ?? 'asc';
-                $value = strtolower($attribute . '|' . $direction);
-                if (in_array($value, $stack)) {
-                    $this->message = 'Duplicate attributes provided';
-                    return false;
-                }
-                $stack[] = $value;
-            }
+        if (empty($index->getAttribute('attributes', []))) {
+            $this->message = 'No attributes provided for index';
+            return false;
         }
-
         return true;
     }
 
     /**
-     * @param Document $collection
+     * @param Document $index
+     * @return bool
+     */
+    public function checkDuplicatedAttributes(Document $index): bool
+    {
+        $attributes = $index->getAttribute('attributes', []);
+        $orders = $index->getAttribute('orders', []);
+        $stack = [];
+        foreach ($attributes as $key => $attribute) {
+            $direction = $orders[$key] ?? 'ASC';
+            $value = \strtolower($attribute . '|' . $direction);
+            if (\in_array($value, $stack)) {
+                $this->message = 'Duplicate attributes provided';
+                return false;
+            }
+            $stack[] = $value;
+        }
+        return true;
+    }
+
+    /**
+     * @param Document $index
      * @return bool
      * @throws DatabaseException
      */
-    public function checkFulltextIndexNonString(Document $collection): bool
+    public function checkFulltextIndexNonString(Document $index): bool
     {
-        foreach ($collection->getAttribute('indexes', []) as $index) {
-            if ($index->getAttribute('type') === Database::INDEX_FULLTEXT) {
-                foreach ($index->getAttribute('attributes', []) as $attributeName) {
-                    $attribute = $this->attributes[$attributeName] ?? new Document([]);
-                    if ($attribute->getAttribute('type', '') !== Database::VAR_STRING) {
-                        $this->message = 'Attribute "'.$attribute->getAttribute('key', $attribute->getAttribute('$id')).'" cannot be part of a FULLTEXT index, must be of type string';
-                        return false;
-                    }
+        if ($index->getAttribute('type') === Database::INDEX_FULLTEXT) {
+            foreach ($index->getAttribute('attributes', []) as $attribute) {
+                $attribute = $this->attributes[$attribute] ?? new Document();
+                if ($attribute->getAttribute('type', '') !== Database::VAR_STRING) {
+                    $this->message = 'Attribute "' . $attribute->getAttribute('key', $attribute->getAttribute('$id')) . '" cannot be part of a FULLTEXT index, must be of type string';
+                    return false;
                 }
             }
         }
-
         return true;
     }
 
     /**
-     * @param Document $collection
+     * @param Document $index
      * @return bool
      */
-    public function checkIndexLength(Document $collection): bool
+    public function checkIndexLength(Document $index): bool
     {
-        foreach ($collection->getAttribute('indexes', []) as $index) {
-            if ($index->getAttribute('type') === Database::INDEX_FULLTEXT) {
-                continue;
+        if ($index->getAttribute('type') === Database::INDEX_FULLTEXT) {
+            return true;
+        }
+
+        $total = 0;
+        $lengths = $index->getAttribute('lengths', []);
+
+        foreach ($index->getAttribute('attributes', []) as $attributePosition => $attributeName) {
+            $attribute = $this->attributes[$attributeName];
+
+            switch ($attribute->getAttribute('type')) {
+                case Database::VAR_STRING:
+                    $attributeSize = $attribute->getAttribute('size', 0);
+                    $indexLength = $lengths[$attributePosition] ?? $attributeSize;
+                    break;
+                case Database::VAR_FLOAT:
+                    $attributeSize = 2; // 8 bytes / 4 mb4
+                    $indexLength = 2;
+                    break;
+                default:
+                    $attributeSize = 1; // 4 bytes / 4 mb4
+                    $indexLength = 1;
+                    break;
             }
 
-            $total = 0;
-            $lengths = $index->getAttribute('lengths', []);
-
-            foreach ($index->getAttribute('attributes', []) as $attributePosition => $attributeName) {
-                $attribute = $this->attributes[$attributeName];
-
-                switch ($attribute->getAttribute('type')) {
-                    case Database::VAR_STRING:
-                        $attributeSize = $attribute->getAttribute('size', 0);
-                        $indexLength = $lengths[$attributePosition] ?? $attributeSize;
-                        break;
-
-                    case Database::VAR_FLOAT:
-                        $attributeSize = 2; // 8 bytes / 4 mb4
-                        $indexLength = 2;
-                        break;
-
-                    default:
-                        $attributeSize = 1; // 4 bytes / 4 mb4
-                        $indexLength = 1;
-                        break;
-                }
-
-                if ($indexLength > $attributeSize) {
-                    $this->message = 'Index length '.$indexLength.' is larger than the size for '.$attributeName.': '.$attributeSize.'"';
-                    return false;
-                }
-
-                $total += $indexLength;
-            }
-
-            if ($total > $this->maxLength && $this->maxLength > 0) {
-                $this->message = 'Index length is longer than the maximum: ' . $this->maxLength;
+            if ($indexLength > $attributeSize) {
+                $this->message = 'Index length ' . $indexLength . ' is larger than the size for ' . $attributeName . ': ' . $attributeSize . '"';
                 return false;
             }
+
+            $total += $indexLength;
+        }
+
+        if ($total > $this->maxLength && $this->maxLength > 0) {
+            $this->message = 'Index length is longer than the maximum: ' . $this->maxLength;
+            return false;
         }
 
         return true;
@@ -175,14 +167,6 @@ class Index extends Validator
      */
     public function isValid($value): bool
     {
-        foreach ($value->getAttribute('attributes', []) as $attribute) {
-            $this->attributes[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute;
-        }
-
-        foreach (Database::getInternalAttributes() as $attribute) {
-            $this->attributes[$attribute->getAttribute('$id')] = $attribute;
-        }
-
         if (!$this->checkAttributesNotFound($value)) {
             return false;
         }

--- a/src/Database/Validator/Index.php
+++ b/src/Database/Validator/Index.php
@@ -26,10 +26,12 @@ class Index extends Validator
         $this->maxLength = $maxLength;
 
         foreach ($attributes as $attribute) {
-            $this->attributes[$attribute->getAttribute('$id')] = $attribute;
+            $key = $attribute->getAttribute('key', $attribute->getAttribute('$id'));
+            $this->attributes[$key] = $attribute;
         }
         foreach (Database::getInternalAttributes() as $attribute) {
-            $this->attributes[$attribute->getAttribute('$id')] = $attribute;
+            $key = $attribute->getAttribute('$id');
+            $this->attributes[$key] = $attribute;
         }
     }
 

--- a/src/Database/Validator/Index.php
+++ b/src/Database/Validator/Index.php
@@ -26,11 +26,11 @@ class Index extends Validator
         $this->maxLength = $maxLength;
 
         foreach ($attributes as $attribute) {
-            $key = $attribute->getAttribute('key', $attribute->getAttribute('$id'));
+            $key = \strtolower($attribute->getAttribute('key', $attribute->getAttribute('$id')));
             $this->attributes[$key] = $attribute;
         }
         foreach (Database::getInternalAttributes() as $attribute) {
-            $key = $attribute->getAttribute('$id');
+            $key = \strtolower($attribute->getAttribute('$id'));
             $this->attributes[$key] = $attribute;
         }
     }
@@ -51,7 +51,7 @@ class Index extends Validator
     public function checkAttributesNotFound(Document $index): bool
     {
         foreach ($index->getAttribute('attributes', []) as $attribute) {
-            if (!isset($this->attributes[$attribute])) {
+            if (!isset($this->attributes[\strtolower($attribute)])) {
                 $this->message = 'Invalid index attribute "' . $attribute . '" not found';
                 return false;
             }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -122,10 +122,10 @@ abstract class Base extends TestCase
             'indexes' => $indexes
         ]);
 
-        $validator = new Index(static::getDatabase()->getAdapter()->getMaxIndexLength());
+        $validator = new Index($attributes, static::getDatabase()->getAdapter()->getMaxIndexLength());
 
         $errorMessage = 'Index length 701 is larger than the size for title1: 700"';
-        $this->assertFalse($validator->isValid($collection));
+        $this->assertFalse($validator->isValid($indexes[0]));
         $this->assertEquals($errorMessage, $validator->getDescription());
 
         try {
@@ -149,7 +149,7 @@ abstract class Base extends TestCase
 
         if (static::getDatabase()->getAdapter()->getMaxIndexLength() > 0) {
             $errorMessage = 'Index length is longer than the maximum: ' . static::getDatabase()->getAdapter()->getMaxIndexLength();
-            $this->assertFalse($validator->isValid($collection));
+            $this->assertFalse($validator->isValid($indexes[0]));
             $this->assertEquals($errorMessage, $validator->getDescription());
 
             try {
@@ -189,8 +189,9 @@ abstract class Base extends TestCase
             'indexes' => $indexes
         ]);
 
+        $validator = new Index($attributes, static::getDatabase()->getAdapter()->getMaxIndexLength());
         $errorMessage = 'Attribute "integer" cannot be part of a FULLTEXT index, must be of type string';
-        $this->assertFalse($validator->isValid($collection));
+        $this->assertFalse($validator->isValid($indexes[0]));
         $this->assertEquals($errorMessage, $validator->getDescription());
 
         try {

--- a/tests/Database/Validator/IndexTest.php
+++ b/tests/Database/Validator/IndexTest.php
@@ -24,8 +24,6 @@ class IndexTest extends TestCase
      */
     public function testAttributeNotFound(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -53,7 +51,9 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertFalse($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertFalse($validator->isValid($index));
         $this->assertEquals('Invalid index attribute "not_exist" not found', $validator->getDescription());
     }
 
@@ -62,8 +62,6 @@ class IndexTest extends TestCase
      */
     public function testFulltextWithNonString(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -102,7 +100,9 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertFalse($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertFalse($validator->isValid($index));
         $this->assertEquals('Attribute "date" cannot be part of a FULLTEXT index, must be of type string', $validator->getDescription());
     }
 
@@ -111,8 +111,6 @@ class IndexTest extends TestCase
      */
     public function testIndexLength(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -140,7 +138,9 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertFalse($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertFalse($validator->isValid($index));
         $this->assertEquals('Index length is longer than the maximum: 768', $validator->getDescription());
     }
 
@@ -149,8 +149,6 @@ class IndexTest extends TestCase
      */
     public function testMultipleIndexLength(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -187,15 +185,18 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertTrue($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertTrue($validator->isValid($index));
 
-        $collection->setAttribute('indexes', new Document([
+        $index = new Document([
             '$id' => ID::custom('index2'),
             'type' => Database::INDEX_KEY,
             'attributes' => ['title', 'description'],
-        ]), Document::SET_TYPE_APPEND);
+        ]);
 
-        $this->assertFalse($validator->isValid($collection));
+        $collection->setAttribute('indexes', $index, Document::SET_TYPE_APPEND);
+        $this->assertFalse($validator->isValid($index));
         $this->assertEquals('Index length is longer than the maximum: 768', $validator->getDescription());
     }
 
@@ -204,8 +205,6 @@ class IndexTest extends TestCase
      */
     public function testEmptyAttributes(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -233,7 +232,9 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertFalse($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertFalse($validator->isValid($index));
         $this->assertEquals('No attributes provided for index', $validator->getDescription());
     }
 
@@ -242,8 +243,6 @@ class IndexTest extends TestCase
      */
     public function testDuplicatedAttributes(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -271,7 +270,9 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertFalse($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertFalse($validator->isValid($index));
         $this->assertEquals('Duplicate attributes provided', $validator->getDescription());
     }
 
@@ -280,8 +281,6 @@ class IndexTest extends TestCase
      */
     public function testDuplicatedAttributesDifferentOrder(): void
     {
-        $validator = new Index(768);
-
         $collection = new Document([
             '$id' => ID::custom('test'),
             'name' => 'test',
@@ -309,6 +308,8 @@ class IndexTest extends TestCase
             ],
         ]);
 
-        $this->assertTrue($validator->isValid($collection));
+        $validator = new Index($collection->getAttribute('attributes'), 768);
+        $index = $collection->getAttribute('indexes')[0];
+        $this->assertTrue($validator->isValid($index));
     }
 }


### PR DESCRIPTION
Make index validator accept the related collection `attributes` in constructor, and the index document in the `isValid` function. This is more consistent with other validators and allows us to validate a single index at a time instead of the entire collection.