### PR TITLE
Global timeouts using before query hooks

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2608,5 +2608,5 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1589,7 +1589,7 @@ class MariaDB extends SQL
 
         $seconds = $milliseconds / 1000;
 
-        $this->before(Database::EVENT_ALL, 'timeout', function ($sql) use ($seconds) {
+        $this->before($event, 'timeout', function ($sql) use ($seconds) {
             return "SET STATEMENT max_statement_time = {$seconds} FOR " . $sql;
         });
     }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -5,11 +5,11 @@ namespace Utopia\Database\Adapter;
 use Exception;
 use PDO;
 use PDOException;
-use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
-use Utopia\Database\Exception\Duplicate;
-use Utopia\Database\Exception\Timeout;
+use Utopia\Database\Exception as DatabaseException;
+use Utopia\Database\Exception\Duplicate as DuplicateException;
+use Utopia\Database\Exception\Timeout as TimeoutException;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Authorization;
 
@@ -641,7 +641,7 @@ class MariaDB extends SQL
      * @return Document
      * @throws Exception
      * @throws PDOException
-     * @throws Duplicate
+     * @throws DuplicateException
      */
     public function createDocument(string $collection, Document $document): Document
     {
@@ -736,7 +736,7 @@ class MariaDB extends SQL
             switch ($e->getCode()) {
                 case 1062:
                 case 23000:
-                    throw new Duplicate('Duplicated document: ' . $e->getMessage());
+                    throw new DuplicateException('Duplicated document: ' . $e->getMessage());
 
                 default:
                     throw $e;
@@ -758,7 +758,7 @@ class MariaDB extends SQL
      * @return Document
      * @throws Exception
      * @throws PDOException
-     * @throws Duplicate
+     * @throws DuplicateException
      */
     public function updateDocument(string $collection, Document $document): Document
     {
@@ -939,7 +939,7 @@ class MariaDB extends SQL
             switch ($e->getCode()) {
                 case 1062:
                 case 23000:
-                    throw new Duplicate('Duplicated document: ' . $e->getMessage());
+                    throw new DuplicateException('Duplicated document: ' . $e->getMessage());
 
                 default:
                     throw $e;
@@ -1058,12 +1058,11 @@ class MariaDB extends SQL
      * @param array<string> $orderTypes
      * @param array<string, mixed> $cursor
      * @param string $cursorDirection
-     * @param int|null $timeout
      * @return array<Document>
      * @throws DatabaseException
-     * @throws Timeout
+     * @throws TimeoutException
      */
-    public function find(string $collection, array $queries = [], ?int $limit = 25, ?int $offset = null, array $orderAttributes = [], array $orderTypes = [], array $cursor = [], string $cursorDirection = Database::CURSOR_AFTER, ?int $timeout = null): array
+    public function find(string $collection, array $queries = [], ?int $limit = 25, ?int $offset = null, array $orderAttributes = [], array $orderTypes = [], array $cursor = [], string $cursorDirection = Database::CURSOR_AFTER): array
     {
         $name = $this->filter($collection);
         $roles = Authorization::getRoles();
@@ -1173,11 +1172,8 @@ class MariaDB extends SQL
 
         $sql = $this->trigger(Database::EVENT_DOCUMENT_FIND, $sql);
 
-        if ($timeout || static::$timeout) {
-            $sql = $this->setTimeoutForQuery($sql, $timeout ? $timeout : static::$timeout);
-        }
-
         $stmt = $this->getPDO()->prepare($sql);
+
         foreach ($queries as $query) {
             $this->bindConditionValue($stmt, $query);
         }
@@ -1257,7 +1253,7 @@ class MariaDB extends SQL
      * @throws Exception
      * @throws PDOException
      */
-    public function count(string $collection, array $queries = [], ?int $max = null, ?int $timeout = null): int
+    public function count(string $collection, array $queries = [], ?int $max = null): int
     {
         $name = $this->filter($collection);
         $roles = Authorization::getRoles();
@@ -1287,11 +1283,8 @@ class MariaDB extends SQL
 
         $sql = $this->trigger(Database::EVENT_DOCUMENT_COUNT, $sql);
 
-        if ($timeout || self::$timeout) {
-            $sql = $this->setTimeoutForQuery($sql, $timeout ? $timeout : self::$timeout);
-        }
-
         $stmt = $this->getPDO()->prepare($sql);
+
         foreach ($queries as $query) {
             $this->bindConditionValue($stmt, $query);
         }
@@ -1322,7 +1315,7 @@ class MariaDB extends SQL
      * @throws Exception
      * @throws PDOException
      */
-    public function sum(string $collection, string $attribute, array $queries = [], ?int $max = null, ?int $timeout = null): int|float
+    public function sum(string $collection, string $attribute, array $queries = [], ?int $max = null): int|float
     {
         $name = $this->filter($collection);
         $roles = Authorization::getRoles();
@@ -1351,10 +1344,6 @@ class MariaDB extends SQL
         ";
 
         $sql = $this->trigger(Database::EVENT_DOCUMENT_SUM, $sql);
-
-        if ($timeout || self::$timeout) {
-            $sql = $this->setTimeoutForQuery($sql, $timeout ? $timeout : self::$timeout);
-        }
 
         $stmt = $this->getPDO()->prepare($sql);
 
@@ -1583,35 +1572,42 @@ class MariaDB extends SQL
     }
 
     /**
-     * Returns Max Execution Time
-     * @param string $sql
+     * Set max execution time
      * @param int $milliseconds
-     * @return string
+     * @param string $event
+     * @return void
+     * @throws DatabaseException
      */
-    protected function setTimeoutForQuery(string $sql, int $milliseconds): string
+    public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
     {
         if (!$this->getSupportForTimeouts()) {
-            return $sql;
+            return;
+        }
+        if ($milliseconds <= 0) {
+            throw new DatabaseException('Timeout must be greater than 0');
         }
 
         $seconds = $milliseconds / 1000;
-        return "SET STATEMENT max_statement_time = {$seconds} FOR " . $sql;
+
+        $this->before(Database::EVENT_ALL, 'timeout', function ($sql) use ($seconds) {
+            return "SET STATEMENT max_statement_time = {$seconds} FOR " . $sql;
+        });
     }
 
     /**
      * @param PDOException $e
-     * @throws Timeout
+     * @throws TimeoutException
      */
     protected function processException(PDOException $e): void
     {
         // Regular PDO
         if ($e->getCode() === '70100' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1969) {
-            throw new Timeout($e->getMessage());
+            throw new TimeoutException($e->getMessage());
         }
 
         // PDOProxy switches errorInfo PDOProxy.php line 64
         if ($e->getCode() === 1969 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '70100') {
-            throw new Timeout($e->getMessage());
+            throw new TimeoutException($e->getMessage());
         }
 
         throw $e;

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -42,6 +42,8 @@ class Mongo extends Adapter
 
     protected Client $client;
 
+    protected ?int $timeout = null;
+
     /**
      * Constructor.
      *
@@ -812,13 +814,12 @@ class Mongo extends Adapter
      * @param array<string> $orderTypes
      * @param array<string, mixed> $cursor
      * @param string $cursorDirection
-     * @param int|null $timeout
      *
      * @return array<Document>
      * @throws Exception
      * @throws Timeout
      */
-    public function find(string $collection, array $queries = [], ?int $limit = 25, ?int $offset = null, array $orderAttributes = [], array $orderTypes = [], array $cursor = [], string $cursorDirection = Database::CURSOR_AFTER, ?int $timeout = null): array
+    public function find(string $collection, array $queries = [], ?int $limit = 25, ?int $offset = null, array $orderAttributes = [], array $orderTypes = [], array $cursor = [], string $cursorDirection = Database::CURSOR_AFTER): array
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection);
 
@@ -838,8 +839,8 @@ class Mongo extends Adapter
             $options['skip'] = $offset;
         }
 
-        if ($timeout || self::$timeout) {
-            $options['maxTimeMS'] = $timeout ? $timeout : self::$timeout;
+        if ($this->timeout) {
+            $options['maxTimeMS'] = $this->timeout;
         }
 
         $selections = $this->getAttributeSelections($queries);
@@ -1076,7 +1077,7 @@ class Mongo extends Adapter
      * @return int
      * @throws Exception
      */
-    public function count(string $collection, array $queries = [], ?int $max = null, ?int $timeout = null): int
+    public function count(string $collection, array $queries = [], ?int $max = null): int
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection);
 
@@ -1088,8 +1089,8 @@ class Mongo extends Adapter
             $options['limit'] = $max;
         }
 
-        if ($timeout || self::$timeout) {
-            $options['maxTimeMS'] = $timeout ? $timeout : self::$timeout;
+        if ($this->timeout) {
+            $options['maxTimeMS'] = $this->timeout;
         }
 
         // queries
@@ -1115,15 +1116,9 @@ class Mongo extends Adapter
      * @return int|float
      * @throws Exception
      */
-    public function sum(string $collection, string $attribute, array $queries = [], ?int $max = null, ?int $timeout = null): float|int
+    public function sum(string $collection, string $attribute, array $queries = [], ?int $max = null): float|int
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection);
-        $collection = $this->getDatabase()->selectCollection($name);
-        // todo $collection is not used?
-
-        // todo add $timeout for aggregate in Mongo utopia client
-
-        $filters = [];
 
         // queries
         $filters = $this->buildFilters($queries);
@@ -1706,5 +1701,17 @@ class Mongo extends Adapter
     public function getMaxIndexLength(): int
     {
         return 0;
+    }
+
+    public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
+    {
+        $this->timeout = $milliseconds;
+    }
+
+    public function clearTimeout(string $event): void
+    {
+        parent::clearTimeout($event);
+
+        $this->timeout = null;
     }
 }

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1705,6 +1705,9 @@ class Mongo extends Adapter
 
     public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
     {
+		if (!$this->getSupportForTimeouts()) {
+			return;
+		}
         $this->timeout = $milliseconds;
     }
 

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1705,9 +1705,9 @@ class Mongo extends Adapter
 
     public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
     {
-		if (!$this->getSupportForTimeouts()) {
-			return;
-		}
+        if (!$this->getSupportForTimeouts()) {
+            return;
+        }
         $this->timeout = $milliseconds;
     }
 

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -65,7 +65,7 @@ class MySQL extends MariaDB
         if ($milliseconds <= 0) {
             throw new DatabaseException('Timeout must be greater than 0');
         }
-        $this->before(Database::EVENT_ALL, 'timeout', function ($sql) use ($milliseconds) {
+        $this->before($event, 'timeout', function ($sql) use ($milliseconds) {
             return \preg_replace(
                 pattern: '/SELECT/',
                 replacement: "SELECT /*+ max_execution_time({$milliseconds}) */",

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1644,7 +1644,7 @@ class Postgres extends SQL
         if ($milliseconds <= 0) {
             throw new DatabaseException('Timeout must be greater than 0');
         }
-        $this->before(Database::EVENT_ALL, 'timeout', function ($sql) use ($milliseconds) {
+        $this->before($event, 'timeout', function ($sql) use ($milliseconds) {
             return "
 				SET statement_timeout = {$milliseconds};
 				{$sql};

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -221,13 +221,14 @@ abstract class Base extends TestCase
         $this->assertNotNull($document->getInternalId());
     }
 
-    public function testQueryTimeoutUsingStaticTimeout(): void
+
+    public function testQueryTimeout(): void
     {
         if ($this->getDatabase()->getAdapter()->getSupportForTimeouts()) {
             static::getDatabase()->createCollection('global-timeouts');
             $this->assertEquals(true, static::getDatabase()->createAttribute('global-timeouts', 'longtext', Database::VAR_STRING, 100000000, true));
 
-            for ($i = 0 ; $i <= 5 ; $i++) {
+            for ($i = 0 ; $i <= 20 ; $i++) {
                 static::getDatabase()->createDocument('global-timeouts', new Document([
                     'longtext' => file_get_contents(__DIR__ . '/../resources/longtext.txt'),
                     '$permissions' => [
@@ -239,6 +240,7 @@ abstract class Base extends TestCase
             }
 
             $this->expectException(Timeout::class);
+
             static::getDatabase()->setTimeout(1);
 
             try {
@@ -251,9 +253,9 @@ abstract class Base extends TestCase
                 throw $ex;
             }
         }
+
         $this->expectNotToPerformAssertions();
     }
-
 
     /**
      * @depends testCreateExistsDelete
@@ -2651,33 +2653,6 @@ abstract class Base extends TestCase
             Query::offset(0),
             Query::cursorAfter($document)
         ]);
-    }
-
-    public function testTimeout(): void
-    {
-        if ($this->getDatabase()->getAdapter()->getSupportForTimeouts()) {
-            static::getDatabase()->createCollection('timeouts');
-            $this->assertEquals(true, static::getDatabase()->createAttribute('timeouts', 'longtext', Database::VAR_STRING, 100000000, true));
-
-            for ($i = 0 ; $i <= 5 ; $i++) {
-                static::getDatabase()->createDocument('timeouts', new Document([
-                    'longtext' => file_get_contents(__DIR__ . '/../resources/longtext.txt'),
-                    '$permissions' => [
-                        Permission::read(Role::any()),
-                        Permission::update(Role::any()),
-                        Permission::delete(Role::any())
-                    ]
-                ]));
-            }
-
-            $this->expectException(Timeout::class);
-
-            static::getDatabase()->find('timeouts', [
-                Query::notEqual('longtext', 'appwrite'),
-            ], 1);
-        }
-
-        $this->expectNotToPerformAssertions();
     }
 
     /**


### PR DESCRIPTION
## What's Changed

Allow using instance level query hooks to set timeout per database event (or all)

## Test Plan

Existing tests, updated timeout test