### PR TITLE
feat: constrain findOne return type

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4279,10 +4279,10 @@ class Database
     /**
      * @param string $collection
      * @param array<Query> $queries
-     * @return bool|Document
+     * @return false|Document
      * @throws DatabaseException
      */
-    public function findOne(string $collection, array $queries = []): bool|Document
+    public function findOne(string $collection, array $queries = []): false|Document
     {
         $results = $this->silent(fn () => $this->find($collection, \array_merge([
             Query::limit(1)


### PR DESCRIPTION
Allows falsy checks such as 
```php
$doc = $database->findOne(...)

if (!$doc) {
   return;
}

// now $doc is type Document
```