### PR TITLE
 Many to One issue - invalid relation type 

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false">
+    stopOnFailure="true">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3550,6 +3550,10 @@ class Database
                             $document->setAttribute($key, $value->getId());
                         } elseif (\is_null($value)) {
                             break;
+                        } elseif(empty($value)){
+                           var_dump('I am an empty array Is I think it is ok to throw an exeption');
+                           throw new DatabaseException('Invalid value for relationship');
+
                         } else {
                             throw new DatabaseException('Invalid value for relationship');
                         }

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -6799,6 +6799,24 @@ abstract class Base extends TestCase
         $review5 = static::getDatabase()->getDocument('review', 'review5');
         $this->assertEquals('Movie 5', $review5->getAttribute('movie')->getAttribute('name'));
 
+
+        // Todo: fix this is failing
+        static::getDatabase()->updateDocument('review', $review5->getId(), new Document([
+            '$id' => 'review5',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Review 5',
+            'movie' => [], //
+        ]));
+
+
+        $this->assertEquals(true, false);
+
+
+
         // Update document with new related document
         static::getDatabase()->updateDocument(
             'review',


### PR DESCRIPTION
 Many to One issue - invalid relation type
From Sentry, with no specific issue, this is supposed to solve people getting 500 errors on update relations