### PR TITLE
Fix getId() on null delete document relations

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="true">
+    stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
     processIsolation="false"
-    stopOnFailure="false">
+    stopOnFailure="true">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory>./tests/</directory>

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3880,8 +3880,6 @@ class Database
                     $this->deleteRestrict($relatedCollection, $document, $value, $relationType, $twoWay, $twoWayKey, $side);
                     break;
                 case Database::RELATION_MUTATE_SET_NULL:
-                    var_dump("inininininininininini   RELATION_MUTATE_SET_NULL   ninininininininininininininininin");
-                    var_dump($value);
                     $this->deleteSetNull($collection, $relatedCollection, $document, $value, $relationType, $twoWay, $twoWayKey, $side);
                     break;
                 case Database::RELATION_MUTATE_CASCADE:

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3880,6 +3880,8 @@ class Database
                     $this->deleteRestrict($relatedCollection, $document, $value, $relationType, $twoWay, $twoWayKey, $side);
                     break;
                 case Database::RELATION_MUTATE_SET_NULL:
+                    var_dump("inininininininininini   RELATION_MUTATE_SET_NULL   ninininininininininininininininin");
+                    var_dump($value);
                     $this->deleteSetNull($collection, $relatedCollection, $document, $value, $relationType, $twoWay, $twoWayKey, $side);
                     break;
                 case Database::RELATION_MUTATE_CASCADE:
@@ -4038,6 +4040,9 @@ class Database
                             Query::equal($twoWayKey, [$document->getId()])
                         ]);
                     } else {
+                        if(empty($value)) {
+                            return;
+                        }
                         $related = $this->getDocument($relatedCollection->getId(), $value->getId());
                     }
 

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -5571,17 +5571,14 @@ abstract class Base extends TestCase
             onDelete: Database::RELATION_MUTATE_SET_NULL
         );
 
-
-
-        $city1 = static::getDatabase()->getDocument('city', 'city1');
-        var_dump($city1);
         static::getDatabase()->updateDocument('city', 'city1', new Document(['newCountry' => null, '$id' => 'city1']));
+        $city1 = static::getDatabase()->getDocument('city', 'city1');
+        $this->assertNull($city1->getAttribute('newCountry'));
 
-        // Check Delete TwoWay = TRUE with related value is NULL
+        // Check Delete TwoWay TRUE && RELATION_MUTATE_SET_NULL && related value NULL
         $this->assertTrue(static::getDatabase()->deleteDocument('city', 'city1'));
-        //  $this->assertTrue(false);
-
-
+        $city1 = static::getDatabase()->getDocument('city', 'city1');
+        $this->assertTrue($city1->isEmpty());
 
         // Delete parent, will set child relationship to null for two-way
         static::getDatabase()->deleteDocument('country', 'country1');

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -5571,6 +5571,18 @@ abstract class Base extends TestCase
             onDelete: Database::RELATION_MUTATE_SET_NULL
         );
 
+
+
+        $city1 = static::getDatabase()->getDocument('city', 'city1');
+        var_dump($city1);
+        static::getDatabase()->updateDocument('city', 'city1', new Document(['newCountry' => null, '$id' => 'city1']));
+
+        // Check Delete TwoWay = TRUE with related value is NULL
+        $this->assertTrue(static::getDatabase()->deleteDocument('city', 'city1'));
+        //  $this->assertTrue(false);
+
+
+
         // Delete parent, will set child relationship to null for two-way
         static::getDatabase()->deleteDocument('country', 'country1');
 


### PR DESCRIPTION
Fix Delets Documents with relations when Database::RELATION_MUTATE_SET_NULL and Two-way attribute key value is set to null.
@stnguyen90 We saw this error on Sentry not sure if it is associated with an issue