### PR TITLE
Feat: preserve dates

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -513,16 +513,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.13.5",
+            "version": "v1.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "df105cf8ce7a8f0b8a9425ff45cd281a5448e423"
+                "reference": "3e3d2ab01c7d8b484c18e6100ecf53639c744fa7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/df105cf8ce7a8f0b8a9425ff45cd281a5448e423",
-                "reference": "df105cf8ce7a8f0b8a9425ff45cd281a5448e423",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/3e3d2ab01c7d8b484c18e6100ecf53639c744fa7",
+                "reference": "3e3d2ab01c7d8b484c18e6100ecf53639c744fa7",
                 "shasum": ""
             },
             "require": {
@@ -533,13 +533,13 @@
                 "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.34.1",
-                "illuminate/view": "^10.26.2",
-                "laravel-zero/framework": "^10.1.2",
+                "friendsofphp/php-cs-fixer": "^3.38.0",
+                "illuminate/view": "^10.30.1",
+                "laravel-zero/framework": "^10.3.0",
                 "mockery/mockery": "^1.6.6",
                 "nunomaduro/larastan": "^2.6.4",
                 "nunomaduro/termwind": "^1.15.1",
-                "pestphp/pest": "^2.20.0"
+                "pestphp/pest": "^2.24.2"
             },
             "bin": [
                 "builds/pint"
@@ -575,7 +575,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2023-10-26T09:26:10+00:00"
+            "time": "2023-11-07T17:59:57+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -839,16 +839,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.40",
+            "version": "1.10.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d"
+                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/93c84b5bf7669920d823631e39904d69b9c7dc5d",
-                "reference": "93c84b5bf7669920d823631e39904d69b9c7dc5d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bf84367c53a23f759513985c54ffe0d0c249825b",
+                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b",
                 "shasum": ""
             },
             "require": {
@@ -897,7 +897,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-30T14:48:31+00:00"
+            "time": "2023-11-21T16:30:46+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2428,7 +2428,7 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.3.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
@@ -2475,7 +2475,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -2495,16 +2495,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -2533,7 +2533,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -2541,7 +2541,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "utopia-php/cli",
@@ -2608,5 +2608,5 @@
         "php": ">=8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2667,6 +2667,7 @@ class Database
      *
      * @param string $collection
      * @param Document $document
+     * @param bool $preserveDates If true, createdAt and updatedAt will not be overwritten
      *
      * @return Document
      *
@@ -2674,7 +2675,7 @@ class Database
      * @throws DatabaseException
      * @throws StructureException
      */
-    public function createDocument(string $collection, Document $document): Document
+    public function createDocument(string $collection, Document $document, bool $preserveDates = false): Document
     {
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
@@ -2687,11 +2688,14 @@ class Database
 
         $time = DateTime::now();
 
+        $createdAt = $document->getCreatedAt();
+        $updatedAt = $document->getUpdatedAt();
+
         $document
             ->setAttribute('$id', empty($document->getId()) ? ID::unique() : $document->getId())
             ->setAttribute('$collection', $collection->getId())
-            ->setAttribute('$createdAt', $time)
-            ->setAttribute('$updatedAt', $time);
+            ->setAttribute('$createdAt', empty($createdAt) || !$preserveDates ? $time : $createdAt)
+            ->setAttribute('$updatedAt', empty($updatedAt) || !$preserveDates ? $time : $updatedAt);
 
         $document = $this->encode($collection, $document);
 
@@ -2728,6 +2732,7 @@ class Database
      * @param string $collection
      * @param array<Document> $documents
      * @param int $batchSize
+     * @param bool $preserveDates If true, createdAt and updatedAt will not be overwritten
      *
      * @return array<Document>
      *
@@ -2735,7 +2740,7 @@ class Database
      * @throws StructureException
      * @throws Exception
      */
-    public function createDocuments(string $collection, array $documents, int $batchSize = self::INSERT_BATCH_SIZE): array
+    public function createDocuments(string $collection, array $documents, int $batchSize = self::INSERT_BATCH_SIZE, bool $preserveDates = false): array
     {
         if (empty($documents)) {
             return [];
@@ -2746,11 +2751,14 @@ class Database
         $time = DateTime::now();
 
         foreach ($documents as $key => $document) {
+            $createdAt = $document->getCreatedAt();
+            $updatedAt = $document->getUpdatedAt();
+
             $document
                 ->setAttribute('$id', empty($document->getId()) ? ID::unique() : $document->getId())
                 ->setAttribute('$collection', $collection->getId())
-                ->setAttribute('$createdAt', $time)
-                ->setAttribute('$updatedAt', $time);
+                ->setAttribute('$createdAt', empty($createdAt) || !$preserveDates ? $time : $createdAt)
+                ->setAttribute('$updatedAt', empty($updatedAt) || !$preserveDates ? $time : $updatedAt);
 
             $document = $this->encode($collection, $document);
 
@@ -3055,6 +3063,7 @@ class Database
      * @param string $collection
      * @param string $id
      * @param Document $document
+     * @param bool $preserveDates If true, updatedAt will not be overwritten
      * @return Document
      *
      * @throws AuthorizationException
@@ -3062,7 +3071,7 @@ class Database
      * @throws DatabaseException
      * @throws StructureException
      */
-    public function updateDocument(string $collection, string $id, Document $document): Document
+    public function updateDocument(string $collection, string $id, Document $document, bool $preserveDates = false): Document
     {
         if (!$document->getId() || !$id) {
             throw new DatabaseException('Must define $id attribute');
@@ -3176,7 +3185,8 @@ class Database
         }
 
         if ($shouldUpdate) {
-            $document->setAttribute('$updatedAt', $time);
+            $updatedAt = $document->getUpdatedAt();
+            $document->setAttribute('$updatedAt', empty($updatedAt) || !$preserveDates ? $time : $updatedAt);
         }
 
         // Check if document was updated after the request timestamp
@@ -3220,6 +3230,7 @@ class Database
      * @param string $collection
      * @param array<Document> $documents
      * @param int $batchSize
+     * @param bool $preserveDates If true, updatedAt will not be overwritten
      *
      * @return array<Document>
      *
@@ -3227,7 +3238,7 @@ class Database
      * @throws Exception
      * @throws StructureException
      */
-    public function updateDocuments(string $collection, array $documents, int $batchSize = self::INSERT_BATCH_SIZE): array
+    public function updateDocuments(string $collection, array $documents, int $batchSize = self::INSERT_BATCH_SIZE, bool $preserveDates = false): array
     {
         if (empty($documents)) {
             return [];
@@ -3241,7 +3252,8 @@ class Database
                 throw new Exception('Must define $id attribute for each document');
             }
 
-            $document->setAttribute('$updatedAt', $time);
+            $updatedAt = $document->getUpdatedAt();
+            $document->setAttribute('$updatedAt', empty($updatedAt) || !$preserveDates ? $time : $updatedAt);
             $document = $this->encode($collection, $document);
 
             $old = Authorization::skip(fn () => $this->silent(

--- a/tests/Database/Base.php
+++ b/tests/Database/Base.php
@@ -75,6 +75,97 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->create());
     }
 
+    public function testPreserveDatesUpdate(): void
+    {
+        Authorization::disable();
+
+        static::getDatabase()->createCollection('preserve_update_dates');
+
+        static::getDatabase()->createAttribute('preserve_update_dates', 'attr1', Database::VAR_STRING, 10, false);
+
+        $doc1 = static::getDatabase()->createDocument('preserve_update_dates', new Document([
+            '$id' => 'doc1',
+            '$permissions' => [],
+            'attr1' => 'value1',
+        ]));
+
+        $doc2 = static::getDatabase()->createDocument('preserve_update_dates', new Document([
+            '$id' => 'doc2',
+            '$permissions' => [],
+            'attr1' => 'value2',
+        ]));
+
+        $doc3 = static::getDatabase()->createDocument('preserve_update_dates', new Document([
+            '$id' => 'doc3',
+            '$permissions' => [],
+            'attr1' => 'value3',
+        ]));
+
+        $newDate = '2000-01-01T10:00:00.000+00:00';
+
+        $doc1->setAttribute('$updatedAt', $newDate);
+        static::getDatabase()->updateDocument('preserve_update_dates', 'doc1', $doc1, true);
+        $doc1 = static::getDatabase()->getDocument('preserve_update_dates', 'doc1');
+        $this->assertEquals($newDate, $doc1->getAttribute('$updatedAt'));
+
+        $doc2->setAttribute('$updatedAt', $newDate);
+        $doc3->setAttribute('$updatedAt', $newDate);
+        static::getDatabase()->updateDocuments('preserve_update_dates', [$doc2, $doc3], 2, true);
+
+        $doc2 = static::getDatabase()->getDocument('preserve_update_dates', 'doc2');
+        $doc3 = static::getDatabase()->getDocument('preserve_update_dates', 'doc3');
+        $this->assertEquals($newDate, $doc2->getAttribute('$updatedAt'));
+        $this->assertEquals($newDate, $doc3->getAttribute('$updatedAt'));
+
+        static::getDatabase()->deleteCollection('preserve_update_dates');
+
+        Authorization::reset();
+    }
+
+    public function testPreserveDatesCreate(): void
+    {
+        Authorization::disable();
+
+        static::getDatabase()->createCollection('preserve_create_dates');
+
+        static::getDatabase()->createAttribute('preserve_create_dates', 'attr1', Database::VAR_STRING, 10, false);
+
+        $date = '2000-01-01T10:00:00.000+00:00';
+
+        static::getDatabase()->createDocument('preserve_create_dates', new Document([
+            '$id' => 'doc1',
+            '$permissions' => [],
+            'attr1' => 'value1',
+            '$createdAt' => $date
+        ]), true);
+
+        static::getDatabase()->createDocuments('preserve_create_dates', [
+            new Document([
+                '$id' => 'doc2',
+                '$permissions' => [],
+                'attr1' => 'value2',
+                '$createdAt' => $date
+            ]),
+            new Document([
+                '$id' => 'doc3',
+                '$permissions' => [],
+                'attr1' => 'value3',
+                '$createdAt' => $date
+            ]),
+        ], 2, true);
+
+        $doc1 = static::getDatabase()->getDocument('preserve_create_dates', 'doc1');
+        $doc2 = static::getDatabase()->getDocument('preserve_create_dates', 'doc2');
+        $doc3 = static::getDatabase()->getDocument('preserve_create_dates', 'doc3');
+        $this->assertEquals($date, $doc1->getAttribute('$createdAt'));
+        $this->assertEquals($date, $doc2->getAttribute('$createdAt'));
+        $this->assertEquals($date, $doc3->getAttribute('$createdAt'));
+
+        static::getDatabase()->deleteCollection('preserve_create_dates');
+
+        Authorization::reset();
+    }
+
     /**
      * @throws Exception|Throwable
      */


### PR DESCRIPTION
In some scenarios (migration) you want to create/update a document, but don't want the $createdAt or $updatedAt to change.

I added a parameter to allow control of this. Default stays the same as it is, to prevent breaking changes.