### PR TITLE
Fix-#3914-invalid-queries causes 500 error

### DIFF
--- a/src/Database/Validator/Queries.php
+++ b/src/Database/Validator/Queries.php
@@ -127,7 +127,7 @@ class Queries extends Validator
      */
     public function isArray(): bool
     {
-        return true;
+        return is_array($value);
     }
 
     /**

--- a/tests/unit/Validator/QueriesTest.php
+++ b/tests/unit/Validator/QueriesTest.php
@@ -52,6 +52,15 @@ class QueriesTest extends TestCase
         $this->assertEquals(false, $validator->isValid(['limit(-1)']));
     }
 
+    public function testInvalidApiCall(): void
+    {
+        $validator = new Queries(); 
+        $queryParams = ['queries' => 100];
+        $isValid = $validator->isValid($queryParams['queries']);
+        $this->assertFalse($isValid);
+        $this->assertStringContainsString('Queries must be an array', $validator->getDescription());
+    }
+
     /**
      * @throws Exception
      */


### PR DESCRIPTION
### Test Enhancement 🚀

#### Test Invalid API Call

Added a PHPUnit test case to ensure proper validation of an invalid API call. This test checks if the `isValid` method in the `Documents` class correctly handles the scenario where the provided queries are not an array. The expected behavior is that the method returns `false` and sets an error message indicating that "Queries must be an array."

### Code Improvement 🛠️

#### Enhance isArray Method

Improved the `isArray` method in the same class (`Documents`) by fixing a parameter mismatch. The method now correctly checks if the provided value is an array using the `is_array` function, enhancing the reliability of the isArray function.

These changes aim to strengthen the validation logic and improve the overall robustness of the codebase.
