### PR TITLE
Only add tenant attribute when shared tables enabled to fix migrations

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -119,7 +119,6 @@ class MariaDB extends SQL
 			CREATE TABLE IF NOT EXISTS {$this->getSQLTable($id)} (
 				_id INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
 				_uid VARCHAR(255) NOT NULL,
-				_tenant INT(11) UNSIGNED DEFAULT NULL,
 				_createdAt DATETIME(3) DEFAULT NULL,
 				_updatedAt DATETIME(3) DEFAULT NULL,
 				_permissions MEDIUMTEXT DEFAULT NULL,
@@ -130,6 +129,7 @@ class MariaDB extends SQL
 
         if ($this->shareTables) {
             $sql .= "
+            	_tenant INT(11) UNSIGNED DEFAULT NULL,
 				UNIQUE KEY _uid_tenant (_uid, _tenant),
 				KEY _created_at (_tenant, _createdAt),
 				KEY _updated_at (_tenant, _updatedAt),
@@ -155,7 +155,6 @@ class MariaDB extends SQL
             $sql = "
 				CREATE TABLE IF NOT EXISTS {$this->getSQLTable($id . '_perms')} (
 					_id int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-					_tenant INT(11) UNSIGNED DEFAULT NULL,
 					_type VARCHAR(12) NOT NULL,
 					_permission VARCHAR(255) NOT NULL,
 					_document VARCHAR(255) NOT NULL,
@@ -164,6 +163,7 @@ class MariaDB extends SQL
 
             if ($this->shareTables) {
                 $sql .= "
+                	_tenant INT(11) UNSIGNED DEFAULT NULL,
 					UNIQUE INDEX _index1 (_document, _tenant, _type, _permission),
 					INDEX _permission (_tenant, _permission, _type)
 				";
@@ -716,10 +716,13 @@ class MariaDB extends SQL
     public function createDocument(string $collection, Document $document): Document
     {
         $attributes = $document->getAttributes();
-        $attributes['_tenant'] = $this->tenant;
         $attributes['_createdAt'] = $document->getCreatedAt();
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = \json_encode($document->getPermissions());
+
+		if ($this->shareTables) {
+			$attributes['_tenant'] = $this->tenant;
+		}
 
         $name = $this->filter($collection);
         $columns = '';
@@ -775,7 +778,15 @@ class MariaDB extends SQL
         foreach (Database::PERMISSIONS as $type) {
             foreach ($document->getPermissionsByType($type) as $permission) {
                 $permission = \str_replace('"', '', $permission);
-                $permissions[] = "('{$type}', '{$permission}', '{$document->getId()}', :_tenant)";
+                $permission = "('{$type}', '{$permission}', '{$document->getId()}'";
+
+				if ($this->shareTables) {
+					$permission .= ", :_tenant)";
+				} else {
+					$permission .= ")";
+				}
+
+				$permissions[] = $permission;
             }
         }
 
@@ -783,12 +794,22 @@ class MariaDB extends SQL
             $permissions = \implode(', ', $permissions);
 
             $sqlPermissions = "
-				INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document, _tenant) 
-				VALUES {$permissions}
+				INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document
 			";
+
+			if ($this->shareTables) {
+				$sqlPermissions .= ', _tenant)';
+			} else {
+				$sqlPermissions .= ")";
+			}
+
+			$sqlPermissions .=	" VALUES {$permissions}";
             $sqlPermissions = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sqlPermissions);
             $stmtPermissions = $this->getPDO()->prepare($sqlPermissions);
-            $stmtPermissions->bindValue(':_tenant', $this->tenant);
+
+			if ($this->shareTables) {
+				$stmtPermissions->bindValue(':_tenant', $this->tenant);
+			}
         }
 
         try {
@@ -852,10 +873,13 @@ class MariaDB extends SQL
                 foreach ($batch as $document) {
                     $attributes = $document->getAttributes();
                     $attributes['_uid'] = $document->getId();
-                    $attributes['_tenant'] = $this->tenant;
                     $attributes['_createdAt'] = $document->getCreatedAt();
                     $attributes['_updatedAt'] = $document->getUpdatedAt();
                     $attributes['_permissions'] = \json_encode($document->getPermissions());
+
+					if ($this->shareTables) {
+						$attributes['_tenant'] = $this->tenant;
+					}
 
                     $columns = [];
                     foreach (\array_keys($attributes) as $key => $attribute) {
@@ -881,7 +905,15 @@ class MariaDB extends SQL
                     foreach (Database::PERMISSIONS as $type) {
                         foreach ($document->getPermissionsByType($type) as $permission) {
                             $permission = \str_replace('"', '', $permission);
-                            $permissions[] = "('{$type}', '{$permission}', '{$document->getId()}', :_tenant)";
+							$permission = "('{$type}', '{$permission}', '{$document->getId()}'";
+
+							if ($this->shareTables) {
+								$permission .= ", :_tenant)";
+							} else {
+								$permission .= ")";
+							}
+
+							$permissions[] = $permission;
                         }
                     }
                 }
@@ -899,12 +931,24 @@ class MariaDB extends SQL
                 $stmt->execute();
 
                 if (!empty($permissions)) {
-                    $stmtPermissions = $this->getPDO()->prepare(
-                        "
-                        INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document, _tenant) 
-                        VALUES " . \implode(', ', $permissions)
-                    );
-                    $stmtPermissions->bindValue(':_tenant', $this->tenant);
+					$sqlPermissions = "
+						INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document
+					";
+
+					if ($this->shareTables) {
+						$sqlPermissions .= ', _tenant)';
+					} else {
+						$sqlPermissions .= ")";
+					}
+
+                    $sqlPermissions .= " VALUES " . \implode(', ', $permissions);
+
+					$stmtPermissions = $this->getPDO()->prepare($sqlPermissions);
+
+					if ($this->shareTables) {
+						$stmtPermissions->bindValue(':_tenant', $this->tenant);
+					}
+
                     $stmtPermissions?->execute();
                 }
             }
@@ -941,10 +985,13 @@ class MariaDB extends SQL
     public function updateDocument(string $collection, Document $document): Document
     {
         $attributes = $document->getAttributes();
-        $attributes['_tenant'] = $this->tenant;
         $attributes['_createdAt'] = $document->getCreatedAt();
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = json_encode($document->getPermissions());
+
+		if ($this->shareTables) {
+			$attributes['_tenant'] = $this->tenant;
+		}
 
         $name = $this->filter($collection);
         $columns = '';
@@ -1061,20 +1108,40 @@ class MariaDB extends SQL
             $values = [];
             foreach ($additions as $type => $permissions) {
                 foreach ($permissions as $i => $_) {
-                    $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i}, :_tenant)";
+                    $value = "( :_uid, '{$type}', :_add_{$type}_{$i}";
+
+					if ($this->shareTables) {
+						$value .= ", :_tenant)";
+					} else {
+						$value .= ")";
+					}
+
+					$values[] = $value;
                 }
             }
 
             $sql = "
-				INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission, _tenant)
-				VALUES " . \implode(', ', $values);
+				INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission
+			";
+
+			if ($this->shareTables) {
+				$sql .= ', _tenant)';
+			} else {
+				$sql .= ')';
+			}
+
+			$sql .= " VALUES " . \implode(', ', $values);
 
             $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
             $stmtAddPermissions = $this->getPDO()->prepare($sql);
 
             $stmtAddPermissions->bindValue(":_uid", $document->getId());
-            $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+
+			if ($this->shareTables) {
+				$stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+			}
+
             foreach ($additions as $type => $permissions) {
                 foreach ($permissions as $i => $permission) {
                     $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
@@ -1193,10 +1260,13 @@ class MariaDB extends SQL
                 foreach ($batch as $index => $document) {
                     $attributes = $document->getAttributes();
                     $attributes['_uid'] = $document->getId();
-                    $attributes['_tenant'] = $this->tenant;
                     $attributes['_createdAt'] = $document->getCreatedAt();
                     $attributes['_updatedAt'] = $document->getUpdatedAt();
                     $attributes['_permissions'] = json_encode($document->getPermissions());
+
+					if ($this->shareTables) {
+						$attributes['_tenant'] = $this->tenant;
+					}
 
                     $columns = \array_map(function ($attribute) {
                         return "`" . $this->filter($attribute) . "`";
@@ -1314,7 +1384,13 @@ class MariaDB extends SQL
                                 $bindKey = 'add_' . $type . '_' . $index . '_' . $i;
                                 $addBindValues[$bindKey] = $permission;
 
-                                $addQuery .= "(:uid_{$index}, '{$type}', :{$bindKey}, :_tenant)";
+                                $addQuery .= "(:uid_{$index}, '{$type}', :{$bindKey}";
+
+								if ($this->shareTables) {
+									$addQuery .= ", :_tenant)";
+								} else {
+									$addQuery .= ")";
+								}
 
                                 if ($i !== \array_key_last($permissionsToAdd) || $type !== \array_key_last($additions)) {
                                     $addQuery .= ', ';
@@ -1365,15 +1441,28 @@ class MariaDB extends SQL
                 }
 
                 if (!empty($addQuery)) {
-                    $stmtAddPermissions = $this->getPDO()->prepare("
-                        INSERT INTO {$this->getSQLTable($name . '_perms')} (`_document`, `_type`, `_permission`, `_tenant`)
-                        VALUES {$addQuery}
-                    ");
+					$sqlAddPermissions = "
+                        INSERT INTO {$this->getSQLTable($name . '_perms')} (`_document`, `_type`, `_permission`
+                    ";
+
+					if ($this->shareTables) {
+						$sqlAddPermissions .= ', `_tenant`)';
+					} else {
+						$sqlAddPermissions .= ')';
+					}
+
+                     $sqlAddPermissions .=  " VALUES {$addQuery}";
+
+					$stmtAddPermissions = $this->getPDO()->prepare($sqlAddPermissions);
 
                     foreach ($addBindValues as $key => $value) {
                         $stmtAddPermissions->bindValue($key, $value, $this->getPDOType($value));
                     }
-                    $stmtAddPermissions->bindValue(':_tenant', $this->tenant);
+
+					if ($this->shareTables) {
+						$stmtAddPermissions->bindValue(':_tenant', $this->tenant);
+					}
+
                     $stmtAddPermissions->execute();
                 }
             }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -720,9 +720,9 @@ class MariaDB extends SQL
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = \json_encode($document->getPermissions());
 
-		if ($this->shareTables) {
-			$attributes['_tenant'] = $this->tenant;
-		}
+        if ($this->shareTables) {
+            $attributes['_tenant'] = $this->tenant;
+        }
 
         $name = $this->filter($collection);
         $columns = '';
@@ -780,13 +780,13 @@ class MariaDB extends SQL
                 $permission = \str_replace('"', '', $permission);
                 $permission = "('{$type}', '{$permission}', '{$document->getId()}'";
 
-				if ($this->shareTables) {
-					$permission .= ", :_tenant)";
-				} else {
-					$permission .= ")";
-				}
+                if ($this->shareTables) {
+                    $permission .= ", :_tenant)";
+                } else {
+                    $permission .= ")";
+                }
 
-				$permissions[] = $permission;
+                $permissions[] = $permission;
             }
         }
 
@@ -797,19 +797,19 @@ class MariaDB extends SQL
 				INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document
 			";
 
-			if ($this->shareTables) {
-				$sqlPermissions .= ', _tenant)';
-			} else {
-				$sqlPermissions .= ")";
-			}
+            if ($this->shareTables) {
+                $sqlPermissions .= ', _tenant)';
+            } else {
+                $sqlPermissions .= ")";
+            }
 
-			$sqlPermissions .=	" VALUES {$permissions}";
+            $sqlPermissions .=	" VALUES {$permissions}";
             $sqlPermissions = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sqlPermissions);
             $stmtPermissions = $this->getPDO()->prepare($sqlPermissions);
 
-			if ($this->shareTables) {
-				$stmtPermissions->bindValue(':_tenant', $this->tenant);
-			}
+            if ($this->shareTables) {
+                $stmtPermissions->bindValue(':_tenant', $this->tenant);
+            }
         }
 
         try {
@@ -877,9 +877,9 @@ class MariaDB extends SQL
                     $attributes['_updatedAt'] = $document->getUpdatedAt();
                     $attributes['_permissions'] = \json_encode($document->getPermissions());
 
-					if ($this->shareTables) {
-						$attributes['_tenant'] = $this->tenant;
-					}
+                    if ($this->shareTables) {
+                        $attributes['_tenant'] = $this->tenant;
+                    }
 
                     $columns = [];
                     foreach (\array_keys($attributes) as $key => $attribute) {
@@ -905,15 +905,15 @@ class MariaDB extends SQL
                     foreach (Database::PERMISSIONS as $type) {
                         foreach ($document->getPermissionsByType($type) as $permission) {
                             $permission = \str_replace('"', '', $permission);
-							$permission = "('{$type}', '{$permission}', '{$document->getId()}'";
+                            $permission = "('{$type}', '{$permission}', '{$document->getId()}'";
 
-							if ($this->shareTables) {
-								$permission .= ", :_tenant)";
-							} else {
-								$permission .= ")";
-							}
+                            if ($this->shareTables) {
+                                $permission .= ", :_tenant)";
+                            } else {
+                                $permission .= ")";
+                            }
 
-							$permissions[] = $permission;
+                            $permissions[] = $permission;
                         }
                     }
                 }
@@ -931,23 +931,23 @@ class MariaDB extends SQL
                 $stmt->execute();
 
                 if (!empty($permissions)) {
-					$sqlPermissions = "
+                    $sqlPermissions = "
 						INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document
 					";
 
-					if ($this->shareTables) {
-						$sqlPermissions .= ', _tenant)';
-					} else {
-						$sqlPermissions .= ")";
-					}
+                    if ($this->shareTables) {
+                        $sqlPermissions .= ', _tenant)';
+                    } else {
+                        $sqlPermissions .= ")";
+                    }
 
                     $sqlPermissions .= " VALUES " . \implode(', ', $permissions);
 
-					$stmtPermissions = $this->getPDO()->prepare($sqlPermissions);
+                    $stmtPermissions = $this->getPDO()->prepare($sqlPermissions);
 
-					if ($this->shareTables) {
-						$stmtPermissions->bindValue(':_tenant', $this->tenant);
-					}
+                    if ($this->shareTables) {
+                        $stmtPermissions->bindValue(':_tenant', $this->tenant);
+                    }
 
                     $stmtPermissions?->execute();
                 }
@@ -989,9 +989,9 @@ class MariaDB extends SQL
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = json_encode($document->getPermissions());
 
-		if ($this->shareTables) {
-			$attributes['_tenant'] = $this->tenant;
-		}
+        if ($this->shareTables) {
+            $attributes['_tenant'] = $this->tenant;
+        }
 
         $name = $this->filter($collection);
         $columns = '';
@@ -1110,13 +1110,13 @@ class MariaDB extends SQL
                 foreach ($permissions as $i => $_) {
                     $value = "( :_uid, '{$type}', :_add_{$type}_{$i}";
 
-					if ($this->shareTables) {
-						$value .= ", :_tenant)";
-					} else {
-						$value .= ")";
-					}
+                    if ($this->shareTables) {
+                        $value .= ", :_tenant)";
+                    } else {
+                        $value .= ")";
+                    }
 
-					$values[] = $value;
+                    $values[] = $value;
                 }
             }
 
@@ -1124,13 +1124,13 @@ class MariaDB extends SQL
 				INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission
 			";
 
-			if ($this->shareTables) {
-				$sql .= ', _tenant)';
-			} else {
-				$sql .= ')';
-			}
+            if ($this->shareTables) {
+                $sql .= ', _tenant)';
+            } else {
+                $sql .= ')';
+            }
 
-			$sql .= " VALUES " . \implode(', ', $values);
+            $sql .= " VALUES " . \implode(', ', $values);
 
             $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
@@ -1138,9 +1138,9 @@ class MariaDB extends SQL
 
             $stmtAddPermissions->bindValue(":_uid", $document->getId());
 
-			if ($this->shareTables) {
-				$stmtAddPermissions->bindValue(":_tenant", $this->tenant);
-			}
+            if ($this->shareTables) {
+                $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+            }
 
             foreach ($additions as $type => $permissions) {
                 foreach ($permissions as $i => $permission) {
@@ -1264,9 +1264,9 @@ class MariaDB extends SQL
                     $attributes['_updatedAt'] = $document->getUpdatedAt();
                     $attributes['_permissions'] = json_encode($document->getPermissions());
 
-					if ($this->shareTables) {
-						$attributes['_tenant'] = $this->tenant;
-					}
+                    if ($this->shareTables) {
+                        $attributes['_tenant'] = $this->tenant;
+                    }
 
                     $columns = \array_map(function ($attribute) {
                         return "`" . $this->filter($attribute) . "`";
@@ -1386,11 +1386,11 @@ class MariaDB extends SQL
 
                                 $addQuery .= "(:uid_{$index}, '{$type}', :{$bindKey}";
 
-								if ($this->shareTables) {
-									$addQuery .= ", :_tenant)";
-								} else {
-									$addQuery .= ")";
-								}
+                                if ($this->shareTables) {
+                                    $addQuery .= ", :_tenant)";
+                                } else {
+                                    $addQuery .= ")";
+                                }
 
                                 if ($i !== \array_key_last($permissionsToAdd) || $type !== \array_key_last($additions)) {
                                     $addQuery .= ', ';
@@ -1441,27 +1441,27 @@ class MariaDB extends SQL
                 }
 
                 if (!empty($addQuery)) {
-					$sqlAddPermissions = "
+                    $sqlAddPermissions = "
                         INSERT INTO {$this->getSQLTable($name . '_perms')} (`_document`, `_type`, `_permission`
                     ";
 
-					if ($this->shareTables) {
-						$sqlAddPermissions .= ', `_tenant`)';
-					} else {
-						$sqlAddPermissions .= ')';
-					}
+                    if ($this->shareTables) {
+                        $sqlAddPermissions .= ', `_tenant`)';
+                    } else {
+                        $sqlAddPermissions .= ')';
+                    }
 
-                     $sqlAddPermissions .=  " VALUES {$addQuery}";
+                    $sqlAddPermissions .=  " VALUES {$addQuery}";
 
-					$stmtAddPermissions = $this->getPDO()->prepare($sqlAddPermissions);
+                    $stmtAddPermissions = $this->getPDO()->prepare($sqlAddPermissions);
 
                     foreach ($addBindValues as $key => $value) {
                         $stmtAddPermissions->bindValue($key, $value, $this->getPDOType($value));
                     }
 
-					if ($this->shareTables) {
-						$stmtAddPermissions->bindValue(':_tenant', $this->tenant);
-					}
+                    if ($this->shareTables) {
+                        $stmtAddPermissions->bindValue(':_tenant', $this->tenant);
+                    }
 
                     $stmtAddPermissions->execute();
                 }


### PR DESCRIPTION
In migrations we have an issue where previous tables did not have the _tenant column so trying to insert a new row with this column set would throw an exception. We didn't add this check before to reduce complexity. Now we check all cases where _tenant is used and only add it if `shareTables` is enabled