### PR TITLE
Fix structure validator allowing objects for arrays

### DIFF
--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -285,16 +285,17 @@ class Structure extends Validator
             }
 
             if ($array) { // Validate attribute type for arrays - format for arrays handled separately
-                if ($required == false && ((is_array($value) && empty($value)) || is_null($value))) { // Allow both null and [] for optional arrays
+                if (!$required && ((is_array($value) && empty($value)) || is_null($value))) { // Allow both null and [] for optional arrays
                     continue;
                 }
-                if (!is_array($value)) {
+
+                if (!\is_array($value) || (!empty($value) && \array_keys($value) !== \range(0, count($value) - 1))) {
                     $this->message = 'Attribute "'.$key.'" must be an array';
                     return false;
                 }
 
                 foreach ($value as $x => $child) {
-                    if ($required == false && is_null($child)) { // Allow null value to optional params
+                    if (!$required && is_null($child)) { // Allow null value to optional params
                         continue;
                     }
 

--- a/tests/Database/Validator/StructureTest.php
+++ b/tests/Database/Validator/StructureTest.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Tests\Validator;
 
+use Utopia\Database\Exception;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Validator\Structure;
 use PHPUnit\Framework\TestCase;
@@ -295,7 +296,6 @@ class StructureTest extends TestCase
             'feedback' => 'team@appwrite.io',
         ])));
 
-
         $this->assertEquals(false, $validator->isValid(new Document([
             '$collection' => ID::custom('posts'),
             'title' => 'string',
@@ -308,6 +308,41 @@ class StructureTest extends TestCase
         ])));
 
         $this->assertEquals('Invalid document structure: Attribute "tags[\'0\']" has invalid type. Value must be a valid string and no longer than 55 chars', $validator->getDescription());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testArrayAsObjectValidation(): void
+    {
+        $validator = new Structure(new Document($this->collection));
+
+        $this->assertEquals(false, $validator->isValid(new Document([
+            '$collection' => ID::custom('posts'),
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'price' => 1.99,
+            'published' => true,
+            'tags' => ['name' => 'dog'],
+            'feedback' => 'team@appwrite.io'
+        ])));
+    }
+
+    public function testArrayOfObjectsValidation(): void
+    {
+        $validator = new Structure(new Document($this->collection));
+
+        $this->assertEquals(false, $validator->isValid(new Document([
+            '$collection' => ID::custom('posts'),
+            'title' => 'string',
+            'description' => 'Demo description',
+            'rating' => 5,
+            'price' => 1.99,
+            'published' => true,
+            'tags' => [['name' => 'dog']],
+            'feedback' => 'team@appwrite.io'
+        ])));
     }
 
     public function testIntegerValidation(): void


### PR DESCRIPTION
By validating that all keys of array attributes are numerical and in order from 0..count(values)-1