### PR TITLE
Add skipValidation method to Database class

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -775,6 +775,27 @@ class Database
     }
 
     /**
+     * Skip Validation
+     *
+     * Skips validation for the code to be executed inside the callback
+     *
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    public function skipValidation(callable $callback): mixed
+    {
+        $initial = $this->validate;
+        $this->disableValidation();
+
+        try {
+            return $callback();
+        } finally {
+            $this->validate = $initial;
+        }
+    }
+
+    /**
      * Set Share Tables
      *
      * Set whether to share tables between tenants
@@ -1056,8 +1077,10 @@ class Database
             throw new DatabaseException('Collection not found');
         }
 
-        if ($this->adapter->getSharedTables()
-            && $collection->getAttribute('$tenant') != $this->adapter->getTenant()) {
+        if (
+            $this->adapter->getSharedTables()
+            && $collection->getAttribute('$tenant') != $this->adapter->getTenant()
+        ) {
             throw new DatabaseException('Collection not found');
         }
 
@@ -1088,9 +1111,11 @@ class Database
 
         $collection = $this->silent(fn () => $this->getDocument(self::METADATA, $id));
 
-        if ($id !== self::METADATA
+        if (
+            $id !== self::METADATA
             && $this->adapter->getSharedTables()
-            && $collection->getAttribute('$tenant') != $this->adapter->getTenant()) {
+            && $collection->getAttribute('$tenant') != $this->adapter->getTenant()
+        ) {
             return new Document();
         }
 
@@ -2525,10 +2550,10 @@ class Database
 
         foreach ($attributes as $i => $attr) {
             foreach ($collectionAttributes as $collectionAttribute) {
-                if($collectionAttribute->getAttribute('key') === $attr) {
+                if ($collectionAttribute->getAttribute('key') === $attr) {
                     $isArray = $collectionAttribute->getAttribute('array', false);
-                    if($isArray) {
-                        if($this->adapter->getMaxIndexLength() > 0) {
+                    if ($isArray) {
+                        if ($this->adapter->getMaxIndexLength() > 0) {
                             $lengths[$i] = self::ARRAY_INDEX_LENGTH;
                         }
                         $orders[$i] = null;
@@ -2794,7 +2819,6 @@ class Database
             $this->cache->save($documentCacheKey, $document->getArrayCopy(), $documentCacheHash);
             //add document reference to the collection key
             $this->cache->save($collectionCacheKey, 'empty', $documentCacheKey);
-
         }
 
         // Remove internal attributes if not queried for select query
@@ -3087,7 +3111,7 @@ class Database
             ->setAttribute('$createdAt', empty($createdAt) || !$this->preserveDates ? $time : $createdAt)
             ->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt);
 
-        if($this->adapter->getSharedTables()) {
+        if ($this->adapter->getSharedTables()) {
             $document['$tenant'] = (string)$this->adapter->getTenant();
         }
 
@@ -3216,7 +3240,7 @@ class Database
             try {
                 switch (\gettype($value)) {
                     case 'array':
-                        if(
+                        if (
                             ($relationType === Database::RELATION_MANY_TO_ONE && $side === Database::RELATION_SIDE_PARENT) ||
                             ($relationType === Database::RELATION_ONE_TO_MANY && $side === Database::RELATION_SIDE_CHILD) ||
                             ($relationType === Database::RELATION_ONE_TO_ONE)
@@ -3268,11 +3292,11 @@ class Database
                             throw new RelationshipException('Invalid relationship value. Must be either a document, document ID, or an array of documents or document IDs.');
                         }
 
-                        if($relationType === Database::RELATION_ONE_TO_ONE && !$twoWay && $side === Database::RELATION_SIDE_CHILD) {
+                        if ($relationType === Database::RELATION_ONE_TO_ONE && !$twoWay && $side === Database::RELATION_SIDE_CHILD) {
                             throw new RelationshipException('Invalid relationship value. Cannot set a value from the child side of a oneToOne relationship when twoWay is false.');
                         }
 
-                        if(
+                        if (
                             ($relationType === Database::RELATION_ONE_TO_MANY && $side === Database::RELATION_SIDE_PARENT) ||
                             ($relationType === Database::RELATION_MANY_TO_ONE && $side === Database::RELATION_SIDE_CHILD) ||
                             ($relationType === Database::RELATION_MANY_TO_MANY)
@@ -3295,11 +3319,11 @@ class Database
                         break;
 
                     case 'string':
-                        if($relationType === Database::RELATION_ONE_TO_ONE && $twoWay === false && $side === Database::RELATION_SIDE_CHILD) {
+                        if ($relationType === Database::RELATION_ONE_TO_ONE && $twoWay === false && $side === Database::RELATION_SIDE_CHILD) {
                             throw new RelationshipException('Invalid relationship value. Cannot set a value from the child side of a oneToOne relationship when twoWay is false.');
                         }
 
-                        if(
+                        if (
                             ($relationType === Database::RELATION_ONE_TO_MANY && $side === Database::RELATION_SIDE_PARENT) ||
                             ($relationType === Database::RELATION_MANY_TO_ONE && $side === Database::RELATION_SIDE_CHILD) ||
                             ($relationType === Database::RELATION_MANY_TO_MANY)
@@ -3519,7 +3543,7 @@ class Database
 
         $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
         $document['$collection'] = $old->getAttribute('$collection');   // Make sure user doesn't switch collection ID
-        if($this->adapter->getSharedTables()) {
+        if ($this->adapter->getSharedTables()) {
             $document['$tenant'] = $old->getAttribute('$tenant');           // Make sure user doesn't switch tenant
         }
         $document['$createdAt'] = $old->getCreatedAt();                 // Make sure user doesn't switch createdAt
@@ -3585,7 +3609,7 @@ class Database
                                 break;
                             }
 
-                            if(!\is_array($value) || !\array_is_list($value)) {
+                            if (!\is_array($value) || !\array_is_list($value)) {
                                 throw new RelationshipException('Invalid relationship value. Must be either an array of documents or document IDs, ' . \gettype($value) . ' given.');
                             }
 
@@ -3813,7 +3837,7 @@ class Database
                 switch ($relationType) {
                     case Database::RELATION_ONE_TO_ONE:
                         if (!$twoWay) {
-                            if($side === Database::RELATION_SIDE_CHILD) {
+                            if ($side === Database::RELATION_SIDE_CHILD) {
                                 throw new RelationshipException('Invalid relationship value. Cannot set a value from the child side of a oneToOne relationship when twoWay is false.');
                             }
 
@@ -3933,7 +3957,7 @@ class Database
                             ($relationType === Database::RELATION_ONE_TO_MANY && $side === Database::RELATION_SIDE_PARENT) ||
                             ($relationType === Database::RELATION_MANY_TO_ONE && $side === Database::RELATION_SIDE_CHILD)
                         ) {
-                            if(!\is_array($value) || !\array_is_list($value)) {
+                            if (!\is_array($value) || !\array_is_list($value)) {
                                 throw new RelationshipException('Invalid relationship value. Must be either an array of documents or document IDs, ' . \gettype($value) . ' given.');
                             }
 

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -14955,6 +14955,12 @@ abstract class Base extends TestCase
         } catch (Exception $e) {
             $this->assertInstanceOf(Exception::class, $e);
         }
+
+        $database->skipValidation(function () use ($database) {
+            $database->find('validation', queries: [
+                Query::equal('$id', ['docwithmorethan36charsasitsidentifier']),
+            ]);
+        });
     }
 
     public function testMetadata(): void


### PR DESCRIPTION
skipValidation() ensures the initial state will be restored after the callback is executed.