### PR TITLE
Don't throw on duplicate column for shared tables

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -4,6 +4,8 @@ namespace Utopia\Database;
 
 use Exception;
 use Utopia\Database\Exception as DatabaseException;
+use Utopia\Database\Exception\Duplicate as DuplicateException;
+use Utopia\Database\Exception\Timeout as TimeoutException;
 
 abstract class Adapter
 {
@@ -337,6 +339,8 @@ abstract class Adapter
      * @param bool $signed
      * @param bool $array
      * @return bool
+     * @throws TimeoutException
+     * @throws DuplicateException
      */
     abstract public function createAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool;
 
@@ -599,6 +603,13 @@ abstract class Adapter
      * @return bool
      */
     abstract public function getSupportForSchemas(): bool;
+
+    /**
+     * Are attributes supported?
+     *
+     * @return bool
+     */
+    abstract public function getSupportForAttributes(): bool;
 
     /**
      * Is index supported?

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -165,7 +165,7 @@ class Mongo extends Adapter
         try {
             $this->getClient()->createCollection($id);
         } catch (MongoException $e) {
-            throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+            throw new Duplicate($e->getMessage(), $e->getCode(), $e);
         }
 
         $indexesCreated = $this->client->createIndexes($id, [[
@@ -1559,6 +1559,16 @@ class Mongo extends Adapter
     public function getSupportForSchemas(): bool
     {
         return true;
+    }
+
+    /**
+     * Are attributes supported?
+     *
+     * @return bool
+     */
+    public function getSupportForAttributes(): bool
+    {
+        return false;
     }
 
     /**

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -230,6 +230,16 @@ abstract class SQL extends Adapter
     }
 
     /**
+     * Are attributes supported?
+     *
+     * @return bool
+     */
+    public function getSupportForAttributes(): bool
+    {
+        return true;
+    }
+
+    /**
      * Is unique index supported?
      *
      * @return bool

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1269,7 +1269,7 @@ class Database
             throw new DatabaseException('Collection not found');
         }
 
-        // attribute IDs are case insensitive
+        // Attribute IDs are case insensitive
         $attributes = $collection->getAttribute('attributes', []);
         /** @var array<Document> $attributes */
         foreach ($attributes as $attribute) {
@@ -1351,10 +1351,17 @@ class Database
             $this->validateDefaultTypes($type, $default);
         }
 
-        $created = $this->adapter->createAttribute($collection->getId(), $id, $type, $size, $signed, $array);
+        try {
+            $created = $this->adapter->createAttribute($collection->getId(), $id, $type, $size, $signed, $array);
 
-        if (!$created) {
-            throw new DatabaseException('Failed to create attribute');
+            if (!$created) {
+                throw new DatabaseException('Failed to create attribute');
+            }
+        } catch (DuplicateException $e) {
+            // HACK: Metadata should still be updated, can be removed when null tenant collections are supported.
+            if (!$this->adapter->getSharedTables()) {
+                throw $e;
+            }
         }
 
         if ($collection->getId() !== self::METADATA) {

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -1220,8 +1220,14 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'socialAccountForYoutubeSubscribersss', Database::VAR_BOOLEAN, 0, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', '5f058a89258075f058a89258075f058t9214', Database::VAR_BOOLEAN, 0, true));
 
-        // Using this collection to test invalid default values
-        // static::getDatabase()->deleteCollection('attributes');
+        // Test shared tables duplicates throw duplicate
+        static::getDatabase()->createAttribute('attributes', 'duplicate', Database::VAR_STRING, 128, true);
+        try {
+            static::getDatabase()->createAttribute('attributes', 'duplicate', Database::VAR_STRING, 128, true);
+            $this->fail('Failed to throw exception');
+        } catch (Exception $e) {
+            $this->assertInstanceOf(DuplicateException::class, $e);
+        }
     }
 
     /**
@@ -15011,7 +15017,7 @@ abstract class Base extends TestCase
      * @throws StructureException
      * @throws TimeoutException
      */
-    public function testIsolationModes(): void
+    public function testSharedTables(): void
     {
         /**
          * Default mode already tested, we'll test 'schema' and 'table' isolation here
@@ -15185,6 +15191,51 @@ abstract class Base extends TestCase
         }
 
         // Reset state
+        $database->setSharedTables(false);
+        $database->setNamespace(static::$namespace);
+        $database->setDatabase($this->testDatabase);
+    }
+
+    public function testSharedTablesDuplicateAttributesDontThrow(): void
+    {
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        if ($database->exists('sharedTables')) {
+            $database->setDatabase('sharedTables')->delete();
+        }
+
+        $database
+            ->setDatabase('sharedTables')
+            ->setNamespace('')
+            ->setSharedTables(true)
+            ->setTenant(1)
+            ->create();
+
+        // Create collection
+        $database->createCollection('duplicates', documentSecurity: false);
+        $database->createAttribute('duplicates', 'name', Database::VAR_STRING, 10, false);
+
+        $database->setTenant(2);
+        try {
+            $database->createCollection('duplicates', documentSecurity: false);
+        } catch (DuplicateException) {
+            // Ignore
+        }
+        $database->createAttribute('duplicates', 'name', Database::VAR_STRING, 10, false);
+
+        $collection = $database->getCollection('duplicates');
+        $this->assertEquals(1, \count($collection->getAttribute('attributes')));
+
+        $database->setTenant(1);
+
+        $collection = $database->getCollection('duplicates');
+        $this->assertEquals(1, \count($collection->getAttribute('attributes')));
+
         $database->setSharedTables(false);
         $database->setNamespace(static::$namespace);
         $database->setDatabase($this->testDatabase);


### PR DESCRIPTION
To allow multiple metadata entries to be updated. Temporary fix until all databases are using shared tables with a single metadata document for all projects. 