### PR TITLE
Implement Renaming Attributes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -266,16 +266,16 @@
         },
         {
             "name": "utopia-php/framework",
-            "version": "0.33.6",
+            "version": "0.33.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/http.git",
-                "reference": "8fe57da0cecd57e3b17cd395b4a666a24f4c07a6"
+                "reference": "78d293d99a262bd63ece750bbf989c7e0643b825"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/http/zipball/8fe57da0cecd57e3b17cd395b4a666a24f4c07a6",
-                "reference": "8fe57da0cecd57e3b17cd395b4a666a24f4c07a6",
+                "url": "https://api.github.com/repos/utopia-php/http/zipball/78d293d99a262bd63ece750bbf989c7e0643b825",
+                "reference": "78d293d99a262bd63ece750bbf989c7e0643b825",
                 "shasum": ""
             },
             "require": {
@@ -305,9 +305,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/http/issues",
-                "source": "https://github.com/utopia-php/http/tree/0.33.6"
+                "source": "https://github.com/utopia-php/http/tree/0.33.7"
             },
-            "time": "2024-03-21T18:10:57+00:00"
+            "time": "2024-08-01T14:01:04+00:00"
         },
         {
             "name": "utopia-php/mongo",

--- a/dev/xdebug.ini
+++ b/dev/xdebug.ini
@@ -1,0 +1,8 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=develop,debug,profile
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes
+xdebug.output_dir=/tmp/xdebug
+xdebug.use_compression=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,15 @@ services:
     image: databases-dev
     build:
       context: .
+      args:
+        DEBUG: false
     networks:
       - database
     volumes:
       - ./bin:/usr/src/code/bin
       - ./src:/usr/src/code/src
       - ./tests:/usr/src/code/tests
+      - ./dev:/usr/src/code/dev
       - ./phpunit.xml:/usr/src/code/phpunit.xml
     ports:
       - "8708:8708"

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -349,10 +349,11 @@ abstract class Adapter
      * @param int $size
      * @param bool $signed
      * @param bool $array
+     * @param string $newKey
      *
      * @return bool
      */
-    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool;
+    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool;
 
     /**
      * Delete Attribute

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -314,7 +314,13 @@ class MariaDB extends SQL
         $id = $this->filter($id);
         $type = $this->getSQLType($type, $size, $signed, $array);
 
-        $sql = "ALTER TABLE {$this->getSQLTable($name)} CHANGE COLUMN `{$id}` {$newKey} {$type};";
+        if (!empty($newKey)) {
+            $newKey = $this->filter($newKey);
+            $sql = "ALTER TABLE {$this->getSQLTable($name)} CHANGE COLUMN `{$id}` {$newKey} {$type};";
+        } else {
+            $sql = "ALTER TABLE {$this->getSQLTable($name)} MODIFY `{$id}` {$type};";
+        }
+
         $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
 
         return $this->getPDO()

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -303,18 +303,18 @@ class MariaDB extends SQL
      * @param int $size
      * @param bool $signed
      * @param bool $array
+     * @param string $newKey
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
         $name = $this->filter($collection);
         $id = $this->filter($id);
         $type = $this->getSQLType($type, $size, $signed, $array);
 
-        $sql = "ALTER TABLE {$this->getSQLTable($name)} MODIFY `{$id}` {$type};";
-
+        $sql = "ALTER TABLE {$this->getSQLTable($name)} CHANGE COLUMN `{$id}` {$newKey} {$type};";
         $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
 
         return $this->getPDO()

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -902,11 +902,16 @@ class Mongo extends Adapter
      * @param int $size
      * @param bool $signed
      * @param bool $array
+     * @param string $newKey
      *
      * @return bool
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
+        if (!empty($newKey) && $newKey !== $id) {
+            return $this->renameAttribute($collection, $id, $newKey);
+        }
+
         return true;
     }
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -343,30 +343,68 @@ class Postgres extends SQL
      * @param int $size
      * @param bool $signed
      * @param bool $array
+     * @param string $newKey
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
-        $name = $this->filter($collection);
-        $id = $this->filter($id);
-        $type = $this->getSQLType($type, $size, $signed, $array);
+        try {
+            $name = $this->filter($collection);
+            $id = $this->filter($id);
+            $type = $this->getSQLType($type, $size, $signed, $array);
 
-        if ($type == 'TIMESTAMP(3)') {
-            $type = "TIMESTAMP(3) without time zone USING TO_TIMESTAMP(\"$id\", 'YYYY-MM-DD HH24:MI:SS.MS')";
+            $this->getPDO()->beginTransaction();
+
+            if ($type == 'TIMESTAMP(3)') {
+                $type = "TIMESTAMP(3) without time zone USING TO_TIMESTAMP(\"$id\", 'YYYY-MM-DD HH24:MI:SS.MS')";
+            }
+
+            if (!empty($newKey) && $id !== $newKey) {
+                $newKey = $this->filter($newKey);
+
+                $sql = "
+                    ALTER TABLE {$this->getSQLTable($name)}
+                    RENAME COLUMN \"{$id}\" TO \"{$newKey}\"
+                ";
+
+                $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+                $result = $this->getPDO()
+                    ->prepare($sql)
+                    ->execute();
+
+                if (!$result) {
+                    return false;
+                }
+
+                $id = $newKey;
+            }
+
+            $sql = "
+                ALTER TABLE {$this->getSQLTable($name)}
+                ALTER COLUMN \"{$id}\" TYPE {$type}
+            ";
+
+            $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+            $result = $this->getPDO()
+                ->prepare($sql)
+                ->execute();
+
+            if (!$this->getPDO()->commit()) {
+                throw new DatabaseException('Failed to commit transaction');
+            }
+
+            return $result;
+        } catch (\Throwable $e) {
+            if($this->getPDO()->inTransaction()) {
+                $this->getPDO()->rollBack();
+            }
+
+            throw $e;
         }
-
-        $sql = "
-			ALTER TABLE {$this->getSQLTable($name)}
-			ALTER COLUMN \"{$id}\" TYPE {$type}
-		";
-
-        $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
-
-        return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
     }
 
     /**

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -278,12 +278,17 @@ class SQLite extends MariaDB
      * @param int $size
      * @param bool $signed
      * @param bool $array
+     * @param string $newKey
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
+        if (!empty($newKey) && $newKey !== $id) {
+            return $this->renameAttribute($collection, $id, $newKey);
+        }
+
         return true;
     }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1495,7 +1495,7 @@ class Database
         }
 
         $attributes = $collection->getAttribute('attributes', []);
-        $index = \array_search($id, \array_map(fn ($attribute) => $attribute['key'], $attributes));
+        $index = \array_search($id, \array_map(fn ($attribute) => $attribute['$id'], $attributes));
 
         if ($index === false) {
             throw new DatabaseException('Attribute not found');

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1698,6 +1698,7 @@ class Database
             }
 
             $attribute
+                ->setAttribute('$id', $newKey ?? $id)
                 ->setattribute('key', $newKey ?? $id)
                 ->setAttribute('type', $type)
                 ->setAttribute('size', $size)
@@ -5182,7 +5183,7 @@ class Database
         $attributes = \array_merge($attributes, $internalAttributes);
 
         foreach ($attributes as $attribute) {
-            $key = $attribute['key'] ?? $attribute['$id'] ?? '';
+            $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $default = $attribute['default'] ?? null;
             $filters = $attribute['filters'] ?? [];
@@ -5260,7 +5261,7 @@ class Database
         $attributes = array_merge($attributes, $this->getInternalAttributes());
 
         foreach ($attributes as $attribute) {
-            $key = $attribute['key'] ?? $attribute['$id'] ?? '';
+            $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key);
@@ -5319,7 +5320,7 @@ class Database
         $attributes = $collection->getAttribute('attributes', []);
 
         foreach ($attributes as $attribute) {
-            $key = $attribute['key'] ?? $attribute['$id'] ?? '';
+            $key = $attribute['$id'] ?? '';
             $type = $attribute['type'] ?? '';
             $array = $attribute['array'] ?? false;
             $value = $document->getAttribute($key, null);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5182,7 +5182,7 @@ class Database
         $attributes = \array_merge($attributes, $internalAttributes);
 
         foreach ($attributes as $attribute) {
-            $key = $attribute['$id'] ?? '';
+            $key = $attribute['key'] ?? $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $default = $attribute['default'] ?? null;
             $filters = $attribute['filters'] ?? [];
@@ -5260,7 +5260,7 @@ class Database
         $attributes = array_merge($attributes, $this->getInternalAttributes());
 
         foreach ($attributes as $attribute) {
-            $key = $attribute['$id'] ?? '';
+            $key = $attribute['key'] ?? $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key);
@@ -5319,7 +5319,7 @@ class Database
         $attributes = $collection->getAttribute('attributes', []);
 
         foreach ($attributes as $attribute) {
-            $key = $attribute['$id'] ?? '';
+            $key = $attribute['key'] ?? $attribute['$id'] ?? '';
             $type = $attribute['type'] ?? '';
             $array = $attribute['array'] ?? false;
             $value = $document->getAttribute($key, null);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1724,15 +1724,11 @@ class Database
             if ($altering) {
                 $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array, $newKey);
 
-                // Update Indexes
                 if ($id !== $newKey) {
-                    // Grab all collection indexes
                     $indexes = $collectionDoc->getAttribute('indexes');
 
-                    // Check if any of the attributes of the index have the same ID as the Old ID
                     foreach ($indexes as $index) {
                         if (in_array($id, $index['attributes'])) {
-                            // Update the metadata of the index
                             $index['attributes'] = array_map(function ($attribute) use ($id, $newKey) {
                                 return $attribute === $id ? $newKey : $attribute;
                             }, $index['attributes']);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1476,7 +1476,7 @@ class Database
      *
      * @param string $collection
      * @param string $id
-     * @param callable(array, Document, int|string): void $updateCallback method that receives document, and returns it with changes applied
+     * @param callable(Document, Document, int|string): void $updateCallback method that receives document, and returns it with changes applied
      *
      * @return Document
      * @throws ConflictException

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1623,16 +1623,18 @@ class Database
      * @param string|null $format
      * @param array<string, mixed>|null $formatOptions
      * @param array<string>|null $filters
+     * @param string|null $newKey
      * @return Document
      * @throws Exception
      */
-    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $required = null, mixed $default = null, bool $signed = null, bool $array = null, string $format = null, ?array $formatOptions = null, ?array $filters = null): Document
+    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $required = null, mixed $default = null, bool $signed = null, bool $array = null, string $format = null, ?array $formatOptions = null, ?array $filters = null, ?string $newKey = null): Document
     {
-        return $this->updateAttributeMeta($collection, $id, function ($attribute, $collectionDoc, $attributeIndex) use ($collection, $id, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters) {
+        return $this->updateAttributeMeta($collection, $id, function ($attribute, $collectionDoc, $attributeIndex) use ($collection, $id, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters, $newKey) {
             $altering = !\is_null($type)
                 || !\is_null($size)
                 || !\is_null($signed)
-                || !\is_null($array);
+                || !\is_null($array)
+                || !\is_null($newKey);
             $type ??= $attribute->getAttribute('type');
             $size ??= $attribute->getAttribute('size');
             $signed ??= $attribute->getAttribute('signed');
@@ -1718,7 +1720,7 @@ class Database
             }
 
             if ($altering) {
-                $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array);
+                $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array, $newKey);
 
                 if (!$updated) {
                     throw new DatabaseException('Failed to update attribute');

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5725,6 +5725,36 @@ abstract class Base extends TestCase
         $this->assertEquals('2000-06-12T14:12:55.000+00:00', $doc->getAttribute('date'));
     }
 
+    public function testUpdateAttributeRename(): void
+    {
+        static::getDatabase()->createCollection('rename');
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute('rename', 'rename_me', Database::VAR_STRING, 128, true));
+
+        $doc = static::getDatabase()->createDocument('rename', new Document([
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'rename_me' => 'rename me'
+        ]));
+
+        $this->assertEquals('rename me', $doc->getAttribute('rename_me'));
+
+        static::getDatabase()->updateAttribute(
+            collection: 'rename',
+            id: 'rename_me',
+            newKey: 'renamed',
+        );
+
+        $doc = static::getDatabase()->getDocument('rename', $doc->getId());
+
+        $this->assertEquals('rename me', $doc->getAttribute('renamed'));
+        $this->assertNull($doc->getAttribute('rename_me'));
+    }
+
     /**
      * @depends testCreatedAtUpdatedAt
      */

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5754,6 +5754,7 @@ abstract class Base extends TestCase
 
         $doc = static::getDatabase()->getDocument('rename_test', $doc->getId());
 
+        // Check the attribute was correctly renamed
         $this->assertEquals('string', $doc->getAttribute('renamed'));
         $this->assertNull($doc->getAttribute('rename_me'));
 
@@ -5780,6 +5781,31 @@ abstract class Base extends TestCase
         // Check the indexes were updated
         $index = $collection->getAttribute('indexes')[0];
         $this->assertEquals('renamed', $index->getAttribute('attributes')[0]);
+
+        // Try and create new document with new key
+        $doc = static::getDatabase()->createDocument('rename_test', new Document([
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'renamed' => 'string'
+        ]));
+
+        $this->assertEquals('string', $doc->getAttribute('renamed'));
+
+        // Make sure we can't create a new attribute with the old key
+        $this->expectException(StructureException::class);
+        $doc = static::getDatabase()->createDocument('rename_test', new Document([
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'rename_me' => 'string'
+        ]));
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5738,13 +5738,13 @@ abstract class Base extends TestCase
                 Permission::update(Role::any()),
                 Permission::delete(Role::any()),
             ],
-            'rename_me' => 'rename me'
+            'rename_me' => 'string'
         ]));
+
+        $this->assertEquals('string', $doc->getAttribute('rename_me'));
 
         // Create an index to check later
         static::getDatabase()->createIndex('rename_test', 'renameIndexes', Database::INDEX_KEY, ['rename_me'], [], [Database::ORDER_DESC, Database::ORDER_DESC]);
-
-        $this->assertEquals('rename me', $doc->getAttribute('rename_me'));
 
         static::getDatabase()->updateAttribute(
             collection: 'rename_test',
@@ -5754,7 +5754,7 @@ abstract class Base extends TestCase
 
         $doc = static::getDatabase()->getDocument('rename_test', $doc->getId());
 
-        $this->assertEquals('rename me', $doc->getAttribute('renamed'));
+        $this->assertEquals('string', $doc->getAttribute('renamed'));
         $this->assertNull($doc->getAttribute('rename_me'));
 
         // Check collection
@@ -5770,7 +5770,8 @@ abstract class Base extends TestCase
 
         $doc = static::getDatabase()->getDocument('rename_test', $doc->getId());
 
-        $this->assertEquals('rename me', $doc->getAttribute('renamed'));
+        $this->assertEquals('string', $doc->getAttribute('renamed'));
+        $this->assertArrayNotHasKey('rename_me', $doc->getAttributes());
 
         // Check the metadata was correctly updated
         $attribute = $collection->getAttribute('attributes')[0];


### PR DESCRIPTION
This PR implements the ability to update attribute's names by adding $newKey to `updateAttributes()`; It also includes `xdebug` for easier debugging.