### PR TITLE
Feat atomic updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,14 +41,14 @@
         "utopia-php/mongo": "0.3.*"
     },
     "require-dev": {
-        "fakerphp/faker": "^1.14",
-        "phpunit/phpunit": "^9.4",
-        "pcov/clobber": "^2.0",
-        "swoole/ide-helper": "4.8.0",
-        "utopia-php/cli": "^0.14.0",
-        "laravel/pint": "1.13.*",
-        "phpstan/phpstan": "1.10.*",
-        "rregeer/phpunit-coverage-check": "^0.3.1"
+        "fakerphp/faker": "1.23.*",
+        "phpunit/phpunit": "9.6.*",
+        "pcov/clobber": "2.0.*",
+        "swoole/ide-helper": "5.1.3",
+        "utopia-php/cli": "0.14.*",
+        "laravel/pint": "1.17.*",
+        "phpstan/phpstan": "1.11.*",
+        "rregeer/phpunit-coverage-check": "0.3.*"
     },
     "suggests": {
         "ext-mongodb": "Needed to support MongoDB Database Adapter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b71e4329463ee71c5067fa62792a52f",
+    "content-hash": "8a6537ec5c4f47cd0b6c34e9ceda042b",
     "packages": [
         {
             "name": "jean85/pretty-package-versions",
@@ -506,16 +506,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.13.11",
+            "version": "v1.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "60a163c3e7e3346a1dec96d3e6f02e6465452552"
+                "reference": "e8a88130a25e3f9d4d5785e6a1afca98268ab110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/60a163c3e7e3346a1dec96d3e6f02e6465452552",
-                "reference": "60a163c3e7e3346a1dec96d3e6f02e6465452552",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/e8a88130a25e3f9d4d5785e6a1afca98268ab110",
+                "reference": "e8a88130a25e3f9d4d5785e6a1afca98268ab110",
                 "shasum": ""
             },
             "require": {
@@ -526,13 +526,13 @@
                 "php": "^8.1.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.49.0",
-                "illuminate/view": "^10.43.0",
-                "larastan/larastan": "^2.8.1",
-                "laravel-zero/framework": "^10.3.0",
-                "mockery/mockery": "^1.6.7",
+                "friendsofphp/php-cs-fixer": "^3.61.1",
+                "illuminate/view": "^10.48.18",
+                "larastan/larastan": "^2.9.8",
+                "laravel-zero/framework": "^10.4.0",
+                "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^1.15.1",
-                "pestphp/pest": "^2.33.6"
+                "pestphp/pest": "^2.35.0"
             },
             "bin": [
                 "builds/pint"
@@ -568,7 +568,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2024-02-13T17:20:13+00:00"
+            "time": "2024-08-06T15:11:54+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -840,16 +840,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.67",
+            "version": "1.11.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/707c2aed5d8d0075666e673a5e71440c1d01a5a3",
+                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3",
                 "shasum": ""
             },
             "require": {
@@ -894,7 +894,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-16T07:22:02+00:00"
+            "time": "2024-08-19T14:37:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2382,16 +2382,16 @@
         },
         {
             "name": "swoole/ide-helper",
-            "version": "4.8.0",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swoole/ide-helper.git",
-                "reference": "837a2b20242e3cebf0ba1168e876f0f1ca9a14e3"
+                "reference": "9cfc6669b83be0fa6fface91a6f372a0bb84bf1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/837a2b20242e3cebf0ba1168e876f0f1ca9a14e3",
-                "reference": "837a2b20242e3cebf0ba1168e876f0f1ca9a14e3",
+                "url": "https://api.github.com/repos/swoole/ide-helper/zipball/9cfc6669b83be0fa6fface91a6f372a0bb84bf1a",
+                "reference": "9cfc6669b83be0fa6fface91a6f372a0bb84bf1a",
                 "shasum": ""
             },
             "type": "library",
@@ -2408,19 +2408,9 @@
             "description": "IDE help files for Swoole.",
             "support": {
                 "issues": "https://github.com/swoole/ide-helper/issues",
-                "source": "https://github.com/swoole/ide-helper/tree/4.8.0"
+                "source": "https://github.com/swoole/ide-helper/tree/5.1.3"
             },
-            "funding": [
-                {
-                    "url": "https://gitee.com/swoole/swoole?donate=true",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/swoole",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-10-14T19:39:28+00:00"
+            "time": "2024-06-17T05:45:20+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -460,9 +460,10 @@ abstract class Adapter
      * @param string $collection
      * @param string $id
      * @param array<Query> $queries
+     * @param bool $forUpdate
      * @return Document
      */
-    abstract public function getDocument(string $collection, string $id, array $queries = []): Document;
+    abstract public function getDocument(string $collection, string $id, array $queries = [], bool $forUpdate = false): Document;
 
     /**
      * Create Document

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -625,7 +625,7 @@ class Mongo extends Adapter
      * @return Document
      * @throws MongoException
      */
-    public function getDocument(string $collection, string $id, array $queries = []): Document
+    public function getDocument(string $collection, string $id, array $queries = [], bool $forUpdate = false): Document
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection);
 
@@ -1637,6 +1637,11 @@ class Mongo extends Adapter
     }
 
     public function getSupportForRelationships(): bool
+    {
+        return false;
+    }
+
+    public function getSupportForUpdateLock(): bool
     {
         return false;
     }

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -58,6 +58,21 @@ class Mongo extends Adapter
         $this->client->connect();
     }
 
+    public function startTransaction(): bool
+    {
+        return true;
+    }
+
+    public function commitTransaction(): bool
+    {
+        return true;
+    }
+
+    public function rollbackTransaction(): bool
+    {
+        return true;
+    }
+
     /**
      * Ping Database
      *

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -85,8 +85,6 @@ class Postgres extends SQL
         /** @var array<string> $attributeStrings */
         $attributeStrings = [];
 
-        $this->getPDO()->beginTransaction();
-
         /** @var array<string> $attributeStrings */
         $attributeStrings = [];
         foreach ($attributes as $attribute) {
@@ -187,12 +185,7 @@ class Postgres extends SQL
                 );
             }
         } catch (Exception $e) {
-            $this->getPDO()->rollBack();
             throw new DatabaseException('Failed to create collection: ' . $e->getMessage());
-        }
-
-        if (!$this->getPDO()->commit()) {
-            throw new DatabaseException('Failed to commit transaction');
         }
 
         return true;
@@ -355,42 +348,21 @@ class Postgres extends SQL
      */
     public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
-        try {
-            $name = $this->filter($collection);
-            $id = $this->filter($id);
-            $type = $this->getSQLType($type, $size, $signed, $array);
+        $name = $this->filter($collection);
+        $id = $this->filter($id);
+        $type = $this->getSQLType($type, $size, $signed, $array);
 
-            $this->getPDO()->beginTransaction();
+        if ($type == 'TIMESTAMP(3)') {
+            $type = "TIMESTAMP(3) without time zone USING TO_TIMESTAMP(\"$id\", 'YYYY-MM-DD HH24:MI:SS.MS')";
+        }
 
-            if ($type == 'TIMESTAMP(3)') {
-                $type = "TIMESTAMP(3) without time zone USING TO_TIMESTAMP(\"$id\", 'YYYY-MM-DD HH24:MI:SS.MS')";
-            }
+        if (!empty($newKey) && $id !== $newKey) {
+            $newKey = $this->filter($newKey);
 
-            if (!empty($newKey) && $id !== $newKey) {
-                $newKey = $this->filter($newKey);
-
-                $sql = "
+            $sql = "
                     ALTER TABLE {$this->getSQLTable($name)}
                     RENAME COLUMN \"{$id}\" TO \"{$newKey}\"
                 ";
-
-                $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
-
-                $result = $this->getPDO()
-                    ->prepare($sql)
-                    ->execute();
-
-                if (!$result) {
-                    return false;
-                }
-
-                $id = $newKey;
-            }
-
-            $sql = "
-                ALTER TABLE {$this->getSQLTable($name)}
-                ALTER COLUMN \"{$id}\" TYPE {$type}
-            ";
 
             $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
 
@@ -398,18 +370,25 @@ class Postgres extends SQL
                 ->prepare($sql)
                 ->execute();
 
-            if (!$this->getPDO()->commit()) {
-                throw new DatabaseException('Failed to commit transaction');
+            if (!$result) {
+                return false;
             }
 
-            return $result;
-        } catch (\Throwable $e) {
-            if($this->getPDO()->inTransaction()) {
-                $this->getPDO()->rollBack();
-            }
-
-            throw $e;
+            $id = $newKey;
         }
+
+        $sql = "
+                ALTER TABLE {$this->getSQLTable($name)}
+                ALTER COLUMN \"{$id}\" TYPE {$type}
+            ";
+
+        $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+        $result = $this->getPDO()
+            ->prepare($sql)
+            ->execute();
+
+        return $result;
     }
 
     /**
@@ -782,8 +761,6 @@ class Postgres extends SQL
         $columns = '';
         $columnNames = '';
 
-        $this->getPDO()->beginTransaction();
-
         /**
          * Insert Attributes
          */
@@ -869,15 +846,10 @@ class Postgres extends SQL
         } catch (Throwable $e) {
             switch ($e->getCode()) {
                 case 23505:
-                    $this->getPDO()->rollBack();
                     throw new Duplicate('Duplicated document: ' . $e->getMessage());
                 default:
                     throw $e;
             }
-        }
-
-        if (!$this->getPDO()->commit()) {
-            throw new DatabaseException('Failed to commit transaction');
         }
 
         return $document;
@@ -899,8 +871,6 @@ class Postgres extends SQL
         if (empty($documents)) {
             return $documents;
         }
-
-        $this->getPDO()->beginTransaction();
 
         try {
             $name = $this->filter($collection);
@@ -975,15 +945,9 @@ class Postgres extends SQL
                 }
             }
 
-            if (!$this->getPDO()->commit()) {
-                throw new DatabaseException('Failed to commit transaction');
-            }
-
             return $documents;
 
         } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-
             throw match ($e->getCode()) {
                 1062, 23000 => new Duplicate('Duplicated document: ' . $e->getMessage()),
                 default => $e,
@@ -1023,6 +987,8 @@ class Postgres extends SQL
             $sql .= ' AND _tenant = :_tenant';
         }
 
+        $sql .= ' FOR UPDATE';
+
         $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
 
         /**
@@ -1049,8 +1015,6 @@ class Postgres extends SQL
 
             return $carry;
         }, $initial);
-
-        $this->getPDO()->beginTransaction();
 
         /**
          * Get removed Permissions
@@ -1206,19 +1170,13 @@ class Postgres extends SQL
                 $stmtAddPermissions->execute();
             }
         } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
             switch ($e->getCode()) {
                 case 1062:
                 case 23505:
                     throw new Duplicate('Duplicated document: ' . $e->getMessage());
-
                 default:
                     throw $e;
             }
-        }
-
-        if (!$this->getPDO()->commit()) {
-            throw new DatabaseException('Failed to commit transaction');
         }
 
         return $document;
@@ -1240,8 +1198,6 @@ class Postgres extends SQL
         if (empty($documents)) {
             return $documents;
         }
-
-        $this->getPDO()->beginTransaction();
 
         try {
             $name = $this->filter($collection);
@@ -1465,13 +1421,8 @@ class Postgres extends SQL
                 }
             }
 
-            if (!$this->getPDO()->commit()) {
-                throw new DatabaseException('Failed to commit transaction');
-            }
-
             return $documents;
         } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
 
             throw match ($e->getCode()) {
                 1062, 23000 => new Duplicate('Duplicated document: ' . $e->getMessage()),
@@ -1542,8 +1493,6 @@ class Postgres extends SQL
     {
         $name = $this->filter($collection);
 
-        $this->getPDO()->beginTransaction();
-
         $sql = "
 			DELETE FROM {$this->getSQLTable($name)} 
 			WHERE _uid = :_uid
@@ -1592,12 +1541,7 @@ class Postgres extends SQL
                 throw new DatabaseException('Failed to delete permissions');
             }
         } catch (\Throwable $th) {
-            $this->getPDO()->rollBack();
             throw new DatabaseException($th->getMessage());
-        }
-
-        if (!$this->getPDO()->commit()) {
-            throw new DatabaseException('Failed to commit transaction');
         }
 
         return $deleted;

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -110,12 +110,6 @@ class SQLite extends MariaDB
     {
         $id = $this->filter($name);
 
-        try {
-            $this->getPDO()->beginTransaction();
-        } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-        }
-
         /** @var array<string> $attributeStrings */
         $attributeStrings = [];
 
@@ -189,8 +183,6 @@ class SQLite extends MariaDB
         $this->createIndex("{$id}_perms", '_index_1', Database::INDEX_UNIQUE, ['_document', '_type', '_permission'], [], []);
         $this->createIndex("{$id}_perms", '_index_2', Database::INDEX_KEY, ['_permission', '_type'], [], []);
 
-        $this->getPDO()->commit();
-
         // Update $this->getCountOfIndexes when adding another default index
         return true;
     }
@@ -246,12 +238,6 @@ class SQLite extends MariaDB
     {
         $id = $this->filter($id);
 
-        try {
-            $this->getPDO()->beginTransaction();
-        } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-        }
-
         $sql = "DROP TABLE IF EXISTS `{$this->getSQLTable($id)}`";
         $sql = $this->trigger(Database::EVENT_COLLECTION_DELETE, $sql);
 
@@ -265,8 +251,6 @@ class SQLite extends MariaDB
         $this->getPDO()
             ->prepare($sql)
             ->execute();
-
-        $this->getPDO()->commit();
 
         return true;
     }
@@ -472,12 +456,6 @@ class SQLite extends MariaDB
         $columns = ['_uid'];
         $values = ['_uid'];
 
-        try {
-            $this->getPDO()->beginTransaction();
-        } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-        }
-
         /**
          * Insert Attributes
          */
@@ -562,16 +540,12 @@ class SQLite extends MariaDB
                 $stmtPermissions->execute();
             }
         } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
             throw match ($e->getCode()) {
                 "1062", "23000" => new Duplicate('Duplicated document: ' . $e->getMessage()),
                 default => $e,
             };
         }
 
-        if (!$this->getPDO()->commit()) {
-            throw new DatabaseException('Failed to commit transaction');
-        }
 
         return $document;
     }
@@ -599,7 +573,6 @@ class SQLite extends MariaDB
 
         $name = $this->filter($collection);
         $columns = '';
-
 
         $sql = "
 			SELECT _type, _permission
@@ -637,12 +610,6 @@ class SQLite extends MariaDB
 
             return $carry;
         }, $initial);
-
-        try {
-            $this->getPDO()->beginTransaction();
-        } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-        }
 
         /**
          * Get removed Permissions
@@ -798,17 +765,11 @@ class SQLite extends MariaDB
                 $stmtAddPermissions->execute();
             }
         } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-
             throw match ($e->getCode()) {
                 '1062',
                 '23000' => new Duplicate('Duplicated document: ' . $e->getMessage()),
                 default => $e,
             };
-        }
-
-        if (!$this->getPDO()->commit()) {
-            throw new DatabaseException('Failed to commit transaction');
         }
 
         return $document;
@@ -830,8 +791,6 @@ class SQLite extends MariaDB
         if (empty($documents)) {
             return $documents;
         }
-
-        $this->getPDO()->beginTransaction();
 
         try {
             $name = $this->filter($collection);
@@ -1061,14 +1020,8 @@ class SQLite extends MariaDB
                 }
             }
 
-            if (!$this->getPDO()->commit()) {
-                throw new DatabaseException('Failed to commit transaction');
-            }
-
             return $documents;
         } catch (PDOException $e) {
-            $this->getPDO()->rollBack();
-
             throw match ($e->getCode()) {
                 1062, 23000 => new Duplicate('Duplicated document: ' . $e->getMessage()),
                 default => $e,
@@ -1122,6 +1075,11 @@ class SQLite extends MariaDB
     }
 
     public function getSupportForRelationships(): bool
+    {
+        return false;
+    }
+
+    public function getSupportForUpdateLock(): bool
     {
         return false;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -853,6 +853,59 @@ class Database
     }
 
     /**
+     * Start a new transaction.
+     *
+     * If a transaction is already active, this will only increment the transaction count and return true.
+     *
+     * @return bool
+     * @throws DatabaseException
+     */
+    public function startTransaction(): bool
+    {
+        return $this->adapter->startTransaction();
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * If no transaction is active, this will be a no-op and will return false.
+     * If there is more than one active transaction, this decrement the transaction count and return true.
+     * If the transaction count is 1, it will be commited, the transaction count will be reset to 0, and return true.
+     *
+     * @return bool
+     * @throws DatabaseException
+     */
+    public function commitTransaction(): bool
+    {
+        return $this->adapter->startTransaction();
+    }
+
+    /**
+     * Rollback a transaction.
+     *
+     * If no transaction is active, this will be a no-op and will return false.
+     * If 1 or more transactions are active, this will roll back all transactions, reset the count to 0, and return true.
+     *
+     * @return bool
+     * @throws DatabaseException
+     */
+    public function rollbackTransaction(): bool
+    {
+        return $this->adapter->rollbackTransaction();
+    }
+
+    /**
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     * @throws \Throwable
+     */
+    public function withTransaction(callable $callback): mixed
+    {
+        return $this->adapter->withTransaction($callback);
+    }
+
+    /**
      * Ping Database
      *
      * @return bool

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -2672,7 +2672,7 @@ class Database
      * @throws DatabaseException
      * @throws Exception
      */
-    public function getDocument(string $collection, string $id, array $queries = []): Document
+    public function getDocument(string $collection, string $id, array $queries = [], bool $forUpdate = false): Document
     {
         if ($this->adapter->getSharedTables() && empty($this->adapter->getTenant())) {
             throw new DatabaseException('Missing tenant. Tenant must be set when table sharing is enabled.');
@@ -2780,7 +2780,7 @@ class Database
             return $document;
         }
 
-        $document = $this->adapter->getDocument($collection->getId(), $id, $queries);
+        $document = $this->adapter->getDocument($collection->getId(), $id, $queries, $forUpdate);
 
         if ($document->isEmpty()) {
             return $document;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3205,15 +3205,18 @@ class Database
             throw new StructureException($structure->getDescription());
         }
 
-        if ($this->resolveRelationships) {
-            $document = $this->silent(fn () => $this->createDocumentRelationships($collection, $document));
-        }
+        $document = $this->withTransaction(function () use ($collection, $document) {
+            if ($this->resolveRelationships) {
+                $document = $this->silent(fn () => $this->createDocumentRelationships($collection, $document));
+            }
 
-        $document = $this->adapter->createDocument($collection->getId(), $document);
+            return $this->adapter->createDocument($collection->getId(), $document);
+        });
 
         if ($this->resolveRelationships) {
             $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
         }
+
         $document = $this->decode($collection, $document);
 
         $this->trigger(self::EVENT_DOCUMENT_CREATE, $document);
@@ -3271,7 +3274,9 @@ class Database
             $documents[$key] = $document;
         }
 
-        $documents = $this->adapter->createDocuments($collection->getId(), $documents, $batchSize);
+        $documents = $this->withTransaction(function () use ($collection, $documents, $batchSize) {
+            return $this->adapter->createDocuments($collection->getId(), $documents, $batchSize);
+        });
 
         foreach ($documents as $key => $document) {
             if ($this->resolveRelationships) {
@@ -3632,163 +3637,170 @@ class Database
             throw new DatabaseException('Must define $id attribute');
         }
 
-        $time = DateTime::now();
-        $old = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
-
-        $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
-        $document['$collection'] = $old->getAttribute('$collection');   // Make sure user doesn't switch collection ID
-        if ($this->adapter->getSharedTables()) {
-            $document['$tenant'] = $old->getAttribute('$tenant');           // Make sure user doesn't switch tenant
-        }
-        $document['$createdAt'] = $old->getCreatedAt();                 // Make sure user doesn't switch createdAt
-        $document = new Document($document);
-
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
-        $relationships = \array_filter($collection->getAttribute('attributes', []), function ($attribute) {
-            return $attribute['type'] === Database::VAR_RELATIONSHIP;
-        });
+        $document = $this->withTransaction(function () use ($collection, $id, $document) {
+            $time = DateTime::now();
+            $old = Authorization::skip(fn () => $this->silent(
+                fn () =>
+                $this->getDocument($collection->getId(), $id, forUpdate: true)
+            ));
 
-        $updateValidator = new Authorization(self::PERMISSION_UPDATE);
-        $readValidator = new Authorization(self::PERMISSION_READ);
-        $shouldUpdate = false;
-
-        if ($collection->getId() !== self::METADATA) {
-            $documentSecurity = $collection->getAttribute('documentSecurity', false);
-
-            foreach ($relationships as $relationship) {
-                $relationships[$relationship->getAttribute('key')] = $relationship;
+            $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
+            $document['$collection'] = $old->getAttribute('$collection');   // Make sure user doesn't switch collection ID
+            if ($this->adapter->getSharedTables()) {
+                $document['$tenant'] = $old->getAttribute('$tenant');           // Make sure user doesn't switch tenant
             }
+            $document['$createdAt'] = $old->getCreatedAt();                 // Make sure user doesn't switch createdAt
+            $document = new Document($document);
 
-            // Compare if the document has any changes
-            foreach ($document as $key => $value) {
-                // Skip the nested documents as they will be checked later in recursions.
-                if (\array_key_exists($key, $relationships)) {
-                    // No need to compare nested documents more than max depth.
-                    if (count($this->relationshipWriteStack) >= Database::RELATION_MAX_DEPTH - 1) {
-                        continue;
-                    }
-                    $relationType = (string) $relationships[$key]['options']['relationType'];
-                    $side = (string) $relationships[$key]['options']['side'];
-                    switch ($relationType) {
-                        case Database::RELATION_ONE_TO_ONE:
-                            $oldValue = $old->getAttribute($key) instanceof Document
-                                ? $old->getAttribute($key)->getId()
-                                : $old->getAttribute($key);
+            $relationships = \array_filter($collection->getAttribute('attributes', []), function ($attribute) {
+                return $attribute['type'] === Database::VAR_RELATIONSHIP;
+            });
 
-                            if ((\is_null($value) !== \is_null($oldValue))
-                                || (\is_string($value) && $value !== $oldValue)
-                                || ($value instanceof Document && $value->getId() !== $oldValue)
-                            ) {
-                                $shouldUpdate = true;
-                            }
-                            break;
-                        case Database::RELATION_ONE_TO_MANY:
-                        case Database::RELATION_MANY_TO_ONE:
-                        case Database::RELATION_MANY_TO_MANY:
-                            if (
-                                ($relationType === Database::RELATION_MANY_TO_ONE && $side === Database::RELATION_SIDE_PARENT) ||
-                                ($relationType === Database::RELATION_ONE_TO_MANY && $side === Database::RELATION_SIDE_CHILD)
-                            ) {
+            $updateValidator = new Authorization(self::PERMISSION_UPDATE);
+            $readValidator = new Authorization(self::PERMISSION_READ);
+            $shouldUpdate = false;
+
+            if ($collection->getId() !== self::METADATA) {
+                $documentSecurity = $collection->getAttribute('documentSecurity', false);
+
+                foreach ($relationships as $relationship) {
+                    $relationships[$relationship->getAttribute('key')] = $relationship;
+                }
+
+                // Compare if the document has any changes
+                foreach ($document as $key => $value) {
+                    // Skip the nested documents as they will be checked later in recursions.
+                    if (\array_key_exists($key, $relationships)) {
+                        // No need to compare nested documents more than max depth.
+                        if (count($this->relationshipWriteStack) >= Database::RELATION_MAX_DEPTH - 1) {
+                            continue;
+                        }
+                        $relationType = (string)$relationships[$key]['options']['relationType'];
+                        $side = (string)$relationships[$key]['options']['side'];
+                        switch ($relationType) {
+                            case Database::RELATION_ONE_TO_ONE:
                                 $oldValue = $old->getAttribute($key) instanceof Document
                                     ? $old->getAttribute($key)->getId()
                                     : $old->getAttribute($key);
 
                                 if ((\is_null($value) !== \is_null($oldValue))
                                     || (\is_string($value) && $value !== $oldValue)
-                                    || ($value instanceof Document &&  $value->getId() !== $oldValue)
+                                    || ($value instanceof Document && $value->getId() !== $oldValue)
                                 ) {
                                     $shouldUpdate = true;
                                 }
                                 break;
-                            }
-
-                            if (!\is_array($value) || !\array_is_list($value)) {
-                                throw new RelationshipException('Invalid relationship value. Must be either an array of documents or document IDs, ' . \gettype($value) . ' given.');
-                            }
-
-                            if (\count($old->getAttribute($key)) !== \count($value)) {
-                                $shouldUpdate = true;
-                                break;
-                            }
-
-                            foreach ($value as $index => $relation) {
-                                $oldValue = $old->getAttribute($key)[$index] instanceof Document
-                                    ? $old->getAttribute($key)[$index]->getId()
-                                    : $old->getAttribute($key)[$index];
-
+                            case Database::RELATION_ONE_TO_MANY:
+                            case Database::RELATION_MANY_TO_ONE:
+                            case Database::RELATION_MANY_TO_MANY:
                                 if (
-                                    (\is_string($relation) && $relation !== $oldValue) ||
-                                    ($relation instanceof Document && $relation->getId() !== $oldValue)
+                                    ($relationType === Database::RELATION_MANY_TO_ONE && $side === Database::RELATION_SIDE_PARENT) ||
+                                    ($relationType === Database::RELATION_ONE_TO_MANY && $side === Database::RELATION_SIDE_CHILD)
                                 ) {
+                                    $oldValue = $old->getAttribute($key) instanceof Document
+                                        ? $old->getAttribute($key)->getId()
+                                        : $old->getAttribute($key);
+
+                                    if ((\is_null($value) !== \is_null($oldValue))
+                                        || (\is_string($value) && $value !== $oldValue)
+                                        || ($value instanceof Document && $value->getId() !== $oldValue)
+                                    ) {
+                                        $shouldUpdate = true;
+                                    }
+                                    break;
+                                }
+
+                                if (!\is_array($value) || !\array_is_list($value)) {
+                                    throw new RelationshipException('Invalid relationship value. Must be either an array of documents or document IDs, ' . \gettype($value) . ' given.');
+                                }
+
+                                if (\count($old->getAttribute($key)) !== \count($value)) {
                                     $shouldUpdate = true;
                                     break;
                                 }
-                            }
+
+                                foreach ($value as $index => $relation) {
+                                    $oldValue = $old->getAttribute($key)[$index] instanceof Document
+                                        ? $old->getAttribute($key)[$index]->getId()
+                                        : $old->getAttribute($key)[$index];
+
+                                    if (
+                                        (\is_string($relation) && $relation !== $oldValue) ||
+                                        ($relation instanceof Document && $relation->getId() !== $oldValue)
+                                    ) {
+                                        $shouldUpdate = true;
+                                        break;
+                                    }
+                                }
+                                break;
+                        }
+
+                        if ($shouldUpdate) {
                             break;
+                        }
+
+                        continue;
                     }
 
-                    if ($shouldUpdate) {
+                    $oldValue = $old->getAttribute($key);
+
+                    // If values are not equal we need to update document.
+                    if ($value !== $oldValue) {
+                        $shouldUpdate = true;
                         break;
                     }
-
-                    continue;
                 }
 
-                $oldValue = $old->getAttribute($key);
+                $updatePermissions = [
+                    ...$collection->getUpdate(),
+                    ...($documentSecurity ? $old->getUpdate() : [])
+                ];
 
-                // If values are not equal we need to update document.
-                if ($value !== $oldValue) {
-                    $shouldUpdate = true;
-                    break;
+                $readPermissions = [
+                    ...$collection->getRead(),
+                    ...($documentSecurity ? $old->getRead() : [])
+                ];
+
+                if ($shouldUpdate && !$updateValidator->isValid($updatePermissions)) {
+                    throw new AuthorizationException($updateValidator->getDescription());
+                } elseif (!$shouldUpdate && !$readValidator->isValid($readPermissions)) {
+                    throw new AuthorizationException($readValidator->getDescription());
                 }
             }
 
-            $updatePermissions = [
-                ...$collection->getUpdate(),
-                ...($documentSecurity ? $old->getUpdate() : [])
-            ];
-
-            $readPermissions = [
-                ...$collection->getRead(),
-                ...($documentSecurity ? $old->getRead() : [])
-            ];
-
-            if ($shouldUpdate && !$updateValidator->isValid($updatePermissions)) {
-                throw new AuthorizationException($updateValidator->getDescription());
-            } elseif (!$shouldUpdate && !$readValidator->isValid($readPermissions)) {
-                throw new AuthorizationException($readValidator->getDescription());
+            if ($old->isEmpty()) {
+                return new Document();
             }
-        }
 
-        if ($old->isEmpty()) {
-            return new Document();
-        }
+            if ($shouldUpdate) {
+                $updatedAt = $document->getUpdatedAt();
+                $document->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt);
+            }
 
-        if ($shouldUpdate) {
-            $updatedAt = $document->getUpdatedAt();
-            $document->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt);
-        }
+            // Check if document was updated after the request timestamp
+            $oldUpdatedAt = new \DateTime($old->getUpdatedAt());
+            if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
+                throw new ConflictException('Document was updated after the request timestamp');
+            }
 
-        // Check if document was updated after the request timestamp
-        $oldUpdatedAt = new \DateTime($old->getUpdatedAt());
-        if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
-            throw new ConflictException('Document was updated after the request timestamp');
-        }
+            $document = $this->encode($collection, $document);
 
-        $document = $this->encode($collection, $document);
+            $structureValidator = new Structure($collection);
 
-        $structureValidator = new Structure($collection);
+            if (!$structureValidator->isValid($document)) { // Make sure updated structure still apply collection rules (if any)
+                throw new StructureException($structureValidator->getDescription());
+            }
 
-        if (!$structureValidator->isValid($document)) { // Make sure updated structure still apply collection rules (if any)
-            throw new StructureException($structureValidator->getDescription());
-        }
+            if ($this->resolveRelationships) {
+                $document = $this->silent(fn () => $this->updateDocumentRelationships($collection, $old, $document));
+            }
 
-        if ($this->resolveRelationships) {
-            $document = $this->silent(fn () => $this->updateDocumentRelationships($collection, $old, $document));
-        }
+            $this->adapter->updateDocument($collection->getId(), $document);
 
-        $this->adapter->updateDocument($collection->getId(), $document);
+            return $document;
+        });
 
         if ($this->resolveRelationships) {
             $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
@@ -3797,9 +3809,7 @@ class Database
         $document = $this->decode($collection, $document);
 
         $this->purgeRelatedDocuments($collection, $id);
-
         $this->purgeCachedDocument($collection->getId(), $id);
-
         $this->trigger(self::EVENT_DOCUMENT_UPDATE, $document);
 
         return $document;
@@ -3828,44 +3838,48 @@ class Database
             return [];
         }
 
-        $time = DateTime::now();
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
-        foreach ($documents as $key => $document) {
-            if (!$document->getId()) {
-                throw new DatabaseException('Must define $id attribute for each document');
+        $documents = $this->withTransaction(function () use ($collection, $documents, $batchSize) {
+            $time = DateTime::now();
+
+            foreach ($documents as $key => $document) {
+                if (!$document->getId()) {
+                    throw new DatabaseException('Must define $id attribute for each document');
+                }
+
+                $updatedAt = $document->getUpdatedAt();
+                $document->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt);
+                $document = $this->encode($collection, $document);
+
+                $old = Authorization::skip(fn () => $this->silent(
+                    fn () => $this->getDocument(
+                        $collection->getId(),
+                        $document->getId(),
+                        forUpdate: true
+                    )
+                ));
+
+                $validator = new Authorization(self::PERMISSION_UPDATE);
+                if (
+                    $collection->getId() !== self::METADATA
+                    && !$validator->isValid($old->getUpdate())
+                ) {
+                    throw new AuthorizationException($validator->getDescription());
+                }
+
+                $validator = new Structure($collection);
+                if (!$validator->isValid($document)) {
+                    throw new StructureException($validator->getDescription());
+                }
+
+                if ($this->resolveRelationships) {
+                    $documents[$key] = $this->silent(fn () => $this->updateDocumentRelationships($collection, $old, $document));
+                }
             }
 
-            $updatedAt = $document->getUpdatedAt();
-            $document->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt);
-            $document = $this->encode($collection, $document);
-
-            $old = Authorization::skip(fn () => $this->silent(
-                fn () => $this->getDocument(
-                    $collection->getId(),
-                    $document->getId()
-                )
-            ));
-
-            $validator = new Authorization(self::PERMISSION_UPDATE);
-            if (
-                $collection->getId() !== self::METADATA
-                && !$validator->isValid($old->getUpdate())
-            ) {
-                throw new AuthorizationException($validator->getDescription());
-            }
-
-            $validator = new Structure($collection);
-            if (!$validator->isValid($document)) {
-                throw new StructureException($validator->getDescription());
-            }
-
-            if ($this->resolveRelationships) {
-                $documents[$key] = $this->silent(fn () => $this->updateDocumentRelationships($collection, $old, $document));
-            }
-        }
-
-        $documents = $this->adapter->updateDocuments($collection->getId(), $documents, $batchSize);
+            return $this->adapter->updateDocuments($collection->getId(), $documents, $batchSize);
+        });
 
         foreach ($documents as $key => $document) {
             if ($this->resolveRelationships) {
@@ -4477,38 +4491,43 @@ class Database
             throw new DatabaseException('Missing tenant. Tenant must be set when table sharing is enabled.');
         }
 
-        $document = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id)));
-
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
-        $validator = new Authorization(self::PERMISSION_DELETE);
+        $deleted = $this->withTransaction(function () use ($collection, $id, &$document) {
+            $document = Authorization::skip(fn () => $this->silent(
+                fn () =>
+                $this->getDocument($collection->getId(), $id, forUpdate: true)
+            ));
 
-        if ($collection->getId() !== self::METADATA) {
-            $documentSecurity = $collection->getAttribute('documentSecurity', false);
-            if (!$validator->isValid([
-                ...$collection->getDelete(),
-                ...($documentSecurity ? $document->getDelete() : [])
-            ])) {
-                throw new AuthorizationException($validator->getDescription());
+            $validator = new Authorization(self::PERMISSION_DELETE);
+
+            if ($collection->getId() !== self::METADATA) {
+                $documentSecurity = $collection->getAttribute('documentSecurity', false);
+                if (!$validator->isValid([
+                    ...$collection->getDelete(),
+                    ...($documentSecurity ? $document->getDelete() : [])
+                ])) {
+                    throw new AuthorizationException($validator->getDescription());
+                }
             }
-        }
 
-        // Check if document was updated after the request timestamp
-        try {
-            $oldUpdatedAt = new \DateTime($document->getUpdatedAt());
-        } catch (Exception $e) {
-            throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
-        }
+            // Check if document was updated after the request timestamp
+            try {
+                $oldUpdatedAt = new \DateTime($document->getUpdatedAt());
+            } catch (Exception $e) {
+                throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+            }
 
-        if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
-            throw new ConflictException('Document was updated after the request timestamp');
-        }
+            if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
+                throw new ConflictException('Document was updated after the request timestamp');
+            }
 
-        if ($this->resolveRelationships) {
-            $document = $this->silent(fn () => $this->deleteDocumentRelationships($collection, $document));
-        }
+            if ($this->resolveRelationships) {
+                $document = $this->silent(fn () => $this->deleteDocumentRelationships($collection, $document));
+            }
 
-        $deleted = $this->adapter->deleteDocument($collection->getId(), $id);
+            return $this->adapter->deleteDocument($collection->getId(), $id);
+        });
 
         $this->purgeRelatedDocuments($collection, $id);
         $this->purgeCachedDocument($collection->getId(), $id);

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -34,10 +34,9 @@ abstract class Base extends TestCase
     protected static string $namespace;
 
     /**
-     * @param bool $fresh
      * @return Database
      */
-    abstract protected static function getDatabase(bool $fresh = false): Database;
+    abstract protected static function getDatabase(): Database;
 
     /**
      * @return string

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -34,9 +34,10 @@ abstract class Base extends TestCase
     protected static string $namespace;
 
     /**
+     * @param bool $fresh
      * @return Database
      */
-    abstract protected static function getDatabase(): Database;
+    abstract protected static function getDatabase(bool $fresh = false): Database;
 
     /**
      * @return string
@@ -964,37 +965,36 @@ abstract class Base extends TestCase
 
     public function testQueryTimeout(): void
     {
-        if ($this->getDatabase()->getAdapter()->getSupportForTimeouts()) {
-            static::getDatabase()->createCollection('global-timeouts');
-            $this->assertEquals(true, static::getDatabase()->createAttribute('global-timeouts', 'longtext', Database::VAR_STRING, 100000000, true));
-
-            for ($i = 0 ; $i <= 20 ; $i++) {
-                static::getDatabase()->createDocument('global-timeouts', new Document([
-                    'longtext' => file_get_contents(__DIR__ . '/../../resources/longtext.txt'),
-                    '$permissions' => [
-                        Permission::read(Role::any()),
-                        Permission::update(Role::any()),
-                        Permission::delete(Role::any())
-                    ]
-                ]));
-            }
-
-            $this->expectException(TimeoutException::class);
-
-            static::getDatabase()->setTimeout(1);
-
-            try {
-                static::getDatabase()->find('global-timeouts', [
-                    Query::notEqual('longtext', 'appwrite'),
-                ]);
-            } catch(TimeoutException $ex) {
-                static::getDatabase()->clearTimeout();
-                static::getDatabase()->deleteCollection('global-timeouts');
-                throw $ex;
-            }
+        if (!$this->getDatabase()->getAdapter()->getSupportForTimeouts()) {
+            $this->expectNotToPerformAssertions();
+            return;
         }
 
-        $this->expectNotToPerformAssertions();
+        static::getDatabase()->createCollection('global-timeouts');
+        $this->assertEquals(true, static::getDatabase()->createAttribute('global-timeouts', 'longtext', Database::VAR_STRING, 100000000, true));
+
+        for ($i = 0 ; $i <= 20 ; $i++) {
+            static::getDatabase()->createDocument('global-timeouts', new Document([
+                'longtext' => file_get_contents(__DIR__ . '/../../resources/longtext.txt'),
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::delete(Role::any())
+                ]
+            ]));
+        }
+
+        static::getDatabase()->setTimeout(1);
+
+        try {
+            static::getDatabase()->find('global-timeouts', [
+                Query::notEqual('longtext', 'appwrite'),
+            ]);
+            $this->fail('Failed to throw exception');
+        } catch(TimeoutException $ex) {
+            static::getDatabase()->clearTimeout();
+            static::getDatabase()->deleteCollection('global-timeouts');
+        }
     }
 
     /**


### PR DESCRIPTION
- Remove inline adapter transactions
- Add abstracted transactions functions to adapter + database
- Wrap CRUD functions in transactions at the database layer
- Allow getting document for update

All of this allows atomic updates. Now when updating a document, we can read the existing document including a `FOR UPDATE` clauses, which will apply a read lock on the row until we complete the update.

Doing this will resolve race conditions where parallel updates overwrite changes.