### PR TITLE
Return on empty docs 

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4317,7 +4317,12 @@ class Database
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
 
+        /* @var $document Document */
         $document = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+
+        if($document->isEmpty()){
+            return false;
+        }
 
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
@@ -4407,7 +4412,12 @@ class Database
 
         $validator = new Authorization(self::PERMISSION_UPDATE);
 
+        /* @var $document Document */
         $document = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
+
+        if($document->isEmpty()){
+            return false;
+        }
 
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
@@ -4494,10 +4504,15 @@ class Database
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         $deleted = $this->withTransaction(function () use ($collection, $id, &$document) {
+            /* @var $document Document */
             $document = Authorization::skip(fn () => $this->silent(
                 fn () =>
                 $this->getDocument($collection->getId(), $id, forUpdate: true)
             ));
+
+            if($document->isEmpty()){
+                return false;
+            }
 
             $validator = new Authorization(self::PERMISSION_DELETE);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4320,7 +4320,7 @@ class Database
         /* @var $document Document */
         $document = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
 
-        if($document->isEmpty()){
+        if($document->isEmpty()) {
             return false;
         }
 
@@ -4415,7 +4415,7 @@ class Database
         /* @var $document Document */
         $document = Authorization::skip(fn () => $this->silent(fn () => $this->getDocument($collection, $id))); // Skip ensures user does not need read permission for this
 
-        if($document->isEmpty()){
+        if($document->isEmpty()) {
             return false;
         }
 
@@ -4510,7 +4510,7 @@ class Database
                 $this->getDocument($collection->getId(), $id, forUpdate: true)
             ));
 
-            if($document->isEmpty()){
+            if($document->isEmpty()) {
                 return false;
             }
 


### PR DESCRIPTION
Fix Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated 
Happens because of reading an empty document