### PR TITLE
Implement resizing string attributes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -898,35 +898,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.31",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
-                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^9.6"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -935,7 +935,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.2-dev"
+                    "dev-main": "9.2.x-dev"
                 }
             },
             "autoload": {
@@ -964,7 +964,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
             },
             "funding": [
                 {
@@ -972,7 +972,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:37:42+00:00"
+            "time": "2024-08-22T04:23:01+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       POSTGRES_PASSWORD: password
 
   mariadb:
-    image: mariadb:11.4
+    image: mariadb:10.11
     container_name: utopia-mariadb
     command: mariadbd --max_allowed_packet=1G
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,9 @@ services:
       POSTGRES_PASSWORD: password
 
   mariadb:
-    image: mariadb:10.11
+    image: mariadb:11.4
     container_name: utopia-mariadb
+    command: mariadbd --max_allowed_packet=1G
     networks:
       - database
     ports:

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -740,6 +740,13 @@ abstract class Adapter
     abstract public function getSupportForUpdateLock(): bool;
 
     /**
+     * Is Attribute Resizing Supported?
+     * 
+     * @return bool
+     */
+    abstract public function getSupportForAttributeResizing(): bool;
+
+    /**
      * Get current attribute count from collection document
      *
      * @param Document $collection

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -420,10 +420,11 @@ abstract class Adapter
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
+     * @param int $newSize
      *
      * @return bool
      */
-    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool;
+    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool;
 
     /**
      * Delete Attribute

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -741,7 +741,7 @@ abstract class Adapter
 
     /**
      * Is Attribute Resizing Supported?
-     * 
+     *
      * @return bool
      */
     abstract public function getSupportForAttributeResizing(): bool;

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -420,11 +420,10 @@ abstract class Adapter
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
-     * @param int $newSize
      *
      * @return bool
      */
-    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool;
+    abstract public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool;
 
     /**
      * Delete Attribute

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -740,7 +740,7 @@ abstract class Adapter
     abstract public function getSupportForUpdateLock(): bool;
 
     /**
-     * Is Attribute Resizing Supported?
+     * Is attribute resizing supported?
      *
      * @return bool
      */

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -2237,14 +2237,10 @@ class MariaDB extends SQL
         // Timeout
         if ($e->getCode() === '70100' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1969) {
             throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 1969 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '70100') {
-            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
         }
 
         // Duplicate column
         if ($e->getCode() === '42S21' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1060) {
-            throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 1060 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '42S21') {
             throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
         }
 
@@ -2255,8 +2251,6 @@ class MariaDB extends SQL
 
         // Duplicate index
         if ($e->getCode() === '42000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1061) {
-            throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 1061 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '42000') {
             throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
         }
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -309,21 +309,27 @@ class MariaDB extends SQL
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
+     * @param int $newSize
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
     {
         $name = $this->filter($collection);
         $id = $this->filter($id);
-        $type = $this->getSQLType($type, $size, $signed, $array);
+
+        if (!empty($newSize) && $size > $newSize && $type === Database::VAR_STRING) {
+            $this->truncateStringAttribute($name, $id, $newSize);
+        }
+
+        $type = $this->getSQLType($type, $newSize ?? $size, $signed, $array);
 
         if (!empty($newKey)) {
             $newKey = $this->filter($newKey);
-            $sql = "ALTER TABLE {$this->getSQLTable($name)} CHANGE COLUMN `{$id}` {$newKey} {$type};";
+            $sql = "ALTER TABLE {$this->getSQLTable($name)} CHANGE COLUMN `{$id}` {$newKey} {$type}, LOCK=NONE;";
         } else {
-            $sql = "ALTER TABLE {$this->getSQLTable($name)} MODIFY `{$id}` {$type};";
+            $sql = "ALTER TABLE {$this->getSQLTable($name)} MODIFY `{$id}` {$type}, LOCK=NONE;";
         }
 
         $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
@@ -375,6 +381,29 @@ class MariaDB extends SQL
 
         $sql = "ALTER TABLE {$this->getSQLTable($collection)} RENAME COLUMN `{$old}` TO `{$new}`;";
 
+        $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+        return $this->getPDO()
+            ->prepare($sql)
+            ->execute();
+    }
+
+    /**
+     * Truncate String Attribute
+     *
+     * @param string $collection
+     * @param string $id
+     * @param int $new
+     * @return bool
+     * @throws Exception
+     * @throws PDOException
+     */
+    public function truncateStringAttribute(string $collection, string $id, int $new): bool
+    {
+        $collection = $this->filter($collection);
+        $id = $this->filter($id);
+
+        $sql = "UPDATE {$this->getSQLTable($collection)} SET `{$id}` = substr(`{$id}`, 1, {$new})";
         $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
 
         return $this->getPDO()

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -309,17 +309,16 @@ class MariaDB extends SQL
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
-     * @param int $newSize
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
         $name = $this->filter($collection);
         $id = $this->filter($id);
         $newKey = empty($newKey) ? null : $this->filter($newKey);
-        $type = $this->getSQLType($type, $newSize ?? $size, $signed, $array);
+        $type = $this->getSQLType($type, $size, $signed, $array);
 
         if (!empty($newKey)) {
             $sql = "ALTER TABLE {$this->getSQLTable($name)} CHANGE COLUMN `{$id}` {$newKey} {$type};";

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1667,6 +1667,11 @@ class Mongo extends Adapter
         return false;
     }
 
+    public function getSupportForAttributeResizing(): bool
+    {
+        return false;
+    }
+
     /**
      * Get current attribute count from collection document
      *

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -928,11 +928,6 @@ class Mongo extends Adapter
             return $this->renameAttribute($collection, $id, $newKey);
         }
 
-        // TODO
-        // if (!empty($newSize) && $newSize !== $size) {
-        //     return $this->resizeAttribute($collection, $id, $newSize);
-        // }
-
         return true;
     }
 

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -918,14 +918,20 @@ class Mongo extends Adapter
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
+     * @param int $newSize
      *
      * @return bool
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
     {
         if (!empty($newKey) && $newKey !== $id) {
             return $this->renameAttribute($collection, $id, $newKey);
         }
+
+        // TODO
+        // if (!empty($newSize) && $newSize !== $size) {
+        //     return $this->resizeAttribute($collection, $id, $newSize);
+        // }
 
         return true;
     }

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -918,11 +918,10 @@ class Mongo extends Adapter
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
-     * @param int $newSize
      *
      * @return bool
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
         if (!empty($newKey) && $newKey !== $id) {
             return $this->renameAttribute($collection, $id, $newKey);

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -58,6 +58,11 @@ class MySQL extends MariaDB
             throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
         }
 
+        // Data is too big for column resize
+        if ($e->getCode() === '22001' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1406) {
+            throw new DatabaseException('Resize would result in data truncation', $e->getCode(), $e);
+        }
+
         throw $e;
     }
 

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -97,21 +97,15 @@ class MySQL extends MariaDB
         // Timeout
         if ($e->getCode() === 'HY000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 3024) {
             throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 3024 && isset($e->errorInfo[0]) && $e->errorInfo[0] === "HY000") {
-            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
         }
 
         // Duplicate column
         if ($e->getCode() === '42S21' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1060) {
             throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 1060 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '42S21') {
-            throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
         }
 
         // Duplicate index
         if ($e->getCode() === '42000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1061) {
-            throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 1061 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '42000') {
             throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
         }
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -357,6 +357,27 @@ class Postgres extends SQL
             $type = "TIMESTAMP(3) without time zone USING TO_TIMESTAMP(\"$id\", 'YYYY-MM-DD HH24:MI:SS.MS')";
         }
 
+        if (!empty($newKey) && $id !== $newKey) {
+            $newKey = $this->filter($newKey);
+
+            $sql = "
+                    ALTER TABLE {$this->getSQLTable($name)}
+                    RENAME COLUMN \"{$id}\" TO \"{$newKey}\"
+                ";
+
+            $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+            $result = $this->getPDO()
+                ->prepare($sql)
+                ->execute();
+
+            if (!$result) {
+                return false;
+            }
+
+            $id = $newKey;
+        }
+
         $sql = "
                 ALTER TABLE {$this->getSQLTable($name)}
                 ALTER COLUMN \"{$id}\" TYPE {$type}

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -2210,13 +2210,9 @@ class Postgres extends SQL
 
         if ($e->getCode() === '57014' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 7) {
             throw new Timeout($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 7 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '57014') {
-            throw new Timeout($e->getMessage(), $e->getCode(), $e);
         }
 
         if ($e->getCode() === '42701' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 7) {
-            throw new Duplicate($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 7 && isset($e->errorInfo[0]) && $e->errorInfo[0] === '42701') {
             throw new Duplicate($e->getMessage(), $e->getCode(), $e);
         }
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -334,7 +334,7 @@ class Postgres extends SQL
 
     /**
      * Truncate String Attribute
-     * 
+     *
      * @param string $collection
      * @param string $id
      * @param int $size

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -342,16 +342,15 @@ class Postgres extends SQL
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
-     * @param int $newSize
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
         $name = $this->filter($collection);
         $id = $this->filter($id);
-        $type = $this->getSQLType($type, $newSize ?? $size, $signed, $array);
+        $type = $this->getSQLType($type, $size, $signed, $array);
 
         if ($type == 'TIMESTAMP(3)') {
             $type = "TIMESTAMP(3) without time zone USING TO_TIMESTAMP(\"$id\", 'YYYY-MM-DD HH24:MI:SS.MS')";

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -390,7 +390,7 @@ class Postgres extends SQL
             ->execute();
 
             return $result;
-        } catch (Exception $e) {
+        } catch (PDOException $e) {
             $this->processException($e);
             return false;
         }

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -353,7 +353,7 @@ abstract class SQL extends Adapter
 
     /**
      * Is Attribute Resizing Supported?
-     * 
+     *
      * @return bool
      */
     public function getSupportForAttributeResizing(): bool

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -352,6 +352,16 @@ abstract class SQL extends Adapter
     }
 
     /**
+     * Is Attribute Resizing Supported?
+     * 
+     * @return bool
+     */
+    public function getSupportForAttributeResizing(): bool
+    {
+        return true;
+    }
+
+    /**
      * Get current attribute count from collection document
      *
      * @param Document $collection

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -265,12 +265,11 @@ class SQLite extends MariaDB
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
-     * @param int $newSize
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
     {
         if (!empty($newKey) && $newKey !== $id) {
             return $this->renameAttribute($collection, $id, $newKey);

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -276,18 +276,6 @@ class SQLite extends MariaDB
             return $this->renameAttribute($collection, $id, $newKey);
         }
 
-        if (!empty($newSize) && $newSize < $size) {
-            $collection = $this->filter($collection);
-            $id = $this->filter($id);
-
-            $sql = "UPDATE {$this->getSQLTable($collection)} SET `{$id}` = substr(`{$id}`, 1, {$newSize})";
-            $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
-
-            return $this->getPDO()
-                ->prepare($sql)
-                ->execute();
-        }
-
         return true;
     }
 
@@ -1093,6 +1081,16 @@ class SQLite extends MariaDB
     }
 
     public function getSupportForUpdateLock(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Is attribute resizing supported?
+     *
+     * @return bool
+     */
+    public function getSupportForAttributeResizing(): bool
     {
         return false;
     }

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -265,14 +265,19 @@ class SQLite extends MariaDB
      * @param bool $signed
      * @param bool $array
      * @param string $newKey
+     * @param int $newSize
      * @return bool
      * @throws Exception
      * @throws PDOException
      */
-    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null): bool
+    public function updateAttribute(string $collection, string $id, string $type, int $size, bool $signed = true, bool $array = false, string $newKey = null, int $newSize = null): bool
     {
         if (!empty($newKey) && $newKey !== $id) {
             return $this->renameAttribute($collection, $id, $newKey);
+        }
+
+        if (!empty($newSize) && $newSize < $size && $type === Database::VAR_STRING) {
+            return $this->truncateStringAttribute($collection, $id, $newSize);
         }
 
         return true;

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -1370,14 +1370,10 @@ class SQLite extends MariaDB
         // Timeout
         if ($e->getCode() === 'HY000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 3024) {
             throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 3024 && isset($e->errorInfo[0]) && $e->errorInfo[0] === "HY000") {
-            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
         }
 
         // Duplicate
         if ($e->getCode() === 'HY000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1) {
-            throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
-        } elseif ($e->getCode() === 1 && isset($e->errorInfo[0]) && $e->errorInfo[0] === 'HY000') {
             throw new DuplicateException($e->getMessage(), $e->getCode(), $e);
         }
 

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -276,34 +276,19 @@ class SQLite extends MariaDB
             return $this->renameAttribute($collection, $id, $newKey);
         }
 
-        if (!empty($newSize) && $newSize < $size && $type === Database::VAR_STRING) {
-            return $this->truncateStringAttribute($collection, $id, $newSize);
+        if (!empty($newSize) && $newSize < $size) {
+            $collection = $this->filter($collection);
+            $id = $this->filter($id);
+
+            $sql = "UPDATE {$this->getSQLTable($collection)} SET `{$id}` = substr(`{$id}`, 1, {$newSize})";
+            $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+            return $this->getPDO()
+                ->prepare($sql)
+                ->execute();
         }
 
         return true;
-    }
-
-    /**
-     * Truncate String Attribute
-     *
-     * @param string $collection
-     * @param string $id
-     * @param int $new
-     * @return bool
-     * @throws Exception
-     * @throws PDOException
-     */
-    public function truncateStringAttribute(string $collection, string $id, int $new): bool
-    {
-        $collection = $this->filter($collection);
-        $id = $this->filter($id);
-
-        $sql = "UPDATE {$this->getSQLTable($collection)} SET `{$id}` = substr(`{$id}`, 1, {$new})";
-        $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
-
-        return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
     }
 
     /**

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -284,6 +284,29 @@ class SQLite extends MariaDB
     }
 
     /**
+     * Truncate String Attribute
+     *
+     * @param string $collection
+     * @param string $id
+     * @param int $new
+     * @return bool
+     * @throws Exception
+     * @throws PDOException
+     */
+    public function truncateStringAttribute(string $collection, string $id, int $new): bool
+    {
+        $collection = $this->filter($collection);
+        $id = $this->filter($id);
+
+        $sql = "UPDATE {$this->getSQLTable($collection)} SET `{$id}` = substr(`{$id}`, 1, {$new})";
+        $sql = $this->trigger(Database::EVENT_ATTRIBUTE_UPDATE, $sql);
+
+        return $this->getPDO()
+            ->prepare($sql)
+            ->execute();
+    }
+
+    /**
      * Delete Attribute
      *
      * @param string $collection

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1684,17 +1684,19 @@ class Database
      * @param array<string, mixed>|null $formatOptions
      * @param array<string>|null $filters
      * @param string|null $newKey
+     * @param int|null $newSize
      * @return Document
      * @throws Exception
      */
-    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $required = null, mixed $default = null, bool $signed = null, bool $array = null, string $format = null, ?array $formatOptions = null, ?array $filters = null, ?string $newKey = null): Document
+    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $required = null, mixed $default = null, bool $signed = null, bool $array = null, string $format = null, ?array $formatOptions = null, ?array $filters = null, ?string $newKey = null, ?int $newSize = null): Document
     {
-        return $this->updateAttributeMeta($collection, $id, function ($attribute, $collectionDoc, $attributeIndex) use ($collection, $id, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters, $newKey) {
+        return $this->updateAttributeMeta($collection, $id, function ($attribute, $collectionDoc, $attributeIndex) use ($collection, $id, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters, $newKey, $newSize) {
             $altering = !\is_null($type)
                 || !\is_null($size)
                 || !\is_null($signed)
                 || !\is_null($array)
-                || !\is_null($newKey);
+                || !\is_null($newKey)
+                || !\is_null($newSize);
             $type ??= $attribute->getAttribute('type');
             $size ??= $attribute->getAttribute('size');
             $signed ??= $attribute->getAttribute('signed');
@@ -1761,7 +1763,7 @@ class Database
                 ->setAttribute('$id', $newKey ?? $id)
                 ->setattribute('key', $newKey ?? $id)
                 ->setAttribute('type', $type)
-                ->setAttribute('size', $size)
+                ->setAttribute('size', $newSize ?? $size)
                 ->setAttribute('signed', $signed)
                 ->setAttribute('array', $array)
                 ->setAttribute('format', $format)
@@ -1782,7 +1784,7 @@ class Database
             }
 
             if ($altering) {
-                $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array, $newKey);
+                $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array, $newKey, $newSize);
 
                 if ($id !== $newKey) {
                     $indexes = $collectionDoc->getAttribute('indexes');

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1761,7 +1761,7 @@ class Database
                 ->setAttribute('$id', $newKey ?? $id)
                 ->setattribute('key', $newKey ?? $id)
                 ->setAttribute('type', $type)
-                ->setAttribute('size',  $size)
+                ->setAttribute('size', $size)
                 ->setAttribute('signed', $signed)
                 ->setAttribute('array', $array)
                 ->setAttribute('format', $format)

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1717,7 +1717,7 @@ class Database
                         throw new DatabaseException('Size length is required');
                     }
 
-                    if ($size > $this->adapter->getLimitForString()) {
+                    if ($size > $this->adapter->getLimitForString() && $newSize > $this->adapter->getLimitForString()) {
                         throw new DatabaseException('Max size allowed for string is: ' . number_format($this->adapter->getLimitForString()));
                     }
                     break;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1684,19 +1684,17 @@ class Database
      * @param array<string, mixed>|null $formatOptions
      * @param array<string>|null $filters
      * @param string|null $newKey
-     * @param int|null $newSize
      * @return Document
      * @throws Exception
      */
-    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $required = null, mixed $default = null, bool $signed = null, bool $array = null, string $format = null, ?array $formatOptions = null, ?array $filters = null, ?string $newKey = null, ?int $newSize = null): Document
+    public function updateAttribute(string $collection, string $id, string $type = null, int $size = null, bool $required = null, mixed $default = null, bool $signed = null, bool $array = null, string $format = null, ?array $formatOptions = null, ?array $filters = null, ?string $newKey = null): Document
     {
-        return $this->updateAttributeMeta($collection, $id, function ($attribute, $collectionDoc, $attributeIndex) use ($collection, $id, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters, $newKey, $newSize) {
+        return $this->updateAttributeMeta($collection, $id, function ($attribute, $collectionDoc, $attributeIndex) use ($collection, $id, $type, $size, $required, $default, $signed, $array, $format, $formatOptions, $filters, $newKey) {
             $altering = !\is_null($type)
                 || !\is_null($size)
                 || !\is_null($signed)
                 || !\is_null($array)
-                || !\is_null($newKey)
-                || !\is_null($newSize);
+                || !\is_null($newKey);
             $type ??= $attribute->getAttribute('type');
             $size ??= $attribute->getAttribute('size');
             $signed ??= $attribute->getAttribute('signed');
@@ -1717,7 +1715,7 @@ class Database
                         throw new DatabaseException('Size length is required');
                     }
 
-                    if ($size > $this->adapter->getLimitForString() && $newSize > $this->adapter->getLimitForString()) {
+                    if ($size > $this->adapter->getLimitForString()) {
                         throw new DatabaseException('Max size allowed for string is: ' . number_format($this->adapter->getLimitForString()));
                     }
                     break;
@@ -1763,7 +1761,7 @@ class Database
                 ->setAttribute('$id', $newKey ?? $id)
                 ->setattribute('key', $newKey ?? $id)
                 ->setAttribute('type', $type)
-                ->setAttribute('size', $newSize ?? $size)
+                ->setAttribute('size',  $size)
                 ->setAttribute('signed', $signed)
                 ->setAttribute('array', $array)
                 ->setAttribute('format', $format)
@@ -1784,7 +1782,7 @@ class Database
             }
 
             if ($altering) {
-                $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array, $newKey, $newSize);
+                $updated = $this->adapter->updateAttribute($collection, $id, $type, $size, $signed, $array, $newKey);
 
                 if ($id !== $newKey) {
                     $indexes = $collectionDoc->getAttribute('indexes');

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5829,7 +5829,7 @@ abstract class Base extends TestCase
         }
     }
 
-    public function createRandomString($length = 10): string
+    public function createRandomString(int $length = 10): string
     {
         $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $charactersLength = strlen($characters);

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -6109,7 +6109,7 @@ abstract class Base extends TestCase
             $this->assertEquals('reservedKeyDocument', $documents[0]->getId());
             $this->assertEquals('Reserved:' . $keyword, $documents[0]->getAttribute($keyword));
 
-            $documents = $database->find($collectionName, [Query::equal($keyword, ["Reserved:${keyword}"])]);
+            $documents = $database->find($collectionName, [Query::equal($keyword, ["Reserved:{$keyword}"])]);
             $this->assertCount(1, $documents);
             $this->assertEquals('reservedKeyDocument', $documents[0]->getId());
 

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5829,7 +5829,7 @@ abstract class Base extends TestCase
         }
     }
 
-    public function createRandomString($length = 10)
+    public function createRandomString($length = 10): string
     {
         $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
         $charactersLength = strlen($characters);
@@ -5840,7 +5840,7 @@ abstract class Base extends TestCase
         return $randomString;
     }
 
-    public function updateStringAttributeSize(int $originalSize, int $newSize, Document $document)
+    public function updateStringAttributeSize(int $originalSize, int $newSize, Document $document): Document
     {
         static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, $originalSize, true, newSize: $newSize);
 

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5834,35 +5834,17 @@ abstract class Base extends TestCase
         return \substr(\bin2hex(\random_bytes(\max(1, \intval(($length + 1) / 2)))), 0, $length);
     }
 
-    public function updateStringAttributeSize(int $originalSize, int $newSize, Document $document): Document
+    public function updateStringAttributeSize(int $size, Document $document): Document
     {
-        static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, $originalSize, true, newSize: $newSize);
+        static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, $size, true);
 
-        // Check truncation if the new size is smaller
-        if ($originalSize > $newSize) {
-            $checkDoc = static::getDatabase()->getDocument('resize_test', $document->getId());
-
-            $this->assertEquals(
-                $newSize,
-                strlen($checkDoc->getAttribute('resize_me'))
-            );
-
-            // Check we get a structure exception when we reduce the size
-            try {
-                $document->setAttribute('resize_me', $this->createRandomString($newSize));
-                static::getDatabase()->updateDocument('resize_test', $document->getId(), $document);
-            } catch (StructureException $e) {
-                $this->assertEquals('Invalid document structure: Attribute "resize_me" has invalid type. Value must be a valid string and no longer than ' . $newSize . ' chars', $e->getMessage());
-            }
-        }
-
-        $document = $document->setAttribute('resize_me', $this->createRandomString($newSize));
+        $document = $document->setAttribute('resize_me', $this->createRandomString($size));
 
         static::getDatabase()->updateDocument('resize_test', $document->getId(), $document);
         $checkDoc = static::getDatabase()->getDocument('resize_test', $document->getId());
 
         $this->assertEquals($document->getAttribute('resize_me'), $checkDoc->getAttribute('resize_me'));
-        $this->assertEquals($newSize, strlen($checkDoc->getAttribute('resize_me')));
+        $this->assertEquals($size, strlen($checkDoc->getAttribute('resize_me')));
 
         return $checkDoc;
     }
@@ -5891,18 +5873,18 @@ abstract class Base extends TestCase
         // Go up in size
 
         // 0-16381 to 16382-65535
-        $document = $this->updateStringAttributeSize(128, 16382, $document);
+        $document = $this->updateStringAttributeSize(16382, $document);
 
         // 16382-65535 to 65536-16777215
-        $document = $this->updateStringAttributeSize(16382, 65536, $document);
+        $document = $this->updateStringAttributeSize(65536, $document);
 
         // 65536-16777216 to PHP_INT_MAX or adapter limit
         $maxStringSize = 16777217;
-        $document = $this->updateStringAttributeSize(65536, $maxStringSize, $document);
+        $document = $this->updateStringAttributeSize($maxStringSize, $document);
 
         // Test going down in size with data that is too big (Expect Failure)
         try {
-            static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, $maxStringSize, true, newSize: 128);
+            static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, 128, true);
             $this->fail('Succeeded updating attribute size to smaller size with data that is too big');
         } catch (DatabaseException $e) {
             $this->assertEquals('Resize would result in data truncation', $e->getMessage());
@@ -5910,7 +5892,7 @@ abstract class Base extends TestCase
 
         // Test going down in size when data isn't too big.
         static::getDatabase()->updateDocument('resize_test', $document->getId(), $document->setAttribute('resize_me', $this->createRandomString(128)));
-        static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, $maxStringSize, true, newSize: 128);
+        static::getDatabase()->updateAttribute('resize_test', 'resize_me', Database::VAR_STRING, 128, true);
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -5829,9 +5829,9 @@ abstract class Base extends TestCase
         }
     }
 
-    function createRandomString(int $length = 10): string
+    public function createRandomString(int $length = 10): string
     {
-        return \substr(\bin2hex(\random_bytes(\intval(($length + 1) / 2))), 0, $length);
+        return \substr(\bin2hex(\random_bytes(\max(1, \intval(($length + 1) / 2)))), 0, $length);
     }
 
     public function updateStringAttributeSize(int $originalSize, int $newSize, Document $document): Document


### PR DESCRIPTION
This PR implements the ability to resize string attributes. Currently, it works for MySQL, MariaDB, SQLite, and PostgreSQL. Currently working on fixing it for MongoDB.