### PR TITLE
Fix nested id queries not working

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1651,6 +1651,8 @@ class MariaDB extends SQL
         $where = [];
         $orders = [];
 
+        $queries = array_map(fn ($query) => clone $query, $queries);
+
         $orderAttributes = \array_map(fn ($orderAttribute) => match ($orderAttribute) {
             '$id' => '_uid',
             '$internalId' => '_id',
@@ -1852,6 +1854,8 @@ class MariaDB extends SQL
         $where = [];
         $limit = \is_null($max) ? '' : 'LIMIT :max';
 
+        $queries = array_map(fn ($query) => clone $query, $queries);
+
         $conditions = $this->getSQLConditions($queries);
         if(!empty($conditions)) {
             $where[] = $conditions;
@@ -1922,6 +1926,8 @@ class MariaDB extends SQL
         $roles = Authorization::getRoles();
         $where = [];
         $limit = \is_null($max) ? '' : 'LIMIT :max';
+
+        $queries = array_map(fn ($query) => clone $query, $queries);
 
         foreach ($queries as $query) {
             $where[] = $this->getSQLCondition($query);

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -951,6 +951,7 @@ class Mongo extends Adapter
     public function find(string $collection, array $queries = [], ?int $limit = 25, ?int $offset = null, array $orderAttributes = [], array $orderTypes = [], array $cursor = [], string $cursorDirection = Database::CURSOR_AFTER): array
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection);
+        $queries = array_map(fn ($query) => clone $query, $queries);
 
         $filters = $this->buildFilters($queries);
 
@@ -1212,6 +1213,8 @@ class Mongo extends Adapter
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection);
 
+        $queries = array_map(fn ($query) => clone $query, $queries);
+
         $filters = [];
         $options = [];
 
@@ -1252,6 +1255,7 @@ class Mongo extends Adapter
         $name = $this->getNamespace() . '_' . $this->filter($collection);
 
         // queries
+        $queries = array_map(fn ($query) => clone $query, $queries);
         $filters = $this->buildFilters($queries);
 
         // permissions

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1578,6 +1578,8 @@ class Postgres extends SQL
         $where = [];
         $orders = [];
 
+        $queries = array_map(fn ($query) => clone $query, $queries);
+
         $orderAttributes = \array_map(fn ($orderAttribute) => match ($orderAttribute) {
             '$id' => '_uid',
             '$internalId' => '_id',
@@ -1773,6 +1775,8 @@ class Postgres extends SQL
         $where = [];
         $limit = \is_null($max) ? '' : 'LIMIT :max';
 
+        $queries = array_map(fn ($query) => clone $query, $queries);
+
         $conditions = $this->getSQLConditions($queries);
         if(!empty($conditions)) {
             $where[] = $conditions;
@@ -1836,6 +1840,8 @@ class Postgres extends SQL
         $roles = Authorization::getRoles();
         $where = [];
         $limit = \is_null($max) ? '' : 'LIMIT :max';
+
+        $queries = array_map(fn ($query) => clone $query, $queries);
 
         foreach ($queries as $query) {
             $where[] = $this->getSQLCondition($query);

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -91,6 +91,15 @@ class Query
         $this->values = $values;
     }
 
+    public function __clone(): void
+    {
+        foreach ($this->values as $index => $value) {
+            if ($value instanceof self) {
+                $this->values[$index] = clone $value;
+            }
+        }
+    }
+
     /**
      * @return string
      */

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -4163,36 +4163,50 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute('movies_nested_id', 'name', Database::VAR_STRING, 128, true));
 
         static::getDatabase()->createDocument('movies_nested_id', new Document([
-            '$id' => ID::custom('frozen'),
+            '$id' => ID::custom('1'),
             '$permissions' => [
                 Permission::read(Role::any()),
                 Permission::create(Role::any()),
                 Permission::update(Role::any()),
                 Permission::delete(Role::any()),
             ],
-            'name' => 'Frozen',
+            'name' => '1',
         ]));
 
         static::getDatabase()->createDocument('movies_nested_id', new Document([
-            '$id' => ID::custom('wip2'),
+            '$id' => ID::custom('2'),
             '$permissions' => [
                 Permission::read(Role::any()),
                 Permission::create(Role::any()),
                 Permission::update(Role::any()),
                 Permission::delete(Role::any()),
             ],
-            'name' => 'wip2',
+            'name' => '2',
+        ]));
+
+        static::getDatabase()->createDocument('movies_nested_id', new Document([
+            '$id' => ID::custom('3'),
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::create(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => '3',
         ]));
 
         $queries = [
             Query::or([
-                Query::equal('$id', ["frozen"]),
-                Query::equal('$id', ["wip2"])
+                Query::equal('$id', ["1"]),
+                Query::equal('$id', ["2"])
             ])
         ];
 
         $documents = static::getDatabase()->find('movies_nested_id', $queries);
         $this->assertCount(2, $documents);
+
+        // Make sure the query was not modified by reference
+        $this->assertEquals($queries[0]->getValues()[0]->getAttribute(), '$id');
 
         $count = static::getDatabase()->count('movies_nested_id', $queries);
         $this->assertEquals(2, $count);

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2903,7 +2903,6 @@ abstract class Base extends TestCase
                 Permission::delete(Role::user('1x')),
                 Permission::delete(Role::user('2x')),
             ],
-            '$id' => 'wip2',
             'name' => 'Work in Progress 2',
             'director' => 'TBD',
             'year' => 2026,


### PR DESCRIPTION
This PR fixes issues resulting from nested ID queries as the original references get modified, making subsequent queries fail.