### PR TITLE
Make findOne return empty document instead of false

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4039,10 +4039,10 @@ class Database
                                 }
                                 if (
                                     $oldValue?->getId() !== $value
-                                    && $this->skipRelationships(fn () => $this->findOne($relatedCollection->getId(), [
+                                    && !($this->skipRelationships(fn () => $this->findOne($relatedCollection->getId(), [
                                         Query::select(['$id']),
                                         Query::equal($twoWayKey, [$value]),
-                                    ]))
+                                    ]))->isEmpty())
                                 ) {
                                     // Have to do this here because otherwise relations would be updated before the database can throw the unique violation
                                     throw new DuplicateException('Document already has a related document');
@@ -4060,10 +4060,10 @@ class Database
 
                                     if (
                                         $oldValue?->getId() !== $value->getId()
-                                        && $this->skipRelationships(fn () => $this->findOne($relatedCollection->getId(), [
+                                        && !($this->skipRelationships(fn () => $this->findOne($relatedCollection->getId(), [
                                             Query::select(['$id']),
                                             Query::equal($twoWayKey, [$value->getId()]),
-                                        ]))
+                                        ]))->isEmpty())
                                     ) {
                                         // Have to do this here because otherwise relations would be updated before the database can throw the unique violation
                                         throw new DuplicateException('Document already has a related document');
@@ -4726,7 +4726,7 @@ class Database
                     Query::equal($twoWayKey, [$document->getId()])
                 ]);
 
-                if (!$related instanceof Document) {
+                if ($related->isEmpty()) {
                     return;
                 }
 
@@ -4749,7 +4749,7 @@ class Database
                 Query::equal($twoWayKey, [$document->getId()])
             ]));
 
-            if ($related) {
+            if (!$related->isEmpty()) {
                 throw new RestrictedException('Cannot delete document because it has at least one related document.');
             }
         }
@@ -4793,7 +4793,7 @@ class Database
                         $related = $this->getDocument($relatedCollection->getId(), $value->getId(), [Query::select(['$id'])]);
                     }
 
-                    if (!$related instanceof Document) {
+                    if ($related->isEmpty()) {
                         return;
                     }
 
@@ -5172,10 +5172,10 @@ class Database
     /**
      * @param string $collection
      * @param array<Query> $queries
-     * @return false|Document
+     * @return Document
      * @throws DatabaseException
      */
-    public function findOne(string $collection, array $queries = []): false|Document
+    public function findOne(string $collection, array $queries = []): Document
     {
         $results = $this->silent(fn () => $this->find($collection, \array_merge([
             Query::limit(1)
@@ -5185,7 +5185,11 @@ class Database
 
         $this->trigger(self::EVENT_DOCUMENT_FIND, $found);
 
-        return $found;
+        if (!$found) {
+            return new Document();
+        } else {
+            return $found;
+        }
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -4232,13 +4232,13 @@ abstract class Base extends TestCase
             Query::orderAsc('name')
         ]);
 
-        $this->assertTrue($document instanceof Document);
+        $this->assertFalse($document->isEmpty());
         $this->assertEquals('Frozen', $document->getAttribute('name'));
 
         $document = $this->getDatabase()->findOne('movies', [
             Query::offset(10)
         ]);
-        $this->assertEquals(false, $document);
+        $this->assertTrue($document->isEmpty());
     }
 
     public function testFindNull(): void
@@ -5475,7 +5475,7 @@ abstract class Base extends TestCase
 
         // Document should be there if adapter migrated properly
         $document = $database->findOne('colors');
-        $this->assertTrue($document instanceof Document);
+        $this->assertFalse($document->isEmpty());
         $this->assertEquals('black', $document->getAttribute('verbose'));
         $this->assertEquals('#000000', $document->getAttribute('hex'));
         $this->assertEquals(null, $document->getAttribute('name'));
@@ -6519,7 +6519,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'library.name'])
         ]);
 
-        if (!$person instanceof Document) {
+        if ($person->isEmpty()) {
             throw new Exception('Person not found');
         }
 
@@ -6995,7 +6995,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'city.name'])
         ]);
 
-        if (!$country instanceof Document) {
+        if ($country->isEmpty()) {
             throw new Exception('Country not found');
         }
 
@@ -7569,7 +7569,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'albums.name'])
         ]);
 
-        if (!$artist instanceof Document) {
+        if ($artist->isEmpty()) {
             $this->fail('Artist not found');
         }
 
@@ -8002,7 +8002,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'accounts.name'])
         ]);
 
-        if (!$customer instanceof Document) {
+        if ($customer->isEmpty()) {
             throw new Exception('Customer not found');
         }
 
@@ -8414,7 +8414,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'movie.name'])
         ]);
 
-        if (!$review instanceof Document) {
+        if ($review->isEmpty()) {
             throw new Exception('Review not found');
         }
 
@@ -8791,7 +8791,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'store.name'])
         ]);
 
-        if (!$product instanceof Document) {
+        if ($product->isEmpty()) {
             throw new Exception('Product not found');
         }
 
@@ -9173,7 +9173,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'songs.name'])
         ]);
 
-        if (!$playlist instanceof Document) {
+        if ($playlist->isEmpty()) {
             throw new Exception('Playlist not found');
         }
 
@@ -9555,7 +9555,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'classes.name'])
         ]);
 
-        if (!$student instanceof Document) {
+        if ($student->isEmpty()) {
             throw new Exception('Student not found');
         }
 
@@ -9859,7 +9859,7 @@ abstract class Base extends TestCase
             Query::select(['name', 'models.name']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9881,7 +9881,7 @@ abstract class Base extends TestCase
             Query::select(['name', '$id']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9896,7 +9896,7 @@ abstract class Base extends TestCase
             Query::select(['name', '$internalId']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9911,7 +9911,7 @@ abstract class Base extends TestCase
             Query::select(['name', '$collection']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9926,7 +9926,7 @@ abstract class Base extends TestCase
             Query::select(['name', '$createdAt']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9941,7 +9941,7 @@ abstract class Base extends TestCase
             Query::select(['name', '$updatedAt']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9956,7 +9956,7 @@ abstract class Base extends TestCase
             Query::select(['name', '$permissions']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9972,7 +9972,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'models.year']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -9988,7 +9988,7 @@ abstract class Base extends TestCase
             Query::select(['*', 'models.*']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -10005,7 +10005,7 @@ abstract class Base extends TestCase
             Query::select(['models.*']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 
@@ -10021,7 +10021,7 @@ abstract class Base extends TestCase
             Query::select(['name']),
         ]);
 
-        if (!$make instanceof Document) {
+        if ($make->isEmpty()) {
             throw new Exception('Make not found');
         }
 


### PR DESCRIPTION
This PR makes `findOne` return an empty document instead of a false when no document is found. Tests have been updated appropriately.