### PR TITLE
Don't throw on deleteAttribute if column doesn't exist

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -435,7 +435,7 @@ class MariaDB extends SQL
     /**
      * Rename Attribute
      *
-     * @param string $collectionp
+     * @param string $collection
      * @param string $old
      * @param string $new
      * @return bool

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -421,8 +421,8 @@ class MariaDB extends SQL
 
         try {
             return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
+                ->prepare($sql)
+                ->execute();
         } catch (PDOException $e) {
             if ($e->getCode() === "42000" && $e->errorInfo[1] === 1091) {
                 return true;
@@ -435,7 +435,7 @@ class MariaDB extends SQL
     /**
      * Rename Attribute
      *
-     * @param string $collection
+     * @param string $collectionp
      * @param string $old
      * @param string $new
      * @return bool

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -419,9 +419,17 @@ class MariaDB extends SQL
 
         $sql = $this->trigger(Database::EVENT_ATTRIBUTE_DELETE, $sql);
 
-        return $this->getPDO()
+        try {
+            return $this->getPDO()
             ->prepare($sql)
             ->execute();
+        } catch (PDOException $e) {
+            if ($e->getCode() === "42000" && $e->errorInfo[1] === 1091) {
+                return true;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -348,10 +348,10 @@ class Postgres extends SQL
 
         try {
             return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
+                ->prepare($sql)
+                ->execute();
         } catch (PDOException $e) {
-            if ($e->getCode() === "4242703000" && $e->errorInfo[1] === 7) {
+            if ($e->getCode() === "42703" && $e->errorInfo[1] === 7) {
                 return true;
             }
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -346,9 +346,17 @@ class Postgres extends SQL
 
         $sql = $this->trigger(Database::EVENT_ATTRIBUTE_DELETE, $sql);
 
-        return $this->getPDO()
+        try {
+            return $this->getPDO()
             ->prepare($sql)
             ->execute();
+        } catch (PDOException $e) {
+            if ($e->getCode() === "4242703000" && $e->errorInfo[1] === 7) {
+                return true;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -341,9 +341,17 @@ class SQLite extends MariaDB
 
         $sql = $this->trigger(Database::EVENT_COLLECTION_DELETE, $sql);
 
-        return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
+        try {
+            return $this->getPDO()
+                ->prepare($sql)
+                ->execute();
+        } catch (PDOException $e) {
+            if (str_contains($e->getMessage(), 'no such column')) {
+                return true;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -42,6 +42,14 @@ abstract class Base extends TestCase
     abstract protected static function getDatabase(): Database;
 
     /**
+     * @param string $collection
+     * @param string $column
+     * 
+     * @return bool
+     */
+    abstract protected static function deleteColumn(string $collection, string $column): bool;
+
+    /**
      * @return string
      */
     abstract protected static function getAdapterName(): string;
@@ -1295,6 +1303,11 @@ abstract class Base extends TestCase
         } catch (Exception $e) {
             $this->assertInstanceOf(DuplicateException::class, $e);
         }
+
+        // Test delete attribute when column does not exist
+        $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string1', Database::VAR_STRING, 128, true));
+        $this->assertEquals(true, static::deleteColumn('attributes', 'string1'));
+        $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string1'));
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -1306,8 +1306,23 @@ abstract class Base extends TestCase
 
         // Test delete attribute when column does not exist
         $this->assertEquals(true, static::getDatabase()->createAttribute('attributes', 'string1', Database::VAR_STRING, 128, true));
+        sleep(1);
+
         $this->assertEquals(true, static::deleteColumn('attributes', 'string1'));
+
+        $collection = static::getDatabase()->getCollection('attributes');
+        $attributes = $collection->getAttribute('attributes');
+        $attribute = end($attributes);
+        $this->assertEquals('string1', $attribute->getId());
+
         $this->assertEquals(true, static::getDatabase()->deleteAttribute('attributes', 'string1'));
+
+        $collection = static::getDatabase()->getCollection('attributes');
+        $attributes = $collection->getAttribute('attributes');
+        $attribute = end($attributes);
+        $this->assertNotEquals('string1', $attribute->getId());
+
+        $collection = static::getDatabase()->getCollection('attributes');
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -44,7 +44,7 @@ abstract class Base extends TestCase
     /**
      * @param string $collection
      * @param string $column
-     * 
+     *
      * @return bool
      */
     abstract protected static function deleteColumn(string $collection, string $column): bool;

--- a/tests/e2e/Adapter/MariaDBTest.php
+++ b/tests/e2e/Adapter/MariaDBTest.php
@@ -63,8 +63,8 @@ class MariaDBTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/MariaDBTest.php
+++ b/tests/e2e/Adapter/MariaDBTest.php
@@ -12,6 +12,7 @@ use Utopia\Database\Database;
 class MariaDBTest extends Base
 {
     protected static ?Database $database = null;
+    protected static ?PDO $pdo = null;
     protected static string $namespace;
 
     // Remove once all methods are implemented
@@ -56,6 +57,17 @@ class MariaDBTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/MirrorTest.php
+++ b/tests/e2e/Adapter/MirrorTest.php
@@ -22,6 +22,7 @@ use Utopia\Database\Mirror;
 class MirrorTest extends Base
 {
     protected static ?Mirror $database = null;
+    protected static ?PDO $pdo = null;
     protected static Database $source;
     protected static Database $destination;
 
@@ -95,6 +96,7 @@ class MirrorTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
     }
 
@@ -311,5 +313,15 @@ class MirrorTest extends Base
         // Assert document is deleted in both databases
         $this->assertTrue($database->getSource()->getDocument('testDeleteMirroredDocument', $document->getId())->isEmpty());
         $this->assertTrue($database->getDestination()->getDocument('testDeleteMirroredDocument', $document->getId())->isEmpty());
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/MongoDBTest.php
+++ b/tests/e2e/Adapter/MongoDBTest.php
@@ -95,4 +95,9 @@ class MongoDBTest extends Base
     {
         $this->assertTrue(true);
     }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/MySQLTest.php
+++ b/tests/e2e/Adapter/MySQLTest.php
@@ -12,6 +12,7 @@ use Utopia\Database\Database;
 class MySQLTest extends Base
 {
     public static ?Database $database = null;
+    protected static ?PDO $pdo = null;
     protected static string $namespace;
 
     // Remove once all methods are implemented
@@ -58,6 +59,17 @@ class MySQLTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/MySQLTest.php
+++ b/tests/e2e/Adapter/MySQLTest.php
@@ -65,8 +65,8 @@ class MySQLTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/PostgresTest.php
+++ b/tests/e2e/Adapter/PostgresTest.php
@@ -62,8 +62,8 @@ class PostgresTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = '"' . self::getDatabase()->getDatabase() . '"."' . self::getDatabase()->getNamespace() . '_' . $collection . '"';
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN \"{$column}\"";
+        $sqlTable = '"' . self::getDatabase()->getDatabase() . '"."' . self::getDatabase()->getNamespace() . '_' . $collection . '"';
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN \"{$column}\"";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/PostgresTest.php
+++ b/tests/e2e/Adapter/PostgresTest.php
@@ -12,6 +12,7 @@ use Utopia\Database\Database;
 class PostgresTest extends Base
 {
     public static ?Database $database = null;
+    protected static ?PDO $pdo = null;
     protected static string $namespace;
 
     /**
@@ -55,6 +56,17 @@ class PostgresTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = '"' . self::getDatabase()->getDatabase() . '"."' . self::getDatabase()->getNamespace() . '_' . $collection . '"';
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN \"{$column}\"";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/SQLiteTest.php
+++ b/tests/e2e/Adapter/SQLiteTest.php
@@ -12,6 +12,7 @@ use Utopia\Database\Database;
 class SQLiteTest extends Base
 {
     public static ?Database $database = null;
+    protected static ?PDO $pdo = null;
     protected static string $namespace;
 
     // Remove once all methods are implemented
@@ -61,6 +62,17 @@ class SQLiteTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = "`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/SQLiteTest.php
+++ b/tests/e2e/Adapter/SQLiteTest.php
@@ -68,8 +68,8 @@ class SQLiteTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = "`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+        $sqlTable = "`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/SharedTables/MariaDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MariaDBTest.php
@@ -66,8 +66,8 @@ class MariaDBTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/SharedTables/MariaDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MariaDBTest.php
@@ -13,6 +13,7 @@ use Utopia\Database\Database;
 class MariaDBTest extends Base
 {
     protected static ?Database $database = null;
+    protected static ?PDO $pdo = null;
     protected static string $namespace;
 
     // Remove once all methods are implemented
@@ -59,6 +60,17 @@ class MariaDBTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/SharedTables/MongoDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MongoDBTest.php
@@ -98,4 +98,9 @@ class MongoDBTest extends Base
     {
         $this->assertTrue(true);
     }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SharedTables/MySQLTest.php
+++ b/tests/e2e/Adapter/SharedTables/MySQLTest.php
@@ -68,8 +68,8 @@ class MySQLTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/SharedTables/MySQLTest.php
+++ b/tests/e2e/Adapter/SharedTables/MySQLTest.php
@@ -13,6 +13,7 @@ use Utopia\Database\Database;
 class MySQLTest extends Base
 {
     public static ?Database $database = null;
+    protected static ?PDO $pdo = null;
     protected static string $namespace;
 
     // Remove once all methods are implemented
@@ -61,6 +62,17 @@ class MySQLTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/SharedTables/PostgresTest.php
+++ b/tests/e2e/Adapter/SharedTables/PostgresTest.php
@@ -65,8 +65,8 @@ class PostgresTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = '"' . self::getDatabase()->getDatabase() . '"."' . self::getDatabase()->getNamespace() . '_' . $collection . '"';
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN \"{$column}\"";
+        $sqlTable = '"' . self::getDatabase()->getDatabase() . '"."' . self::getDatabase()->getNamespace() . '_' . $collection . '"';
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN \"{$column}\"";
 
         self::$pdo->exec($sql);
 

--- a/tests/e2e/Adapter/SharedTables/PostgresTest.php
+++ b/tests/e2e/Adapter/SharedTables/PostgresTest.php
@@ -13,6 +13,7 @@ use Utopia\Database\Database;
 class PostgresTest extends Base
 {
     public static ?Database $database = null;
+    public static ?PDO $pdo = null;
     protected static string $namespace;
 
     /**
@@ -58,6 +59,17 @@ class PostgresTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = '"' . self::getDatabase()->getDatabase() . '"."' . self::getDatabase()->getNamespace() . '_' . $collection . '"';
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN \"{$column}\"";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/SharedTables/SQLiteTest.php
+++ b/tests/e2e/Adapter/SharedTables/SQLiteTest.php
@@ -13,6 +13,7 @@ use Utopia\Database\Database;
 class SQLiteTest extends Base
 {
     public static ?Database $database = null;
+    public static ?PDO $pdo = null;
     protected static string $namespace;
 
     // Remove once all methods are implemented
@@ -64,6 +65,17 @@ class SQLiteTest extends Base
 
         $database->create();
 
+        self::$pdo = $pdo;
         return self::$database = $database;
+    }
+
+    protected static function deleteColumn(string $collection, string $column): bool
+    {
+        $SQLTable = "`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+
+        self::$pdo->exec($sql);
+
+        return true;
     }
 }

--- a/tests/e2e/Adapter/SharedTables/SQLiteTest.php
+++ b/tests/e2e/Adapter/SharedTables/SQLiteTest.php
@@ -71,8 +71,8 @@ class SQLiteTest extends Base
 
     protected static function deleteColumn(string $collection, string $column): bool
     {
-        $SQLTable = "`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
-        $sql = "ALTER TABLE {$SQLTable} DROP COLUMN `{$column}`";
+        $sqlTable = "`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "ALTER TABLE {$sqlTable} DROP COLUMN `{$column}`";
 
         self::$pdo->exec($sql);
 


### PR DESCRIPTION
This PR makes it so that when you deleteAttributes, if the column for the attribute does not exist, the adapter will still return true so the metadata can be cleaned up appropriately. Tests are not included for this as replicating the environment for this isn't easy with the tests architecture we have