### PR TITLE
Don't throw when deleting indexes that don't exist

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -832,9 +832,17 @@ class MariaDB extends SQL
 
         $sql = $this->trigger(Database::EVENT_INDEX_DELETE, $sql);
 
-        return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
+        try {
+            return $this->getPDO()
+                ->prepare($sql)
+                ->execute();
+        } catch (PDOException $e) {
+            if ($e->getCode() === "42000" && $e->errorInfo[1] === 1091) {
+                return true;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -499,9 +499,17 @@ class SQLite extends MariaDB
         $sql = "DROP INDEX `{$this->getNamespace()}_{$this->tenant}_{$name}_{$id}`";
         $sql = $this->trigger(Database::EVENT_INDEX_DELETE, $sql);
 
-        return $this->getPDO()
-            ->prepare($sql)
-            ->execute();
+        try {
+            return $this->getPDO()
+                ->prepare($sql)
+                ->execute();
+        } catch (PDOException $e) {
+            if (str_contains($e->getMessage(), 'no such index')) {
+                return true;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -50,6 +50,14 @@ abstract class Base extends TestCase
     abstract protected static function deleteColumn(string $collection, string $column): bool;
 
     /**
+     * @param string $collection
+     * @param string $index
+     * 
+     * @return bool
+     */
+    abstract protected static function deleteIndex(string $collection, string $index): bool;
+
+    /**
      * @return string
      */
     abstract protected static function getAdapterName(): string;
@@ -1615,6 +1623,16 @@ abstract class Base extends TestCase
         } catch (Exception $e) {
             $this->assertInstanceOf(DuplicateException::class, $e);
         }
+
+        // Test delete index when index does not exist
+        $this->assertEquals(true, static::getDatabase()->createIndex('indexes', 'index1', Database::INDEX_KEY, ['string', 'integer'], [128], [Database::ORDER_ASC]));
+        $this->assertEquals(true, static::deleteIndex('indexes', 'index1'));
+        $this->assertEquals(true, static::getDatabase()->deleteIndex('indexes', 'index1'));
+
+        // Test delete index when attribute does not exist
+        $this->assertEquals(true, static::getDatabase()->createIndex('indexes', 'index1', Database::INDEX_KEY, ['string', 'integer'], [128], [Database::ORDER_ASC]));
+        $this->assertEquals(true, static::getDatabase()->deleteAttribute('indexes', 'string'));
+        $this->assertEquals(true, static::getDatabase()->deleteIndex('indexes', 'index1'));
 
         static::getDatabase()->deleteCollection('indexes');
     }

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -52,7 +52,7 @@ abstract class Base extends TestCase
     /**
      * @param string $collection
      * @param string $index
-     * 
+     *
      * @return bool
      */
     abstract protected static function deleteIndex(string $collection, string $index): bool;

--- a/tests/e2e/Adapter/MariaDBTest.php
+++ b/tests/e2e/Adapter/MariaDBTest.php
@@ -70,4 +70,14 @@ class MariaDBTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "DROP INDEX `{$index}` ON {$sqlTable}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/MirrorTest.php
+++ b/tests/e2e/Adapter/MirrorTest.php
@@ -331,4 +331,19 @@ class MirrorTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $sqlTable = "`" . self::$source->getDatabase() . "`.`" . self::$source->getNamespace() . "_" . $collection . "`";
+        $sql = "DROP INDEX `{$index}` ON {$sqlTable}";
+
+        self::$sourcePdo->exec($sql);
+
+        $sqlTable = "`" . self::$destination->getDatabase() . "`.`" . self::$destination->getNamespace() . "_" . $collection . "`";
+        $sql = "DROP INDEX `{$index}` ON {$sqlTable}";
+
+        self::$destinationPdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/MongoDBTest.php
+++ b/tests/e2e/Adapter/MongoDBTest.php
@@ -100,4 +100,9 @@ class MongoDBTest extends Base
     {
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/MySQLTest.php
+++ b/tests/e2e/Adapter/MySQLTest.php
@@ -72,4 +72,14 @@ class MySQLTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "DROP INDEX `{$index}` ON {$sqlTable}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/PostgresTest.php
+++ b/tests/e2e/Adapter/PostgresTest.php
@@ -69,4 +69,15 @@ class PostgresTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $key = "\"".self::getDatabase()->getNamespace()."_".self::getDatabase()->getTenant()."_{$collection}_{$index}\"";
+
+        $sql = "DROP INDEX \"".self::getDatabase()->getDatabase()."\".{$key}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SQLiteTest.php
+++ b/tests/e2e/Adapter/SQLiteTest.php
@@ -75,4 +75,14 @@ class SQLiteTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $index = "`".self::getDatabase()->getNamespace()."_".self::getDatabase()->getTenant()."_{$collection}_{$index}`";
+        $sql = "DROP INDEX {$index}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SharedTables/MariaDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MariaDBTest.php
@@ -73,4 +73,14 @@ class MariaDBTest extends Base
 
         return true;
     }
+    
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "DROP INDEX `{$index}` ON {$sqlTable}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SharedTables/MariaDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MariaDBTest.php
@@ -73,7 +73,7 @@ class MariaDBTest extends Base
 
         return true;
     }
-    
+
     protected static function deleteIndex(string $collection, string $index): bool
     {
         $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/SharedTables/MongoDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MongoDBTest.php
@@ -103,4 +103,9 @@ class MongoDBTest extends Base
     {
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SharedTables/MySQLTest.php
+++ b/tests/e2e/Adapter/SharedTables/MySQLTest.php
@@ -75,4 +75,14 @@ class MySQLTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $sqlTable = "`" . self::getDatabase()->getDatabase() . "`.`" . self::getDatabase()->getNamespace() . "_" . $collection . "`";
+        $sql = "DROP INDEX `{$index}` ON {$sqlTable}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SharedTables/PostgresTest.php
+++ b/tests/e2e/Adapter/SharedTables/PostgresTest.php
@@ -72,4 +72,15 @@ class PostgresTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $key = "\"".self::getDatabase()->getNamespace()."_".self::getDatabase()->getTenant()."_{$collection}_{$index}\"";
+
+        $sql = "DROP INDEX \"".self::getDatabase()->getDatabase()."\".{$key}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }

--- a/tests/e2e/Adapter/SharedTables/SQLiteTest.php
+++ b/tests/e2e/Adapter/SharedTables/SQLiteTest.php
@@ -78,4 +78,14 @@ class SQLiteTest extends Base
 
         return true;
     }
+
+    protected static function deleteIndex(string $collection, string $index): bool
+    {
+        $index = "`".self::getDatabase()->getNamespace()."_".self::getDatabase()->getTenant()."_{$collection}_{$index}`";
+        $sql = "DROP INDEX {$index}";
+
+        self::$pdo->exec($sql);
+
+        return true;
+    }
 }


### PR DESCRIPTION
This PR makes it so we can delete indexes that do not exist so we can cleanup metadata, tests have been added to confirm this functionality works as intended.