### PR TITLE
Make bulk methods always return array of documents

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4033,7 +4033,7 @@ class Database
             throw new StructureException($validator->getDescription());
         }
 
-        $affected = $this->withTransaction(function () use ($collection, $queries, $batchSize, $updates, $limit, $cursor) {
+        $documents = $this->withTransaction(function () use ($collection, $queries, $batchSize, $updates, $limit, $cursor) {
             $lastDocument = null;
             $documents = [];
 
@@ -4105,7 +4105,7 @@ class Database
             return $documents;
         });
 
-        return $affected;
+        return $documents;
     }
 
     /**
@@ -5183,7 +5183,7 @@ class Database
             throw new DatabaseException("cursor Document must be from the same Collection.");
         }
 
-        $modified = $this->withTransaction(function () use ($collection, $queries, $batchSize, $limit, $cursor) {
+        $documents = $this->withTransaction(function () use ($collection, $queries, $batchSize, $limit, $cursor) {
             $documentSecurity = $collection->getAttribute('documentSecurity', false);
             $authorization = new Authorization(self::PERMISSION_DELETE);
             $skipAuth = $authorization->isValid($collection->getDelete());
@@ -5251,7 +5251,7 @@ class Database
             return $documents;
         });
 
-        return $modified;
+        return $documents;
     }
 
     /**

--- a/src/Database/Mirror.php
+++ b/src/Database/Mirror.php
@@ -662,19 +662,19 @@ class Mirror extends Database
         Document $updates,
         array $queries = [],
         int $batchSize = self::INSERT_BATCH_SIZE
-    ): int {
-        $count = $this->source->updateDocuments($collection, $updates, $queries, $batchSize);
+    ): array {
+        $documents = $this->source->updateDocuments($collection, $updates, $queries, $batchSize);
 
         if (
             \in_array($collection, self::SOURCE_ONLY_COLLECTIONS)
             || $this->destination === null
         ) {
-            return $count;
+            return $documents;
         }
 
         $upgrade = $this->silent(fn () => $this->getUpgradeStatus($collection));
         if ($upgrade === null || $upgrade->getAttribute('status', '') !== 'upgraded') {
-            return $count;
+            return $documents;
         }
 
         try {
@@ -707,7 +707,7 @@ class Mirror extends Database
             $this->logError('updateDocuments', $err);
         }
 
-        return $count;
+        return $documents;
     }
 
     public function deleteDocument(string $collection, string $id): bool
@@ -753,20 +753,20 @@ class Mirror extends Database
         return $result;
     }
 
-    public function deleteDocuments(string $collection, array $queries = [], int $batchSize = self::DELETE_BATCH_SIZE): int
+    public function deleteDocuments(string $collection, array $queries = [], int $batchSize = self::DELETE_BATCH_SIZE): array
     {
-        $count = $this->source->deleteDocuments($collection, $queries, $batchSize);
+        $documents = $this->source->deleteDocuments($collection, $queries, $batchSize);
 
         if (
             \in_array($collection, self::SOURCE_ONLY_COLLECTIONS)
             || $this->destination === null
         ) {
-            return $count;
+            return $documents;
         }
 
         $upgrade = $this->silent(fn () => $this->getUpgradeStatus($collection));
         if ($upgrade === null || $upgrade->getAttribute('status', '') !== 'upgraded') {
-            return $count;
+            return $documents;
         }
 
         try {
@@ -793,7 +793,7 @@ class Mirror extends Database
             $this->logError('deleteDocuments', $err);
         }
 
-        return $count;
+        return $documents;
     }
 
     public function updateAttributeRequired(string $collection, string $id, bool $required): Document

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -17037,10 +17037,13 @@ abstract class Base extends TestCase
                 Database::EVENT_DOCUMENT_INCREASE,
                 Database::EVENT_DOCUMENT_DECREASE,
                 Database::EVENT_DOCUMENTS_CREATE,
-                Database::EVENT_DOCUMENTS_UPDATE,
+                Database::EVENT_DOCUMENT_UPDATE,
+                Database::EVENT_DOCUMENT_UPDATE,
+                Database::EVENT_DOCUMENT_UPDATE,
                 Database::EVENT_INDEX_DELETE,
                 Database::EVENT_DOCUMENT_DELETE,
-                Database::EVENT_DOCUMENTS_DELETE,
+                Database::EVENT_DOCUMENT_DELETE,
+                Database::EVENT_DOCUMENT_DELETE,
                 Database::EVENT_ATTRIBUTE_DELETE,
                 Database::EVENT_COLLECTION_DELETE,
                 Database::EVENT_DATABASE_DELETE
@@ -17048,7 +17051,6 @@ abstract class Base extends TestCase
 
             $database->on(Database::EVENT_ALL, 'test', function ($event, $data) use (&$events) {
                 $shifted = array_shift($events);
-
                 $this->assertEquals($shifted, $event);
             });
 
@@ -17115,6 +17117,8 @@ abstract class Base extends TestCase
 
             $database->deleteIndex($collectionId, $indexId1);
             $database->deleteDocument($collectionId, 'doc1');
+
+            var_dump('asd');
             $database->deleteDocuments($collectionId);
             $database->deleteAttribute($collectionId, 'attr1');
             $database->deleteCollection($collectionId);

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -17118,7 +17118,6 @@ abstract class Base extends TestCase
             $database->deleteIndex($collectionId, $indexId1);
             $database->deleteDocument($collectionId, 'doc1');
 
-            var_dump('asd');
             $database->deleteDocuments($collectionId);
             $database->deleteAttribute($collectionId, 'attr1');
             $database->deleteCollection($collectionId);

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -15908,7 +15908,7 @@ abstract class Base extends TestCase
         $modified = static::getDatabase()->deleteDocuments('bulk_delete', [
             Query::greaterThanEqual('integer', 5)
         ]);
-        $this->assertCount(5,$modified);
+        $this->assertCount(5, $modified);
 
         foreach ($modified as $document) {
             $this->assertGreaterThanOrEqual(5, $document->getAttribute('integer'));

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -15905,9 +15905,14 @@ abstract class Base extends TestCase
         // TEST: Bulk delete documents with queries.
         $this->propegateBulkDocuments('bulk_delete');
 
-        $this->assertCount(5,static::getDatabase()->deleteDocuments('bulk_delete', [
+        $modified = static::getDatabase()->deleteDocuments('bulk_delete', [
             Query::greaterThanEqual('integer', 5)
-        ]));
+        ]);
+        $this->assertCount(5,$modified);
+
+        foreach ($modified as $document) {
+            $this->assertGreaterThanOrEqual(5, $document->getAttribute('integer'));
+        }
 
         $docs = static::getDatabase()->find('bulk_delete');
         $this->assertCount(5, $docs);
@@ -16600,11 +16605,16 @@ abstract class Base extends TestCase
         }
 
         // Test Update half of the documents
-        $this->assertCount(5, static::getDatabase()->updateDocuments($collection, new Document([
+        $modified = static::getDatabase()->updateDocuments($collection, new Document([
             'string' => 'text📝 updated',
         ]), [
             Query::greaterThanEqual('integer', 5),
-        ]));
+        ]);
+        $this->assertCount(5, $modified);
+
+        foreach ($modified as $document) {
+            $this->assertEquals('text📝 updated', $document->getAttribute('string'));
+        }
 
         $updatedDocuments = static::getDatabase()->find($collection, [
             Query::greaterThanEqual('integer', 5),
@@ -16614,6 +16624,7 @@ abstract class Base extends TestCase
 
         foreach ($updatedDocuments as $document) {
             $this->assertEquals('text📝 updated', $document->getAttribute('string'));
+            $this->assertGreaterThanOrEqual(5, $document->getAttribute('integer'));
         }
 
         $controlDocuments = static::getDatabase()->find($collection, [


### PR DESCRIPTION
This PR makes the bulk document functions return the array of documents that have been modified, tests have been updated accordingly.