### PR TITLE
Respect timestamps in bulk operations and add tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,5 +55,11 @@
         "ext-redis": "Needed to support Redis Cache Adapter",
         "ext-pdo": "Needed to support MariaDB, MySQL or SQLite Database Adapter",
         "mongodb/mongodb": "Needed to support MongoDB Database Adapter"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false,
+            "tbachert/spi": false
+        }
     }
 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4086,7 +4086,12 @@ class Database
                     }
 
                     // Check if document was updated after the request timestamp
-                    $oldUpdatedAt = new \DateTime($document->getUpdatedAt());
+                    try {
+                        $oldUpdatedAt = new \DateTime($document->getUpdatedAt());
+                    } catch (Exception $e) {
+                        throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+                    }
+
                     if (!is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
                         throw new ConflictException('Document was updated after the request timestamp');
                     }

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -15923,8 +15923,8 @@ abstract class Base extends TestCase
         $oneHourAgo = (new \DateTime())->sub(new \DateInterval('PT1H'));
 
         try {
-            $this->getDatabase()->withRequestTimestamp($oneHourAgo, function () use ($document) {
-                return $this->getDatabase()->deleteDocuments($document->getCollection());
+            $this->getDatabase()->withRequestTimestamp($oneHourAgo, function () {
+                return $this->getDatabase()->deleteDocuments('bulk_delete');
             });
             $this->fail('Failed to throw exception');
         } catch (ConflictException $e) {

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2110,8 +2110,6 @@ abstract class Base extends TestCase
             $this->assertEquals(9223372036854775807, $document->getAttribute('bigint'));
         }
 
-        // Test (FAIL) create documents with invalid timestamps
-
         return $documents;
     }
 


### PR DESCRIPTION
Bulk operations didn't previously respect timestamps, this fixes that and adds tests for that case.