### PR TITLE
Implement Count Queries

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -901,11 +901,11 @@ abstract class Adapter
     abstract public function getSupportForUpserts(): bool;
 
     /**
-     * Are sum queries supported?
+     * Are aggregate queries supported?
      *
      * @return bool
      */
-    abstract public function getSupportForSum(): bool;
+    abstract public function getSupportForAggregateQueries(): bool;
 
     /**
      * Get current attribute count from collection document
@@ -996,17 +996,18 @@ abstract class Adapter
     }
 
     /**
-     * Get all sum attributes from queries
+     * Get all attributes from an aggregate query
      *
-     * @param Query[] $queries
+     * @param array<Query> $queries
+     * @param string $queryType
      * @return array<string|array<string>>
      */
-    protected function getAttributeSums(array $queries): array
+    protected function getAttributeSums(array $queries, string $queryType): array
     {
         $selections = [];
 
         foreach ($queries as $query) {
-            if ($query->getMethod() === Query::TYPE_SUM) {
+            if ($query->getMethod() === $queryType) {
                 $selections[] = $query->getValues();
             }
         }

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1820,7 +1820,7 @@ class Mongo extends Adapter
         return false;
     }
 
-    public function getSupportForSum(): bool
+    public function getSupportForAggregateQueries(): bool
     {
         return false;
     }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1917,7 +1917,6 @@ class Postgres extends SQL
         $sqlLimit = \is_null($limit) ? '' : 'LIMIT :limit';
         $sqlLimit .= \is_null($offset) ? '' : ' OFFSET :offset';
         $selections = $this->getAttributeSelections($queries);
-        $sumSelections = $this->getAttributeSums($queries);
 
         $sql = "
             SELECT {$this->getAttributeProjection($selections, 'table_main')}
@@ -1927,8 +1926,10 @@ class Postgres extends SQL
             {$sqlLimit}
         ";
 
-        if (!empty($sumSelections)) {
-            $sql = "SELECT {$this->getSumQueries($sumSelections)} FROM ({$sql}) table_sum;";
+        $aggregateQueries = array_filter($queries, fn ($query) => in_array($query->getMethod(), Query::AGGREGATE_TYPES));
+
+        if (!empty($aggregateQueries)) {
+            $sql = $this->handleAggregateQueries($sql, $aggregateQueries);
         } else {
             $sql .= ';';
         }
@@ -2481,16 +2482,6 @@ class Postgres extends SQL
     }
 
     /**
-     * Are sum queries supported?
-     *
-     * @return bool
-     */
-    public function getSupportForSum(): bool
-    {
-        return true;
-    }
-
-    /**
      * @return string
      */
     public function getLikeOperator(): string
@@ -2528,6 +2519,37 @@ class Postgres extends SQL
         }
 
         return $e;
+    }
+
+    /**
+     * Handle Aggregate Queries
+     *
+     * @param string $sql
+     * @param array<Query> $aggregateQueries
+     * @return string
+     */
+    public function handleAggregateQueries(string $sql, array $aggregateQueries): string
+    {
+        if (empty($aggregateQueries)) {
+            return $sql;
+        }
+
+        $aggregateType = $aggregateQueries[0]->getMethod();
+
+        switch ($aggregateType) {
+            case Query::TYPE_COUNT:
+                $countSelections = [];
+                foreach ($aggregateQueries as $query) {
+                    $attribute = $query->getAttribute();
+                    $countSelections[] = "COUNT(\"{$attribute}\") as \"{$attribute}\"";
+                }
+                return "SELECT " . implode(', ', $countSelections) . " FROM ({$sql}) table_count;";
+            case Query::TYPE_SUM:
+                $selections = $this->getAttributeSums($aggregateQueries, $aggregateType);
+                return "SELECT {$this->getSumQueries($selections)} FROM ({$sql}) table_sum;";
+            default:
+                throw new DatabaseException('Unknown aggregate type: ' . $aggregateType);
+        }
     }
 
     /**

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -403,6 +403,16 @@ abstract class SQL extends Adapter
     }
 
     /**
+     * Are aggregate queries supported?
+     *
+     * @return bool
+     */
+    public function getSupportForAggregateQueries(): bool
+    {
+        return true;
+    }
+
+    /**
      * Get current attribute count from collection document
      *
      * @param Document $collection
@@ -1134,7 +1144,7 @@ abstract class SQL extends Adapter
         $conditions = [];
         foreach ($queries as $query) {
 
-            if ($query->getMethod() === Query::TYPE_SELECT || $query->getMethod() === Query::TYPE_SUM) {
+            if ($query->getMethod() === Query::TYPE_SELECT || in_array($query->getMethod(), Query::AGGREGATE_TYPES)) {
                 continue;
             }
 

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -25,6 +25,9 @@ class Query
     public const TYPE_SELECT = 'select';
     public const TYPE_SUM = 'sum';
 
+    // Aggregate methods
+    public const TYPE_COUNT = 'count';
+
     // Order methods
     public const TYPE_ORDER_DESC = 'orderDesc';
     public const TYPE_ORDER_ASC = 'orderAsc';
@@ -63,11 +66,17 @@ class Query
         self::TYPE_CURSOR_BEFORE,
         self::TYPE_AND,
         self::TYPE_OR,
+        self::TYPE_COUNT,
     ];
 
     protected const LOGICAL_TYPES = [
         self::TYPE_AND,
         self::TYPE_OR,
+    ];
+
+    public const AGGREGATE_TYPES = [
+        self::TYPE_COUNT,
+        self::TYPE_SUM,
     ];
 
     protected string $method = '';
@@ -217,6 +226,7 @@ class Query
             self::TYPE_OR,
             self::TYPE_AND,
             self::TYPE_SUM,
+            self::TYPE_COUNT,
             self::TYPE_SELECT => true,
             default => false,
         };
@@ -569,6 +579,17 @@ class Query
     public static function endsWith(string $attribute, string $value): self
     {
         return new self(self::TYPE_ENDS_WITH, $attribute, [$value]);
+    }
+
+    /**
+     * Helper method to create Query with sum method
+     *
+     * @param string $attribute
+     * @return Query
+     */
+    public static function count(string $attribute): self
+    {
+        return new self(self::TYPE_COUNT, $attribute);
     }
 
     /**

--- a/src/Database/Validator/Queries.php
+++ b/src/Database/Validator/Queries.php
@@ -83,6 +83,20 @@ class Queries extends Validator
                 }
             }
 
+            $methodsUsed = array_map(
+                fn (Query|string $query) => $query instanceof Query ? $query->getMethod() : $query,
+                $value
+            );
+
+            $methodsUsed = array_unique($methodsUsed);
+            $aggregateMethods = array_intersect($methodsUsed, Query::AGGREGATE_TYPES);
+
+            // Check if multiple aggregate methods are used
+            if (count($aggregateMethods) > 1) {
+                $this->message = 'Invalid query: Multiple types of aggregate methods are not supported';
+                return false;
+            }
+
             if ($query->isNested()) {
                 if (!self::isValid($query->getValues())) {
                     return false;
@@ -95,6 +109,7 @@ class Queries extends Validator
                 Query::TYPE_SUM => Base::METHOD_TYPE_SUM,
                 Query::TYPE_LIMIT => Base::METHOD_TYPE_LIMIT,
                 Query::TYPE_OFFSET => Base::METHOD_TYPE_OFFSET,
+                Query::TYPE_COUNT => Base::METHOD_TYPE_COUNT,
                 Query::TYPE_CURSOR_AFTER,
                 Query::TYPE_CURSOR_BEFORE => Base::METHOD_TYPE_CURSOR,
                 Query::TYPE_ORDER_ASC,

--- a/src/Database/Validator/Queries/Documents.php
+++ b/src/Database/Validator/Queries/Documents.php
@@ -6,6 +6,7 @@ use Exception;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Validator\IndexedQueries;
+use Utopia\Database\Validator\Query\Count;
 use Utopia\Database\Validator\Query\Cursor;
 use Utopia\Database\Validator\Query\Filter;
 use Utopia\Database\Validator\Query\Limit;
@@ -68,6 +69,7 @@ class Documents extends IndexedQueries
             new Order($attributes),
             new Select($attributes),
             new Sum($attributes),
+            new Count($attributes),
         ];
 
         parent::__construct($attributes, $indexes, $validators);

--- a/src/Database/Validator/Query/Base.php
+++ b/src/Database/Validator/Query/Base.php
@@ -13,6 +13,8 @@ abstract class Base extends Validator
     public const METHOD_TYPE_FILTER = 'filter';
     public const METHOD_TYPE_SELECT = 'select';
     public const METHOD_TYPE_SUM = 'sum';
+    public const METHOD_TYPE_COUNT = 'count';
+
 
     protected string $message = 'Invalid query';
 

--- a/src/Database/Validator/Query/Count.php
+++ b/src/Database/Validator/Query/Count.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Utopia\Database\Validator\Query;
+
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+
+class Count extends Base
+{
+    /**
+     * @var array<int|string, mixed>
+     */
+    protected array $schema = [];
+
+    /**
+     * List of internal attributes
+     *
+     * @var array<string>
+     */
+    protected const INTERNAL_ATTRIBUTES = [
+        '$id',
+        '$internalId',
+        '$createdAt',
+        '$updatedAt',
+        '$permissions',
+        '$collection',
+    ];
+
+    /**
+     * @param array<Document> $attributes
+     */
+    public function __construct(array $attributes = [])
+    {
+        foreach ($attributes as $attribute) {
+            $this->schema[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute->getArrayCopy();
+        }
+    }
+
+    /**
+     * Is valid.
+     *
+     * Returns true if method is TYPE_SUM selections are valid
+     *
+     * Otherwise, returns false
+     *
+     * @param Query $value
+     * @return bool
+     */
+    public function isValid($value): bool
+    {
+        if (!$value instanceof Query) {
+            return false;
+        }
+
+        if ($value->getMethod() !== Query::TYPE_COUNT) {
+            return false;
+        }
+
+        $internalKeys = \array_map(
+            fn ($attr) => $attr['$id'],
+            Database::INTERNAL_ATTRIBUTES
+        );
+
+        if (!isset($this->schema[$value->getAttribute()])) {
+            $this->message = 'Attribute not found in schema: ' . $value->getAttribute();
+            return false;
+        }
+        return true;
+    }
+
+    public function getMethodType(): string
+    {
+        return self::METHOD_TYPE_COUNT;
+    }
+}

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -203,6 +203,11 @@ class QueryTest extends TestCase
         $this->assertEquals(null, $query->getAttribute());
         $this->assertEquals(['title', 'director'], $query->getValues());
 
+        $query = Query::parse(Query::count('actors')->toString());
+        $this->assertEquals('count', $query->getMethod());
+        $this->assertEquals('actors', $query->getAttribute());
+        $this->assertEquals([], $query->getValues());
+
         $json = Query::or([
             Query::equal('actors', ['Brad Pitt']),
             Query::equal('actors', ['Johnny Depp'])
@@ -270,6 +275,7 @@ class QueryTest extends TestCase
         $this->assertTrue(Query::isMethod('sum'));
         $this->assertTrue(Query::isMethod('or'));
         $this->assertTrue(Query::isMethod('and'));
+        $this->assertTrue(Query::isMethod('count'));
 
         $this->assertTrue(Query::isMethod(Query::TYPE_EQUAL));
         $this->assertTrue(Query::isMethod(Query::TYPE_NOT_EQUAL));
@@ -292,7 +298,7 @@ class QueryTest extends TestCase
         $this->assertTrue(Query::isMethod(QUERY::TYPE_SUM));
         $this->assertTrue(Query::isMethod(QUERY::TYPE_OR));
         $this->assertTrue(Query::isMethod(QUERY::TYPE_AND));
-
+        $this->assertTrue(Query::isMethod(QUERY::TYPE_COUNT));
         $this->assertFalse(Query::isMethod('invalid'));
         $this->assertFalse(Query::isMethod('lte '));
     }

--- a/tests/unit/Validator/Query/CountTest.php
+++ b/tests/unit/Validator/Query/CountTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Utopia\Tests\Unit\Validator\Query;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Exception;
+use Utopia\Database\Query;
+use Utopia\Database\Validator\Query\Base;
+use Utopia\Database\Validator\Query\Count;
+
+class CountTest extends TestCase
+{
+    protected Base|null $validator = null;
+
+    /**
+     * @throws Exception
+     */
+    public function setUp(): void
+    {
+        $this->validator = new Count(
+            attributes: [
+                new Document([
+                    '$id' => 'value',
+                    'key' => 'value',
+                    'type' => Database::VAR_INTEGER,
+                    'array' => false,
+                ]),
+                new Document([
+                    '$id' => 'valueFloat',
+                    'key' => 'valueFloat',
+                    'type' => Database::VAR_FLOAT,
+                    'array' => false,
+                ]),
+                new Document([
+                    '$id' => 'valueStr',
+                    'key' => 'valueStr',
+                    'type' => Database::VAR_STRING,
+                    'array' => false,
+                ]),
+            ],
+        );
+    }
+
+    public function testValueSuccess(): void
+    {
+        $this->assertTrue($this->validator->isValid(Query::count('value')));
+        $this->assertTrue($this->validator->isValid(Query::count('valueFloat')));
+    }
+
+    public function testValueFailure(): void
+    {
+        $this->assertFalse($this->validator->isValid(Query::limit(1)));
+        $this->assertEquals('Invalid query', $this->validator->getDescription());
+        $this->assertFalse($this->validator->isValid(Query::count('valueStr')));
+    }
+}


### PR DESCRIPTION
This PR implements count queries and generally cleans up the code of how aggregates work so it's more maintainable. This supports all DB adapters excluding MongoDB.