### PR TITLE
Fix different column for nulls bug in create documents

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -465,16 +465,16 @@
         },
         {
             "name": "open-telemetry/api",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/api.git",
-                "reference": "74b1a03263be8c5acb578f41da054b4bac3af4a0"
+                "reference": "8b925df3047628968bc5be722468db1b98b82d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/74b1a03263be8c5acb578f41da054b4bac3af4a0",
-                "reference": "74b1a03263be8c5acb578f41da054b4bac3af4a0",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/8b925df3047628968bc5be722468db1b98b82d51",
+                "reference": "8b925df3047628968bc5be722468db1b98b82d51",
                 "shasum": ""
             },
             "require": {
@@ -531,7 +531,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-20T23:35:16+00:00"
+            "time": "2025-02-03T21:49:11+00:00"
         },
         {
             "name": "open-telemetry/context",
@@ -721,16 +721,16 @@
         },
         {
             "name": "open-telemetry/sdk",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sdk.git",
-                "reference": "96aeaee5b7cb8c0bc4af7ff4717b429f2d9f67e1"
+                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/96aeaee5b7cb8c0bc4af7ff4717b429f2d9f67e1",
-                "reference": "96aeaee5b7cb8c0bc4af7ff4717b429f2d9f67e1",
+                "url": "https://api.github.com/repos/opentelemetry-php/sdk/zipball/37eec0fe47ddd627911f318f29b6cd48196be0c0",
+                "reference": "37eec0fe47ddd627911f318f29b6cd48196be0c0",
                 "shasum": ""
             },
             "require": {
@@ -807,24 +807,24 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2025-01-09T23:17:14+00:00"
+            "time": "2025-01-29T21:40:28+00:00"
         },
         {
             "name": "open-telemetry/sem-conv",
-            "version": "1.27.1",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/opentelemetry-php/sem-conv.git",
-                "reference": "1dba705fea74bc0718d04be26090e3697e56f4e6"
+                "reference": "4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/1dba705fea74bc0718d04be26090e3697e56f4e6",
-                "reference": "1dba705fea74bc0718d04be26090e3697e56f4e6",
+                "url": "https://api.github.com/repos/opentelemetry-php/sem-conv/zipball/4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a",
+                "reference": "4178c9f390da8e4dbca9b181a9d1efd50cf7ee0a",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^8.0"
             },
             "type": "library",
             "extra": {
@@ -864,7 +864,7 @@
                 "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
                 "source": "https://github.com/open-telemetry/opentelemetry-php"
             },
-            "time": "2024-08-28T09:20:31+00:00"
+            "time": "2025-02-06T00:21:48+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -2724,16 +2724,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.16",
+            "version": "1.12.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
+                "reference": "7027b3b0270bf392de0cfba12825979768d728bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
-                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7027b3b0270bf392de0cfba12825979768d728bf",
+                "reference": "7027b3b0270bf392de0cfba12825979768d728bf",
                 "shasum": ""
             },
             "require": {
@@ -2778,7 +2778,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-21T14:50:05+00:00"
+            "time": "2025-02-07T15:01:57+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -4349,7 +4349,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -4357,6 +4357,6 @@
         "ext-pdo": "*",
         "ext-mbstring": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -988,6 +988,10 @@ class MariaDB extends SQL
             }
             $attributeKeys = array_unique($attributeKeys);
 
+            if ($this->sharedTables) {
+                $attributeKeys[] = '_tenant';
+            }
+
             $batches = \array_chunk($documents, \max(1, $batchSize));
             $documentIds = \array_map(fn ($document) => $document->getId(), $documents);
 
@@ -1013,6 +1017,7 @@ class MariaDB extends SQL
                     if (!empty($document->getInternalId())) {
                         $internalIds[$document->getId()] = true;
                         $attributes['_id'] = $document->getInternalId();
+                        $attributeKeys[] = '_id';
                     }
 
                     if ($this->sharedTables) {

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -982,9 +982,17 @@ class MariaDB extends SQL
             $name = $this->filter($collection);
 
             $attributeKeys = Database::INTERNAL_ATTRIBUTE_KEYS;
+
+            $hasInternalId = null;
             foreach ($documents as $document) {
                 $attributes = $document->getAttributes();
                 $attributeKeys = array_merge($attributeKeys, array_keys($attributes));
+
+                if ($hasInternalId === null) {
+                    $hasInternalId = !empty($document->getInternalId());
+                } elseif ($hasInternalId == empty($document->getInternalId())) {
+                    throw new DatabaseException('All documents must have an internalId if one is set');
+                }
             }
             $attributeKeys = array_unique($attributeKeys);
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -981,12 +981,7 @@ class MariaDB extends SQL
         try {
             $name = $this->filter($collection);
 
-            $attributeKeys = [
-                '_uid',
-                '_createdAt',
-                '_updatedAt',
-                '_permissions',
-            ];
+            $attributeKeys = Database::INTERNAL_ATTRIBUTE_KEYS;
             foreach ($documents as $document) {
                 $attributes = $document->getAttributes();
                 $attributeKeys = array_merge($attributeKeys, array_keys($attributes));

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1041,11 +1041,20 @@ class Postgres extends SQL
             $name = $this->filter($collection);
 
             $attributeKeys = Database::INTERNAL_ATTRIBUTE_KEYS;
+
+            $hasInternalId = null;
             foreach ($documents as $document) {
                 $attributes = $document->getAttributes();
                 $attributeKeys = array_merge($attributeKeys, array_keys($attributes));
+
+                if ($hasInternalId === null) {
+                    $hasInternalId = !empty($document->getInternalId());
+                } elseif ($hasInternalId == empty($document->getInternalId())) {
+                    throw new DatabaseException('All documents must have an internalId if one is set');
+                }
             }
             $attributeKeys = array_unique($attributeKeys);
+
             if ($this->sharedTables) {
                 $attributeKeys[] = '_tenant';
             }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1040,12 +1040,7 @@ class Postgres extends SQL
         try {
             $name = $this->filter($collection);
 
-            $attributeKeys = [
-                '_uid',
-                '_createdAt',
-                '_updatedAt',
-                '_permissions',
-            ];
+            $attributeKeys = Database::INTERNAL_ATTRIBUTE_KEYS;
             foreach ($documents as $document) {
                 $attributes = $document->getAttributes();
                 $attributeKeys = array_merge($attributeKeys, array_keys($attributes));

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1046,6 +1046,9 @@ class Postgres extends SQL
                 $attributeKeys = array_merge($attributeKeys, array_keys($attributes));
             }
             $attributeKeys = array_unique($attributeKeys);
+            if ($this->sharedTables) {
+                $attributeKeys[] = '_tenant';
+            }
 
             $batches = \array_chunk($documents, max(1, $batchSize));
             $internalIds = [];
@@ -1073,6 +1076,7 @@ class Postgres extends SQL
                     if (!empty($document->getInternalId())) {
                         $internalIds[$document->getId()] = true;
                         $attributes['_id'] = $document->getInternalId();
+                        $attributeKeys[] = '_id';
                     }
 
                     if ($this->sharedTables) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -222,6 +222,13 @@ class Database
         ],
     ];
 
+    public const INTERNAL_ATTRIBUTE_KEYS = [
+        '_uid',
+        '_createdAt',
+        '_updatedAt',
+        '_permissions',
+    ];
+
     public const INTERNAL_INDEXES = [
         '_id',
         '_uid',

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2247,12 +2247,14 @@ abstract class Base extends TestCase
         $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'string', Database::VAR_STRING, 128, true));
         $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'integer', Database::VAR_INTEGER, 0, false));
         $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'bigint', Database::VAR_INTEGER, 8, false));
+        $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'string_default', Database::VAR_STRING, 128, false, 'default'));
 
         $documents = [
             new Document([
                 '$id' => 'first',
                 'string' => 'text📝',
                 'integer' => 5,
+                'string_default' => 'not_default',
             ]),
             new Document([
                 '$id' => 'second',
@@ -2266,8 +2268,12 @@ abstract class Base extends TestCase
 
         $this->assertEquals('text📝', $documents[0]->getAttribute('string'));
         $this->assertEquals(5, $documents[0]->getAttribute('integer'));
+        $this->assertEquals('not_default', $documents[0]->getAttribute('string_default'));
         $this->assertEquals('text📝', $documents[1]->getAttribute('string'));
         $this->assertNull($documents[1]->getAttribute('integer'));
+        $this->assertEquals('default', $documents[1]->getAttribute('string_default'));
+
+        static::getDatabase()->deleteCollection($collection);
     }
 
     public function testCreateOrUpdateDocuments(): void

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2291,16 +2291,14 @@ abstract class Base extends TestCase
         try {
             static::getDatabase()->createDocuments($collection, $documents);
             $this->fail('Failed to throw exception');
-        } catch (Throwable $e) {
-            $this->assertTrue($e instanceof DatabaseException);
+        } catch (DatabaseException $e) {
         }
 
         $documents = array_reverse($documents);
         try {
             static::getDatabase()->createDocuments($collection, $documents);
             $this->fail('Failed to throw exception');
-        } catch (Throwable $e) {
-            $this->assertTrue($e instanceof DatabaseException);
+        } catch (DatabaseException $e) {
         }
 
         static::getDatabase()->deleteCollection($collection);

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2238,6 +2238,38 @@ abstract class Base extends TestCase
         return $documents;
     }
 
+    public function testCreateDocumentsWithDifferentAttributes(): void
+    {
+        $collection = 'testDiffAttributes';
+
+        static::getDatabase()->createCollection($collection);
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'string', Database::VAR_STRING, 128, true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'integer', Database::VAR_INTEGER, 0, false));
+        $this->assertEquals(true, static::getDatabase()->createAttribute($collection, 'bigint', Database::VAR_INTEGER, 8, false));
+
+        $documents = [
+            new Document([
+                '$id' => 'first',
+                'string' => 'text📝',
+                'integer' => 5,
+            ]),
+            new Document([
+                '$id' => 'second',
+                'string' => 'text📝',
+            ]),
+        ];
+
+        $documents = static::getDatabase()->createDocuments($collection, $documents);
+
+        $this->assertEquals(2, count($documents));
+
+        $this->assertEquals('text📝', $documents[0]->getAttribute('string'));
+        $this->assertEquals(5, $documents[0]->getAttribute('integer'));
+        $this->assertEquals('text📝', $documents[1]->getAttribute('string'));
+        $this->assertNull($documents[1]->getAttribute('integer'));
+    }
+
     public function testCreateOrUpdateDocuments(): void
     {
         if (!static::getDatabase()->getAdapter()->getSupportForUpserts()) {

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2273,6 +2273,36 @@ abstract class Base extends TestCase
         $this->assertNull($documents[1]->getAttribute('integer'));
         $this->assertEquals('default', $documents[1]->getAttribute('string_default'));
 
+        /**
+         * Expect fail, mix of internalId and no internalId
+         */
+        $documents = [
+            new Document([
+                '$id' => 'third',
+                '$internalId' => 'third',
+                'string' => 'text📝',
+            ]),
+            new Document([
+                '$id' => 'fourth',
+                'string' => 'text📝',
+            ]),
+        ];
+
+        try {
+            static::getDatabase()->createDocuments($collection, $documents);
+            $this->fail('Failed to throw exception');
+        } catch (Throwable $e) {
+            $this->assertTrue($e instanceof DatabaseException);
+        }
+
+        $documents = array_reverse($documents);
+        try {
+            static::getDatabase()->createDocuments($collection, $documents);
+            $this->fail('Failed to throw exception');
+        } catch (Throwable $e) {
+            $this->assertTrue($e instanceof DatabaseException);
+        }
+
         static::getDatabase()->deleteCollection($collection);
     }
 


### PR DESCRIPTION
Create documents constructs the column list based on all documents however there is a chance that values don't exist on a document (because of it not being required) meaning it doesn't get set in the bindValues resulting in a diff between the number of values expected and the number of values given.

This PR fixes that by making a column list of all the documents and checking against that when binding values, if a value doesn't exist it will be set as null within the bindValues. Validators from the database adapter should catch if a value is required or doesn't exist at all so we don't need to check that.

Tests have been added to make sure that this fixes the bug explained.