### PR TITLE
fix: purgeCachedDocument after transaction

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4007,10 +4007,11 @@ class Database
             }
 
             $this->adapter->updateDocument($collection->getId(), $id, $document);
-            $this->purgeCachedDocument($collection->getId(), $id);
 
             return $document;
         });
+
+        $this->purgeCachedDocument($collection->getId(), $id);
 
         if ($this->resolveRelationships) {
             $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
@@ -4961,13 +4962,12 @@ class Database
             if ($this->resolveRelationships) {
                 $document = $this->silent(fn () => $this->deleteDocumentRelationships($collection, $document));
             }
-
-            $result = $this->adapter->deleteDocument($collection->getId(), $id);
-
-            $this->purgeCachedDocument($collection->getId(), $id);
-
-            return $result;
+            return $this->adapter->deleteDocument($collection->getId(), $id);
         });
+
+        if ($deleted) {
+            $this->purgeCachedDocument($collection->getId(), $id);
+        }
 
         $this->trigger(self::EVENT_DOCUMENT_DELETE, $document);
 

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -17883,9 +17883,7 @@ abstract class Base extends TestCase
         $this->assertCount(1, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
         $this->assertFalse(($database->getDocument('testRedisFallback', 'doc1'))->isEmpty());
 
-        // With our changes, the transaction should now succeed but cache operations will fail afterward
-        // Let's verify the database operations work but log exceptions from cache operations
-
+        // Check we can modify data
         try {
             $database->updateDocument('testRedisFallback', 'doc1', new Document([
                 'string' => 'text📝 updated',
@@ -17910,3 +17908,4 @@ abstract class Base extends TestCase
         $this->assertCount(0, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
     }
 }
+s

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -17883,7 +17883,9 @@ abstract class Base extends TestCase
         $this->assertCount(1, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
         $this->assertFalse(($database->getDocument('testRedisFallback', 'doc1'))->isEmpty());
 
-        // Check we cannot modify data
+        // With our changes, the transaction should now succeed but cache operations will fail afterward
+        // Let's verify the database operations work but log exceptions from cache operations
+
         try {
             $database->updateDocument('testRedisFallback', 'doc1', new Document([
                 'string' => 'text📝 updated',
@@ -17904,6 +17906,7 @@ abstract class Base extends TestCase
         Console::execute('docker ps -a --filter "name=utopia-redis" --format "{{.Names}}" | xargs -r docker start', "", $stdout, $stderr);
         sleep(5);
 
-        $this->assertCount(1, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
+        // Should return empty results after the delete operation
+        $this->assertCount(0, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
     }
 }

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -17883,7 +17883,7 @@ abstract class Base extends TestCase
         $this->assertCount(1, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
         $this->assertFalse(($database->getDocument('testRedisFallback', 'doc1'))->isEmpty());
 
-        // Check we can modify data
+        // Check we cannot modify data
         try {
             $database->updateDocument('testRedisFallback', 'doc1', new Document([
                 'string' => 'text📝 updated',
@@ -17905,7 +17905,6 @@ abstract class Base extends TestCase
         sleep(5);
 
         // Should return empty results after the delete operation
-        $this->assertCount(0, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
+        $this->assertCount(1, $database->find('testRedisFallback', [Query::equal('string', ['text📝'])]));
     }
 }
-s


### PR DESCRIPTION
This is kind of a big conceptual change, previously we attempted to be strongly consistent with cache and DB (but imperfect due to scenario above), now we are eventually consistent. There is now a gap between purgeCachedDocument and the commit, where gets can be stale