### PR TITLE
Skip auth in bulks

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4212,7 +4212,7 @@ class Database
                 }
             }
 
-            $this->withTransaction(function () use ($collection, $updates, $authorization, $skipAuth, $batch) {
+            $this->withTransaction(function () use ($collection, $updates, $batch) {
                 $this->adapter->updateDocuments(
                     $collection->getId(),
                     $updates,

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4179,15 +4179,11 @@ class Database
                 $new[] = Query::cursorAfter($last);
             }
 
-            $getResults = fn () => $this->find(
+            $batch = $this->silent(fn () => $this->find(
                 $collection->getId(),
                 array_merge($new, $queries),
                 forPermission: Database::PERMISSION_UPDATE
-            );
-
-            $batch = $this->silent(
-                fn () => $skipAuth ? $authorization->skip($getResults) : $getResults()
-            );
+            ));
 
             if (empty($batch)) {
                 break;


### PR DESCRIPTION
- Nothing to skip in updateDocuments.
- @abnegate  Should we skip auth in the find method?
