### PR TITLE
Auto-increment integer attribute

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1577,10 +1577,7 @@ class Database
         }
 
         if ($collection->getId() !== self::METADATA) {
-            // FIXME: remove the unused methods
             $this->silent(fn () => $this->updateDocument(self::METADATA, $collection->getId(), $collection));
-            $val = $this->silent(fn () => $this->getDocument(self::METADATA, $collection->getId()));
-            $val->getAttributes();
         }
 
         $this->purgeCachedCollection($collection->getId());
@@ -3405,7 +3402,7 @@ class Database
         ) {
             throw new DatabaseException('Shared tables must be enabled if tenant per document is enabled.');
         }
-        $collectionId = $collection;
+
         $collection = $this->silent(fn () => $this->getCollection($collection));
 
         if ($collection->getId() !== self::METADATA) {
@@ -3456,9 +3453,9 @@ class Database
         if (!$structure->isValid($document)) {
             throw new StructureException($structure->getDescription());
         }
-        $document = $this->withTransaction(function () use ($collection, $collectionId, $document) {
-            $metadataDocument = $this->getDocument(Database::METADATA, $collectionId);
-            $attributes = $metadataDocument->getAttribute('attributes', []);
+        $document = $this->withTransaction(function () use ($collection, $document) {
+            $collectionId = $collection->getId();
+            $attributes = $collection->getAttribute('attributes', []);
 
             foreach ($attributes as $index => $attr) {
                 if ($attr instanceof Document && $attr->getAttribute('autoIncrement') !== null) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1826,9 +1826,9 @@ class Database
     /**
      * Update autoIncrement attribute of metadata of a collection.
      *
-     * @param string $collection
-     * @param string $id
-     * @param ?int $newValue
+     * @param string $collectionId
+     * @param string $attributeId
+     * @param int $newValue
      *
      * @return Document
      * @throws Exception
@@ -1837,7 +1837,6 @@ class Database
     {
         return $this->updateAttributeMeta($collectionId, $attributeId, function (Document $attribute) use ($newValue) {
             $currentValue = $attribute->getAttribute('autoIncrement');
-            // if value is provided => then no need to update the incrementor as the next value will start from the next
             $updatedValue = max($currentValue, $newValue);
             $attribute->setAttribute('autoIncrement', $updatedValue);
         });

--- a/src/Database/Mirror.php
+++ b/src/Database/Mirror.php
@@ -292,7 +292,7 @@ class Mirror extends Database
         return $result;
     }
 
-    public function createAttribute(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, ?string $format = null, array $formatOptions = [], array $filters = []): bool
+    public function createAttribute(string $collection, string $id, string $type, int $size, bool $required, $default = null, bool $signed = true, bool $array = false, ?string $format = null, array $formatOptions = [], array $filters = [], bool $autoIncrement = false): bool
     {
         $result = $this->source->createAttribute(
             $collection,

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -303,6 +303,7 @@ class Structure extends Validator
             $required = $attribute['required'] ?? false;
             $size = $attribute['size'] ?? 0;
             $signed = $attribute['signed'] ?? true;
+            $autoIncrement = $attribute['autoIncrement'] ?? false;
 
             if ($required === false && is_null($value)) { // Allow null value to optional params
                 continue;
@@ -310,6 +311,11 @@ class Structure extends Validator
 
             if ($type === Database::VAR_RELATIONSHIP) {
                 continue;
+            }
+
+            if ($autoIncrement == true && !is_null($value)) {
+                $this->message = "Auto-increment attributes can not be assigned manually";
+                return false;
             }
 
             $validators = [];

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2253,7 +2253,7 @@ abstract class Base extends TestCase
         return $document;
     }
 
-    public function testCreateAutoIncrementAttributes()
+    public function testCreateAutoIncrementAttributes(): void
     {
         static::getDatabase()->createCollection('documents');
 

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2253,6 +2253,50 @@ abstract class Base extends TestCase
         return $document;
     }
 
+    public function testCreateAutoIncrementAttributes()
+    {
+        static::getDatabase()->createCollection('documents');
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'auto-int', Database::VAR_INTEGER, 100, required: false, autoIncrement: true));
+
+
+        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'manual-int', Database::VAR_INTEGER, 100, required: false, autoIncrement: true));
+
+
+        $document1 = static::getDatabase()->createDocument('documents', new Document([]));
+        $this->assertNotEmpty(true, $document1->getId());
+        $this->assertEquals(1, $document1->getAttribute('auto-int'));
+
+        $document2 = static::getDatabase()->createDocument('documents', new Document([]));
+        $this->assertNotEmpty(true, $document2->getId());
+        $this->assertEquals(2, $document2->getAttribute('auto-int'));
+
+        $document3 = static::getDatabase()->createDocument('documents', new Document([]));
+        $this->assertNotEmpty(true, $document3->getId());
+        $this->assertEquals(3, $document3->getAttribute('auto-int'));
+
+        $document4 = static::getDatabase()->createDocument('documents', new Document(['manual-int' => 10]));
+        $this->assertNotEmpty(true, $document4->getId());
+        $this->assertEquals(10, $document4->getAttribute('manual-int'));
+
+        $document5 = static::getDatabase()->createDocument('documents', new Document([]));
+        $this->assertNotEmpty(true, $document5->getId());
+        $this->assertEquals(11, $document5->getAttribute('manual-int'));
+
+        $document6 = static::getDatabase()->createDocument('documents', new Document([]));
+        $this->assertNotEmpty(true, $document6->getId());
+        $this->assertEquals(6, $document6->getAttribute('auto-int'));
+
+        $document7 = static::getDatabase()->createDocument('documents', new Document(['manual-int' => 5]));
+        $this->assertNotEmpty(true, $document7->getId());
+        $this->assertEquals(7, $document7->getAttribute('auto-int'));
+        $this->assertEquals(5, $document7->getAttribute('manual-int'));
+
+        $document8 = static::getDatabase()->createDocument('documents', new Document([]));
+        $this->assertEquals(8, $document8->getAttribute('auto-int'));
+        $this->assertEquals(13, $document8->getAttribute('manual-int'));
+    }
+
     /**
      * @return array<Document>
      */

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -2255,46 +2255,50 @@ abstract class Base extends TestCase
 
     public function testCreateAutoIncrementAttributes(): void
     {
-        static::getDatabase()->createCollection('documents');
+        $col = static::getDatabase()->createCollection(__FUNCTION__);
 
-        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'auto-int', Database::VAR_INTEGER, 100, required: false, autoIncrement: true));
+        $this->assertEquals(true, static::getDatabase()->createAttribute($col->getId(), 'auto-int', Database::VAR_INTEGER, 100, required: false, autoIncrement: true));
 
-
-        $this->assertEquals(true, static::getDatabase()->createAttribute('documents', 'manual-int', Database::VAR_INTEGER, 100, required: false, autoIncrement: true));
-
-
-        $document1 = static::getDatabase()->createDocument('documents', new Document([]));
-        $this->assertNotEmpty(true, $document1->getId());
+        // Create documents and check auto-incremented values
+        $document1 = static::getDatabase()->createDocument($col->getId(), new Document([]));
+        $this->assertNotEmpty($document1->getId());
         $this->assertEquals(1, $document1->getAttribute('auto-int'));
 
-        $document2 = static::getDatabase()->createDocument('documents', new Document([]));
-        $this->assertNotEmpty(true, $document2->getId());
+        $document2 = static::getDatabase()->createDocument($col->getId(), new Document([]));
+        $this->assertNotEmpty($document2->getId());
         $this->assertEquals(2, $document2->getAttribute('auto-int'));
 
-        $document3 = static::getDatabase()->createDocument('documents', new Document([]));
-        $this->assertNotEmpty(true, $document3->getId());
+        $document3 = static::getDatabase()->createDocument($col->getId(), new Document([]));
+        $this->assertNotEmpty($document3->getId());
         $this->assertEquals(3, $document3->getAttribute('auto-int'));
 
-        $document4 = static::getDatabase()->createDocument('documents', new Document(['manual-int' => 10]));
-        $this->assertNotEmpty(true, $document4->getId());
-        $this->assertEquals(10, $document4->getAttribute('manual-int'));
+        $document4 = static::getDatabase()->createDocument($col->getId(), new Document([]));
+        $this->assertNotEmpty($document4->getId());
+        $this->assertEquals(4, $document4->getAttribute('auto-int'));
 
-        $document5 = static::getDatabase()->createDocument('documents', new Document([]));
-        $this->assertNotEmpty(true, $document5->getId());
-        $this->assertEquals(11, $document5->getAttribute('manual-int'));
+        $document5 = static::getDatabase()->createDocument($col->getId(), new Document([]));
+        $this->assertNotEmpty($document5->getId());
+        $this->assertEquals(5, $document5->getAttribute('auto-int'));
 
-        $document6 = static::getDatabase()->createDocument('documents', new Document([]));
-        $this->assertNotEmpty(true, $document6->getId());
+        $document6 = static::getDatabase()->createDocument($col->getId(), new Document([]));
+        $this->assertNotEmpty($document6->getId());
         $this->assertEquals(6, $document6->getAttribute('auto-int'));
 
-        $document7 = static::getDatabase()->createDocument('documents', new Document(['manual-int' => 5]));
-        $this->assertNotEmpty(true, $document7->getId());
-        $this->assertEquals(7, $document7->getAttribute('auto-int'));
-        $this->assertEquals(5, $document7->getAttribute('manual-int'));
+        // not allowing providing of autoincrement value
+        try {
+            static::getDatabase()->createDocument($col->getId(), new Document(['auto-int' => 7]));
+            $this->fail('providing value for auto increment integer not allowed');
+        } catch (Throwable $e) {
+            $this->assertTrue($e instanceof StructureException);
+        }
 
-        $document8 = static::getDatabase()->createDocument('documents', new Document([]));
-        $this->assertEquals(8, $document8->getAttribute('auto-int'));
-        $this->assertEquals(13, $document8->getAttribute('manual-int'));
+        // expecting error for required attribute with auto increment
+        try {
+            static::getDatabase()->createAttribute($col->getId(), 'manual-int', Database::VAR_INTEGER, 100, required: true, autoIncrement: true);
+            $this->fail('required and autoIncrement together is used and should have thrown error');
+        } catch (Throwable $e) {
+            $this->assertTrue($e instanceof DatabaseException);
+        }
     }
 
     /**


### PR DESCRIPTION
### About
Add a new parameter to createAttribute in Database, bool autoIncrement = false. If set to true, and it's an integer type attribute, the added column should be an auto-increment column that is not required to be set manually

### Behaviour
* createAttribute -> add autoIncrement to the metadata. Basically a global autoincrement value

* createDocument -> add +1 to the autoIncrement value or if any value passed then update that document and have the max last increment and the current value

* updateDocument -> no modification in the global value

* deleteDocument -> no reduction in the global value

### Testing
docker compose exec tests vendor/bin/phpunit tests/e2e/Adapter/SharedTables/MariaDBTest.php --filter testCreateAutoIncrementAttributes