### PR TITLE
Remove tenant set on update

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1134,10 +1134,6 @@ class MariaDB extends SQL
             $attributes['_updatedAt'] = $document->getUpdatedAt();
             $attributes['_permissions'] = json_encode($document->getPermissions());
 
-            if ($this->sharedTables) {
-                $attributes['_tenant'] = $this->tenant;
-            }
-
             $name = $this->filter($collection);
             $columns = '';
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1183,10 +1183,6 @@ class Postgres extends SQL
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = json_encode($document->getPermissions());
 
-        if ($this->sharedTables) {
-            $attributes['_tenant'] = $this->tenant;
-        }
-
         $name = $this->filter($collection);
         $columns = '';
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3902,7 +3902,7 @@ class Database
             $document['$createdAt'] = $old->getCreatedAt();                 // Make sure user doesn't switch createdAt
 
             if ($this->adapter->getSharedTables()) {
-                $document['$tenant'] = $old->getTenant();       // Make sure user doesn't switch tenant
+                $document['$tenant'] = $old->getTenant();                   // Make sure user doesn't switch tenant
             }
 
             $document = new Document($document);


### PR DESCRIPTION
Remove requirement of setting tenant to null before updating system collections