### PR TITLE
Remove auth skip in deleteDocuments

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5638,16 +5638,12 @@ class Database
                 }
             }
 
-            $this->withTransaction(function () use ($collection, $skipAuth, $authorization, $internalIds, $permissionIds) {
-                $getResults = fn () => $this->adapter->deleteDocuments(
+            $this->withTransaction(function () use ($collection, $internalIds, $permissionIds) {
+                $this->adapter->deleteDocuments(
                     $collection->getId(),
                     $internalIds,
                     $permissionIds
                 );
-
-                $skipAuth
-                    ? $authorization->skip($getResults)
-                    : $getResults();
             });
 
             foreach ($batch as $document) {


### PR DESCRIPTION
- No authentication is skipped inside the adapter
- We did the same for updateDocuments