### PR TITLE
updated string sizing code and test cases

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1922,7 +1922,7 @@ class MariaDB extends SQL
         switch ($type) {
             case Database::VAR_STRING:
                 // $size = $size * 4; // Convert utf8mb4 size to bytes
-                if ($size > 767) {
+                if ($size > $this->getMaxIndexLength()) {
                     return 'LONGTEXT';
                 }
                 return "VARCHAR({$size})";

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -2060,18 +2060,9 @@ class MariaDB extends SQL
         switch ($type) {
             case Database::VAR_STRING:
                 // $size = $size * 4; // Convert utf8mb4 size to bytes
-                if ($size > 16777215) {
+                if ($size > 767) {
                     return 'LONGTEXT';
                 }
-
-                if ($size > 65535) {
-                    return 'MEDIUMTEXT';
-                }
-
-                if ($size > $this->getMaxVarcharLength()) {
-                    return 'TEXT';
-                }
-
                 return "VARCHAR({$size})";
 
             case Database::VAR_INTEGER:  // We don't support zerofill: https://stackoverflow.com/a/5634147/2299554

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1575,8 +1575,7 @@ abstract class SQL extends Adapter
     public function getMaxVarcharLength(): int
     {
         // Floor value for Postgres:16383 | MySQL:16381 | MariaDB:16382
-        // new max value is 767 which will be longtext
-        return 767;
+        return $this->getMaxIndexLength();
     }
 
     /**

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1566,7 +1566,9 @@ abstract class SQL extends Adapter
      */
     public function getMaxVarcharLength(): int
     {
-        return 16381; // Floor value for Postgres:16383 | MySQL:16381 | MariaDB:16382
+        // Floor value for Postgres:16383 | MySQL:16381 | MariaDB:16382
+        // new max value is 767 which will be longtext
+        return 767;
     }
 
     /**

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -950,28 +950,19 @@ trait AttributeTests
         }
 
         $attributes = [];
-
-        $attributes[] = new Document([
-            '$id' => ID::custom('varchar_16000'),
-            'type' => Database::VAR_STRING,
-            'size' => 16000,
-            'required' => true,
-            'default' => null,
-            'signed' => true,
-            'array' => false,
-            'filters' => [],
-        ]);
-
-        $attributes[] = new Document([
-            '$id' => ID::custom('varchar_200'),
-            'type' => Database::VAR_STRING,
-            'size' => 200,
-            'required' => true,
-            'default' => null,
-            'signed' => true,
-            'array' => false,
-            'filters' => [],
-        ]);
+        $limit = (int)($database->getAdapter()->getDocumentSizeLimit() / (200 * 4));
+        for ($i = 0; $i < $limit; $i++) {
+            $attributes[] = new Document([
+                '$id' => ID::unique(),
+                'type' => Database::VAR_STRING,
+                'size' => 200,
+                'required' => true,
+                'default' => null,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]);
+        }
 
         try {
             $database->createCollection("attributes_row_size", $attributes);

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -586,8 +586,11 @@ trait CollectionTests
         $collection_1 = $database->createCollection('row_size_1');
         $collection_2 = $database->createCollection('row_size_2');
 
-        $this->assertEquals(true, $database->createAttribute($collection_1->getId(), 'attr_1', Database::VAR_STRING, 16000, true));
+        $limit = (int)($database->getAdapter()->getDocumentSizeLimit() / (200 * 4)) - 1;
 
+        for ($i = 0; $i < $limit; $i++) {
+            $this->assertEquals(true, $database->createAttribute($collection_1->getId(), 'attr_1_'.$i, Database::VAR_STRING, 200, true));
+        }
         try {
             $database->createAttribute($collection_1->getId(), 'attr_2', Database::VAR_STRING, Database::LENGTH_KEY, true);
             $this->fail('Failed to throw exception');

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -519,9 +519,9 @@ trait CollectionTests
 
         $attribute = $attributes['story'];
         $this->assertEquals('story', $attribute['$id']);
-        $this->assertEquals('text', $attribute['dataType']);
-        $this->assertEquals('text', $attribute['columnType']);
-        $this->assertEquals('65535', $attribute['characterMaximumLength']);
+        $this->assertEquals('longtext', $attribute['dataType']);
+        $this->assertEquals('longtext', $attribute['columnType']);
+        $this->assertEquals('4294967295', $attribute['characterMaximumLength']);
 
         $attribute = $attributes['string_list'];
         $this->assertEquals('string_list', $attribute['$id']);


### PR DESCRIPTION
if ($size > 16777215) {
    return 'LONGTEXT';
}
if ($size > 65535) {
    return 'MEDIUMTEXT';
}
if ($size > 16381) {
    return 'TEXT';
}
return "VARCHAR({$size})";

To

if ($size > 767) {
    return 'LONGTEXT';
}
return "VARCHAR({$size})";



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified handling of large string attributes in MariaDB: strings over the maximum index length are stored as LONGTEXT, others as VARCHAR.
  * Adjusted maximum varchar length limit to dynamically reflect the maximum index length for consistency.

* **Tests**
  * Updated tests to expect LONGTEXT type and revised maximum length values for large string attributes.
  * Enhanced test coverage by dynamically generating multiple attributes to better simulate size limit conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->