### PR TITLE
Prevent reusing same cache key for multiple documents

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6678,7 +6678,7 @@ class Database
 
         $tenantSegment = $this->adapter->getTenant();
 
-        if (isset($this->globalCollections[$documentId]) && $collectionId === self::METADATA) {
+        if ($collectionId === self::METADATA && isset($this->globalCollections[$documentId])) {
             $tenantSegment = null;
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6678,7 +6678,7 @@ class Database
 
         $tenantSegment = $this->adapter->getTenant();
 
-        if (isset($this->globalCollections[$collectionId]) && $collectionId === self::METADATA) {
+        if (isset($this->globalCollections[$documentId]) && $collectionId === self::METADATA) {
             $tenantSegment = null;
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6678,7 +6678,7 @@ class Database
 
         $tenantSegment = $this->adapter->getTenant();
 
-        if (isset($this->globalCollections[$collectionId]) && $collectionId !== self::METADATA) {
+        if (isset($this->globalCollections[$collectionId]) && $collectionId === self::METADATA) {
             $tenantSegment = null;
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6678,7 +6678,7 @@ class Database
 
         $tenantSegment = $this->adapter->getTenant();
 
-        if (isset($this->globalCollections[$collectionId])) {
+        if (isset($this->globalCollections[$collectionId]) && $collectionId !== self::METADATA) {
             $tenantSegment = null;
         }
 


### PR DESCRIPTION
Shared cache key across tenants is great, but ONLY for schema. Doing it for everything also does it for content, and how user A (on project A) and user A (on proejct B) share same cache key.