### PR TITLE
Re-force internal attribute selection

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -128,14 +128,7 @@ class MariaDB extends SQL
                 $indexLength = $index->getAttribute('lengths')[$nested] ?? '';
                 $indexLength = (empty($indexLength)) ? '' : '(' . (int)$indexLength . ')';
                 $indexOrder = $index->getAttribute('orders')[$nested] ?? '';
-
-                $indexAttribute = match ($attribute) {
-                    '$id' => '_uid',
-                    '$createdAt' => '_createdAt',
-                    '$updatedAt' => '_updatedAt',
-                    default => $attribute
-                };
-
+                $indexAttribute = $this->getInternalKeyForAttribute($attribute);
                 $indexAttribute = $this->filter($indexAttribute);
 
                 if ($indexType === Database::INDEX_FULLTEXT) {

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1684,30 +1684,18 @@ abstract class SQL extends Adapter
             return '*';
         }
 
-        $selections = \array_diff($selections, ['$id', '$permissions', '$collection']);
+        $internalKeys = [
+            '$id',
+            '$internalId',
+            '$permissions',
+            '$createdAt',
+            '$updatedAt',
+        ];
 
-        $selections[] = $this->getInternalKeyForAttribute('$id');
-        $selections[] = $this->getInternalKeyForAttribute('$permissions');
+        $selections = \array_diff($selections, [...$internalKeys, '$collection']);
 
-        if (\in_array('$internalId', $selections)) {
-            $selections[] = $this->getInternalKeyForAttribute('$internalId');
-            $selections = \array_diff($selections, ['$internalId']);
-        }
-        if (\in_array('$createdAt', $selections)) {
-            $selections[] = $this->getInternalKeyForAttribute('$createdAt');
-            $selections = \array_diff($selections, ['$createdAt']);
-        }
-        if (\in_array('$updatedAt', $selections)) {
-            $selections[] = $this->getInternalKeyForAttribute('$updatedAt');
-            $selections = \array_diff($selections, ['$updatedAt']);
-        }
-        if (\in_array('$collection', $selections)) {
-            $selections[] = $this->getInternalKeyForAttribute('$collection');
-            $selections = \array_diff($selections, ['$collection']);
-        }
-        if (\in_array('$tenant', $selections)) {
-            $selections[] = $this->getInternalKeyForAttribute('$tenant');
-            $selections = \array_diff($selections, ['$tenant']);
+        foreach ($internalKeys as $internalKey) {
+            $selections[] = $this->getInternalKeyForAttribute($internalKey);
         }
 
         if (!empty($prefix)) {
@@ -1720,7 +1708,7 @@ abstract class SQL extends Adapter
             }
         }
 
-        return \implode(', ', $selections);
+        return \implode(',', $selections);
     }
 
     protected function getInternalKeyForAttribute(string $attribute): string

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3169,7 +3169,6 @@ class Database
      */
     public function getDocument(string $collection, string $id, array $queries = [], bool $forUpdate = false): Document
     {
-
         if ($collection === self::METADATA && $id === self::METADATA) {
             return new Document(self::COLLECTION);
         }

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -775,7 +775,6 @@ trait DocumentTests
             Query::select(['string', 'integer_signed']),
         ]);
 
-        $this->assertEmpty($document->getId());
         $this->assertFalse($document->isEmpty());
         $this->assertIsString($document->getAttribute('string'));
         $this->assertEquals('text📝', $document->getAttribute('string'));
@@ -785,78 +784,26 @@ trait DocumentTests
         $this->assertArrayNotHasKey('boolean', $document->getAttributes());
         $this->assertArrayNotHasKey('colors', $document->getAttributes());
         $this->assertArrayNotHasKey('with-dash', $document->getAttributes());
-        $this->assertArrayNotHasKey('$id', $document);
-        $this->assertArrayNotHasKey('$internalId', $document);
-        $this->assertArrayNotHasKey('$createdAt', $document);
-        $this->assertArrayNotHasKey('$updatedAt', $document);
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertArrayNotHasKey('$collection', $document);
+        $this->assertArrayHasKey('$id', $document);
+        $this->assertArrayHasKey('$internalId', $document);
+        $this->assertArrayHasKey('$createdAt', $document);
+        $this->assertArrayHasKey('$updatedAt', $document);
+        $this->assertArrayHasKey('$permissions', $document);
+        $this->assertArrayHasKey('$collection', $document);
 
         $document = static::getDatabase()->getDocument('documents', $documentId, [
             Query::select(['string', 'integer_signed', '$id']),
         ]);
 
         $this->assertArrayHasKey('$id', $document);
-        $this->assertArrayNotHasKey('$internalId', $document);
-        $this->assertArrayNotHasKey('$createdAt', $document);
-        $this->assertArrayNotHasKey('$updatedAt', $document);
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertArrayNotHasKey('$collection', $document);
-
-        $document = static::getDatabase()->getDocument('documents', $documentId, [
-            Query::select(['string', 'integer_signed', '$permissions']),
-        ]);
-
-        $this->assertArrayNotHasKey('$id', $document);
-        $this->assertArrayNotHasKey('$internalId', $document);
-        $this->assertArrayNotHasKey('$createdAt', $document);
-        $this->assertArrayNotHasKey('$updatedAt', $document);
-        $this->assertArrayHasKey('$permissions', $document);
-        $this->assertArrayNotHasKey('$collection', $document);
-
-        $document = static::getDatabase()->getDocument('documents', $documentId, [
-            Query::select(['string', 'integer_signed', '$internalId']),
-        ]);
-
-        $this->assertArrayNotHasKey('$id', $document);
         $this->assertArrayHasKey('$internalId', $document);
-        $this->assertArrayNotHasKey('$createdAt', $document);
-        $this->assertArrayNotHasKey('$updatedAt', $document);
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertArrayNotHasKey('$collection', $document);
-
-        $document = static::getDatabase()->getDocument('documents', $documentId, [
-            Query::select(['string', 'integer_signed', '$collection']),
-        ]);
-
-        $this->assertArrayNotHasKey('$id', $document);
-        $this->assertArrayNotHasKey('$internalId', $document);
-        $this->assertArrayNotHasKey('$createdAt', $document);
-        $this->assertArrayNotHasKey('$updatedAt', $document);
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertArrayHasKey('$collection', $document);
-
-        $document = static::getDatabase()->getDocument('documents', $documentId, [
-            Query::select(['string', 'integer_signed', '$createdAt']),
-        ]);
-
-        $this->assertArrayNotHasKey('$id', $document);
-        $this->assertArrayNotHasKey('$internalId', $document);
         $this->assertArrayHasKey('$createdAt', $document);
-        $this->assertArrayNotHasKey('$updatedAt', $document);
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertArrayNotHasKey('$collection', $document);
-
-        $document = static::getDatabase()->getDocument('documents', $documentId, [
-            Query::select(['string', 'integer_signed', '$updatedAt']),
-        ]);
-
-        $this->assertArrayNotHasKey('$id', $document);
-        $this->assertArrayNotHasKey('$internalId', $document);
-        $this->assertArrayNotHasKey('$createdAt', $document);
         $this->assertArrayHasKey('$updatedAt', $document);
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertArrayNotHasKey('$collection', $document);
+        $this->assertArrayHasKey('$permissions', $document);
+        $this->assertArrayHasKey('$collection', $document);
+        $this->assertArrayHasKey('string', $document);
+        $this->assertArrayHasKey('integer_signed', $document);
+        $this->assertArrayNotHasKey('float', $document);
 
         return $document;
     }
@@ -1037,33 +984,6 @@ trait DocumentTests
             '$internalId' => $document->getInternalId()
         ];
     }
-
-    /**
-    * @return void
-    * @throws \Utopia\Database\Exception
-    */
-    public function testSelectInternalID(): void
-    {
-        $documents = static::getDatabase()->find('movies', [
-            Query::select(['$internalId', '$id']),
-            Query::orderAsc(''),
-            Query::limit(1),
-        ]);
-
-        $document = $documents[0];
-
-        $this->assertArrayHasKey('$internalId', $document);
-        $this->assertCount(2, $document);
-
-        $document = static::getDatabase()->getDocument('movies', $document->getId(), [
-            Query::select(['$internalId']),
-        ]);
-
-        $this->assertArrayHasKey('$internalId', $document);
-        $this->assertCount(1, $document);
-    }
-
-
 
     /**
     * @depends testFind
@@ -2397,12 +2317,12 @@ trait DocumentTests
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayNotHasKey('$id', $document);
-            $this->assertArrayNotHasKey('$internalId', $document);
-            $this->assertArrayNotHasKey('$collection', $document);
-            $this->assertArrayNotHasKey('$createdAt', $document);
-            $this->assertArrayNotHasKey('$updatedAt', $document);
-            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('$id', $document);
+            $this->assertArrayHasKey('$internalId', $document);
+            $this->assertArrayHasKey('$collection', $document);
+            $this->assertArrayHasKey('$createdAt', $document);
+            $this->assertArrayHasKey('$updatedAt', $document);
+            $this->assertArrayHasKey('$permissions', $document);
         }
 
         $documents = static::getDatabase()->find('movies', [
@@ -2416,11 +2336,11 @@ trait DocumentTests
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
             $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayNotHasKey('$internalId', $document);
-            $this->assertArrayNotHasKey('$collection', $document);
-            $this->assertArrayNotHasKey('$createdAt', $document);
-            $this->assertArrayNotHasKey('$updatedAt', $document);
-            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('$internalId', $document);
+            $this->assertArrayHasKey('$collection', $document);
+            $this->assertArrayHasKey('$createdAt', $document);
+            $this->assertArrayHasKey('$updatedAt', $document);
+            $this->assertArrayHasKey('$permissions', $document);
         }
 
         $documents = static::getDatabase()->find('movies', [
@@ -2433,12 +2353,12 @@ trait DocumentTests
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayNotHasKey('$id', $document);
+            $this->assertArrayHasKey('$id', $document);
             $this->assertArrayHasKey('$internalId', $document);
-            $this->assertArrayNotHasKey('$collection', $document);
-            $this->assertArrayNotHasKey('$createdAt', $document);
-            $this->assertArrayNotHasKey('$updatedAt', $document);
-            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('$collection', $document);
+            $this->assertArrayHasKey('$createdAt', $document);
+            $this->assertArrayHasKey('$updatedAt', $document);
+            $this->assertArrayHasKey('$permissions', $document);
         }
 
         $documents = static::getDatabase()->find('movies', [
@@ -2451,12 +2371,12 @@ trait DocumentTests
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayNotHasKey('$id', $document);
-            $this->assertArrayNotHasKey('$internalId', $document);
+            $this->assertArrayHasKey('$id', $document);
+            $this->assertArrayHasKey('$internalId', $document);
             $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayNotHasKey('$createdAt', $document);
-            $this->assertArrayNotHasKey('$updatedAt', $document);
-            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('$createdAt', $document);
+            $this->assertArrayHasKey('$updatedAt', $document);
+            $this->assertArrayHasKey('$permissions', $document);
         }
 
         $documents = static::getDatabase()->find('movies', [
@@ -2469,12 +2389,12 @@ trait DocumentTests
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayNotHasKey('$id', $document);
-            $this->assertArrayNotHasKey('$internalId', $document);
-            $this->assertArrayNotHasKey('$collection', $document);
+            $this->assertArrayHasKey('$id', $document);
+            $this->assertArrayHasKey('$internalId', $document);
+            $this->assertArrayHasKey('$collection', $document);
             $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayNotHasKey('$updatedAt', $document);
-            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('$updatedAt', $document);
+            $this->assertArrayHasKey('$permissions', $document);
         }
 
         $documents = static::getDatabase()->find('movies', [
@@ -2487,12 +2407,12 @@ trait DocumentTests
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayNotHasKey('$id', $document);
-            $this->assertArrayNotHasKey('$internalId', $document);
-            $this->assertArrayNotHasKey('$collection', $document);
-            $this->assertArrayNotHasKey('$createdAt', $document);
+            $this->assertArrayHasKey('$id', $document);
+            $this->assertArrayHasKey('$internalId', $document);
+            $this->assertArrayHasKey('$collection', $document);
+            $this->assertArrayHasKey('$createdAt', $document);
             $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('$permissions', $document);
         }
 
         $documents = static::getDatabase()->find('movies', [
@@ -2505,11 +2425,11 @@ trait DocumentTests
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayNotHasKey('$id', $document);
-            $this->assertArrayNotHasKey('$internalId', $document);
-            $this->assertArrayNotHasKey('$collection', $document);
-            $this->assertArrayNotHasKey('$createdAt', $document);
-            $this->assertArrayNotHasKey('$updatedAt', $document);
+            $this->assertArrayHasKey('$id', $document);
+            $this->assertArrayHasKey('$internalId', $document);
+            $this->assertArrayHasKey('$collection', $document);
+            $this->assertArrayHasKey('$createdAt', $document);
+            $this->assertArrayHasKey('$updatedAt', $document);
             $this->assertArrayHasKey('$permissions', $document);
         }
     }

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -961,12 +961,12 @@ trait RelationshipTests
         $this->assertEquals('Focus', $make['models'][1]['name']);
         $this->assertArrayNotHasKey('year', $make['models'][0]);
         $this->assertArrayNotHasKey('year', $make['models'][1]);
-        $this->assertArrayNotHasKey('$id', $make);
-        $this->assertArrayNotHasKey('$internalId', $make);
-        $this->assertArrayNotHasKey('$permissions', $make);
-        $this->assertArrayNotHasKey('$collection', $make);
-        $this->assertArrayNotHasKey('$createdAt', $make);
-        $this->assertArrayNotHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('$id', $make);
+        $this->assertArrayHasKey('$internalId', $make);
+        $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayHasKey('$createdAt', $make);
+        $this->assertArrayHasKey('$updatedAt', $make);
 
         // Select internal attributes
         $make = static::getDatabase()->findOne('make', [
@@ -977,12 +977,13 @@ trait RelationshipTests
             throw new Exception('Make not found');
         }
 
+        $this->assertArrayHasKey('name', $make);
         $this->assertArrayHasKey('$id', $make);
-        $this->assertArrayNotHasKey('$internalId', $make);
-        $this->assertArrayNotHasKey('$collection', $make);
-        $this->assertArrayNotHasKey('$createdAt', $make);
-        $this->assertArrayNotHasKey('$updatedAt', $make);
-        $this->assertArrayNotHasKey('$permissions', $make);
+        $this->assertArrayHasKey('$internalId', $make);
+        $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayHasKey('$createdAt', $make);
+        $this->assertArrayHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('$permissions', $make);
 
         $make = static::getDatabase()->findOne('make', [
             Query::select(['name', '$internalId']),
@@ -992,12 +993,13 @@ trait RelationshipTests
             throw new Exception('Make not found');
         }
 
-        $this->assertArrayNotHasKey('$id', $make);
+        $this->assertArrayHasKey('name', $make);
+        $this->assertArrayHasKey('$id', $make);
         $this->assertArrayHasKey('$internalId', $make);
-        $this->assertArrayNotHasKey('$collection', $make);
-        $this->assertArrayNotHasKey('$createdAt', $make);
-        $this->assertArrayNotHasKey('$updatedAt', $make);
-        $this->assertArrayNotHasKey('$permissions', $make);
+        $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayHasKey('$createdAt', $make);
+        $this->assertArrayHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('$permissions', $make);
 
         $make = static::getDatabase()->findOne('make', [
             Query::select(['name', '$collection']),
@@ -1007,12 +1009,13 @@ trait RelationshipTests
             throw new Exception('Make not found');
         }
 
-        $this->assertArrayNotHasKey('$id', $make);
-        $this->assertArrayNotHasKey('$internalId', $make);
+        $this->assertArrayHasKey('name', $make);
+        $this->assertArrayHasKey('$id', $make);
+        $this->assertArrayHasKey('$internalId', $make);
         $this->assertArrayHasKey('$collection', $make);
-        $this->assertArrayNotHasKey('$createdAt', $make);
-        $this->assertArrayNotHasKey('$updatedAt', $make);
-        $this->assertArrayNotHasKey('$permissions', $make);
+        $this->assertArrayHasKey('$createdAt', $make);
+        $this->assertArrayHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('$permissions', $make);
 
         $make = static::getDatabase()->findOne('make', [
             Query::select(['name', '$createdAt']),
@@ -1022,12 +1025,13 @@ trait RelationshipTests
             throw new Exception('Make not found');
         }
 
-        $this->assertArrayNotHasKey('$id', $make);
-        $this->assertArrayNotHasKey('$internalId', $make);
-        $this->assertArrayNotHasKey('$collection', $make);
+        $this->assertArrayHasKey('name', $make);
+        $this->assertArrayHasKey('$id', $make);
+        $this->assertArrayHasKey('$internalId', $make);
+        $this->assertArrayHasKey('$collection', $make);
         $this->assertArrayHasKey('$createdAt', $make);
-        $this->assertArrayNotHasKey('$updatedAt', $make);
-        $this->assertArrayNotHasKey('$permissions', $make);
+        $this->assertArrayHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('$permissions', $make);
 
         $make = static::getDatabase()->findOne('make', [
             Query::select(['name', '$updatedAt']),
@@ -1037,12 +1041,13 @@ trait RelationshipTests
             throw new Exception('Make not found');
         }
 
-        $this->assertArrayNotHasKey('$id', $make);
-        $this->assertArrayNotHasKey('$internalId', $make);
-        $this->assertArrayNotHasKey('$collection', $make);
-        $this->assertArrayNotHasKey('$createdAt', $make);
+        $this->assertArrayHasKey('name', $make);
+        $this->assertArrayHasKey('$id', $make);
+        $this->assertArrayHasKey('$internalId', $make);
+        $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayHasKey('$createdAt', $make);
         $this->assertArrayHasKey('$updatedAt', $make);
-        $this->assertArrayNotHasKey('$permissions', $make);
+        $this->assertArrayHasKey('$permissions', $make);
 
         $make = static::getDatabase()->findOne('make', [
             Query::select(['name', '$permissions']),
@@ -1052,11 +1057,12 @@ trait RelationshipTests
             throw new Exception('Make not found');
         }
 
-        $this->assertArrayNotHasKey('$id', $make);
-        $this->assertArrayNotHasKey('$internalId', $make);
-        $this->assertArrayNotHasKey('$collection', $make);
-        $this->assertArrayNotHasKey('$createdAt', $make);
-        $this->assertArrayNotHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('name', $make);
+        $this->assertArrayHasKey('$id', $make);
+        $this->assertArrayHasKey('$internalId', $make);
+        $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayHasKey('$createdAt', $make);
+        $this->assertArrayHasKey('$updatedAt', $make);
         $this->assertArrayHasKey('$permissions', $make);
 
         // Select all parent attributes, some child attributes


### PR DESCRIPTION
Because without them:

- It breaks select queries in all statically typed SDKs,
- There are many places we need them internally
- Select queries meant to be for choosing what of your data you want, regardless of internals
- They add <1KB of data, negligible in almost all scenarios