### PR TITLE
added test for global collection test

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1046,6 +1046,11 @@ class Database
         return \array_keys($this->globalCollections);
     }
 
+    public function resetGlobalCollections(): void
+    {
+        $this->globalCollections = [];
+    }
+
     /**
      * Get list of keywords that cannot be used
      *

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1046,6 +1046,11 @@ class Database
         return \array_keys($this->globalCollections);
     }
 
+    /**
+     * Clear global collections
+     *
+     * @return void
+     */
     public function resetGlobalCollections(): void
     {
         $this->globalCollections = [];

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1461,7 +1461,7 @@ trait CollectionTests
         $this->assertNotEmpty($hashKey);
 
         if ($db->getSharedTables()) {
-            $this->assertStringNotContainsString($db->getAdapter()->getTenant(), $collectionKey);
+            $this->assertStringNotContainsString((string)$db->getAdapter()->getTenant(), $collectionKey);
         }
 
         // non global collection should containt tenant in the cache key
@@ -1471,7 +1471,7 @@ trait CollectionTests
             $nonGlobalCollectionId
         );
         if ($db->getSharedTables()) {
-            $this->assertStringContainsString($db->getAdapter()->getTenant(), $collectionKeyRegular);
+            $this->assertStringContainsString((string)$db->getAdapter()->getTenant(), $collectionKeyRegular);
         }
 
         // Non metadata collection should contain tenant in the cache key
@@ -1486,7 +1486,7 @@ trait CollectionTests
         $this->assertNotEmpty($hashKey);
 
         if ($db->getSharedTables()) {
-            $this->assertStringContainsString($db->getAdapter()->getTenant(), $collectionKey);
+            $this->assertStringContainsString((string)$db->getAdapter()->getTenant(), $collectionKey);
         }
 
     }

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1489,5 +1489,8 @@ trait CollectionTests
             $this->assertStringContainsString((string)$db->getAdapter()->getTenant(), $collectionKey);
         }
 
+        $db->resetGlobalCollections();
+        $this->assertEmpty($db->getGlobalCollections());
+
     }
 }

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1439,4 +1439,55 @@ trait CollectionTests
 
         $this->assertTrue($result->isEmpty());
     }
+
+    public function testSetGlobalCollection(): void
+    {
+        $db = static::getDatabase();
+
+        $collectionId = 'globalCollection';
+
+        // set collection as global
+        $db->setGlobalCollections([$collectionId]);
+
+        // metadata collection should not contain tenant in the cache key
+        [$collectionKey, $documentKey, $hashKey] = $db->getCacheKeys(
+            Database::METADATA,
+            $collectionId,
+            []
+        );
+
+        $this->assertNotEmpty($collectionKey);
+        $this->assertNotEmpty($documentKey);
+        $this->assertNotEmpty($hashKey);
+
+        if ($db->getSharedTables()) {
+            $this->assertStringNotContainsString($db->getAdapter()->getTenant(), $collectionKey);
+        }
+
+        // non global collection should containt tenant in the cache key
+        $nonGlobalCollectionId = 'nonGlobalCollection';
+        [$collectionKeyRegular] = $db->getCacheKeys(
+            Database::METADATA,
+            $nonGlobalCollectionId
+        );
+        if ($db->getSharedTables()) {
+            $this->assertStringContainsString($db->getAdapter()->getTenant(), $collectionKeyRegular);
+        }
+
+        // Non metadata collection should contain tenant in the cache key
+        [$collectionKey, $documentKey, $hashKey] = $db->getCacheKeys(
+            $collectionId,
+            ID::unique(),
+            []
+        );
+
+        $this->assertNotEmpty($collectionKey);
+        $this->assertNotEmpty($documentKey);
+        $this->assertNotEmpty($hashKey);
+
+        if ($db->getSharedTables()) {
+            $this->assertStringContainsString($db->getAdapter()->getTenant(), $collectionKey);
+        }
+
+    }
 }


### PR DESCRIPTION
function setGlobalCollections, that allows you to specify collections that should not include $tenant in their cache key, returned by getCacheKeys
So added tests for this