### PR TITLE
Fix upsert mismatch

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4974,7 +4974,8 @@ class Database
             $document
                 ->setAttribute('$id', empty($document->getId()) ? ID::unique() : $document->getId())
                 ->setAttribute('$collection', $collection->getId())
-                ->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt);
+                ->setAttribute('$updatedAt', empty($updatedAt) || !$this->preserveDates ? $time : $updatedAt)
+                ->removeAttribute('$internalId');
 
             if ($old->isEmpty()) {
                 $createdAt = $document->getCreatedAt();

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4980,16 +4980,19 @@ class Database
             if ($old->isEmpty()) {
                 $createdAt = $document->getCreatedAt();
                 $document->setAttribute('$createdAt', empty($createdAt) || !$this->preserveDates ? $time : $createdAt);
-
-                // Force matching optional parameter sets
-                // Doesn't use decode as that intentionally skips null defaults to reduce payload size
-                foreach ($collectionAttributes as $attr) {
-                    if (!$attr->getAttribute('required') && !$document->isSet($attr['$id'])) {
-                        $document->setAttribute($attr['$id'], $attr['default'] ?? null);
-                    }
-                }
             } else {
                 $document['$createdAt'] = $old->getCreatedAt();
+            }
+
+            // Force matching optional parameter sets
+            // Doesn't use decode as that intentionally skips null defaults to reduce payload size
+            foreach ($collectionAttributes as $attr) {
+                if (!$attr->getAttribute('required') && !\array_key_exists($attr['$id'], (array)$document)) {
+                    $document->setAttribute(
+                        $attr['$id'],
+                        $old->getAttribute($attr['$id'], ($attr['default'] ?? null))
+                    );
+                }
             }
 
             if (!$updatesPermissions) {

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -621,6 +621,7 @@ trait DocumentTests
             'first' => 'second',
         ]);
 
+        // Ensure missing optionals on new document is allowed
         $docs = $database->createOrUpdateDocuments(__FUNCTION__, [
             $existingDocument->setAttribute('first', 'updated'),
             $newDocument,
@@ -628,6 +629,7 @@ trait DocumentTests
 
         $this->assertEquals(2, $docs);
         $this->assertEquals('updated', $existingDocument->getAttribute('first'));
+        $this->assertEquals('last', $existingDocument->getAttribute('last'));
         $this->assertEquals('second', $newDocument->getAttribute('first'));
         $this->assertEquals('', $newDocument->getAttribute('last'));
 
@@ -640,6 +642,36 @@ trait DocumentTests
         } catch (Throwable $e) {
             $this->assertTrue($e instanceof StructureException, $e->getMessage());
         }
+
+        // Ensure missing optionals on existing document is allowed
+        $docs = $database->createOrUpdateDocuments(__FUNCTION__, [
+            $existingDocument
+                ->setAttribute('first', 'first')
+                ->removeAttribute('last'),
+            $newDocument
+                ->setAttribute('last', 'last')
+        ]);
+
+        $this->assertEquals(2, $docs);
+        $this->assertEquals('first', $existingDocument->getAttribute('first'));
+        $this->assertEquals('last', $existingDocument->getAttribute('last'));
+        $this->assertEquals('second', $newDocument->getAttribute('first'));
+        $this->assertEquals('last', $newDocument->getAttribute('last'));
+
+        // Ensure set null on existing document is allowed
+        $docs = $database->createOrUpdateDocuments(__FUNCTION__, [
+            $existingDocument
+                ->setAttribute('first', 'first')
+                ->setAttribute('last', null),
+            $newDocument
+                ->setAttribute('last', 'last')
+        ]);
+
+        $this->assertEquals(1, $docs);
+        $this->assertEquals('first', $existingDocument->getAttribute('first'));
+        $this->assertEquals(null, $existingDocument->getAttribute('last'));
+        $this->assertEquals('second', $newDocument->getAttribute('first'));
+        $this->assertEquals('last', $newDocument->getAttribute('last'));
     }
 
     public function testUpsertDocumentsNoop(): void


### PR DESCRIPTION
Addresses `PDOException` thrown when documents contain different sets of optional attributes during upsert