### PR TITLE
Fix PDOException on increment array attribute

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5231,8 +5231,8 @@ class Database
          * @var Document $attr
          */
         $attr = \end($attr);
-        if (!in_array($attr->getAttribute('type'), $whiteList)) {
-            throw new TypeException('Attribute type must be one of: ' . \implode(',', $whiteList));
+        if (!\in_array($attr->getAttribute('type'), $whiteList) || $attr->getAttribute('array')) {
+            throw new TypeException('Attribute must be an integer or float and can not be an array.');
         }
 
         $document = $this->withTransaction(function () use ($collection, $id, $attribute, $value, $min) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5132,8 +5132,8 @@ class Database
 
         /** @var Document $attr */
         $attr = \end($attr);
-        if (!in_array($attr->getAttribute('type'), $whiteList)) {
-            throw new TypeException('Attribute type must be one of: ' . implode(',', $whiteList));
+        if (!\in_array($attr->getAttribute('type'), $whiteList) || $attr->getAttribute('array')) {
+            throw new TypeException('Attribute must be an integer or float and can not be an array.');
         }
 
         $document = $this->withTransaction(function () use ($collection, $id, $attribute, $value, $max) {

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -1174,7 +1174,7 @@ trait AttributeTests
         try {
             $queries = [Query::equal('title', ['test'])];
             $database->find($col->getId(), $queries);
-        } catch (Throwable $e) {
+        } catch (Throwable) {
             $this->fail('Should not have thrown error');
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to prevent increment and decrement operations on array-typed attributes, ensuring only integer or float attributes can be modified.

- **Tests**
  - Added and updated tests to verify that incrementing array or string attributes correctly throws a type exception.
  - Enhanced test coverage for type-related errors during attribute increment operations.
  - Minor formatting improvements in test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->