### PR TITLE
Default alias getDocument

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -1070,7 +1070,7 @@ abstract class Adapter
      * @param string $prefix
      * @return mixed
      */
-    abstract protected function getAttributeProjection(array $selections, string $prefix = ''): mixed;
+    abstract protected function getAttributeProjection(array $selections, string $prefix): mixed;
 
     /**
      * Get all selected attributes from queries

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -455,7 +455,7 @@ class Pool extends Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
-    protected function getAttributeProjection(array $selections, string $prefix = ''): mixed
+    protected function getAttributeProjection(array $selections, string $prefix): mixed
     {
         return $this->delegate(__FUNCTION__, \func_get_args());
     }

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1677,43 +1677,6 @@ abstract class SQL extends Adapter
     /**
      * Get the SQL projection given the selected attributes
      *
-     * @param array<Query> $selects
-     * @return string
-     * @throws Exception
-     */
-    protected function addHiddenAttribute(array $selects): string
-    {
-        $hash = [Query::DEFAULT_ALIAS => true];
-
-        foreach ($selects as $select) {
-            $alias = $select->getAlias();
-            if (!isset($hash[$alias])){
-                $hash[$alias] = true;
-            }
-        }
-
-        $hash = array_keys($hash);
-
-        $strings = [];
-
-        foreach ($hash as $alias) {
-            $strings[] = $alias.'._uid as '.$this->quote($alias.'::$id');
-            $strings[] = $alias.'._id as '.$this->quote($alias.'::$internalId');
-            $strings[] = $alias.'._permissions as '.$this->quote($alias.'::$permissions');
-            $strings[] = $alias.'._createdAt as '.$this->quote($alias.'::$createdAt');
-            $strings[] = $alias.'._updatedAt as '.$this->quote($alias.'::$updatedAt');
-
-            if ($this->sharedTables) {
-                $strings[] = $alias.'._tenant as '.$this->quote($alias.'::$tenant');
-            }
-        }
-
-        return ', '.implode(', ', $strings);
-    }
-
-    /**
-     * Get the SQL projection given the selected attributes
-     *
      * @param array<string> $selections
      * @param string $prefix
      * @return mixed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in SQL queries by enforcing the use of table aliases for all column references.
  - Updated method signatures to require explicit prefix parameters for attribute projections, enhancing clarity and reducing ambiguity in database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->