### PR TITLE
Internal attributes defaults

### DIFF
--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -350,10 +350,6 @@ abstract class SQL extends Adapter
             $sql .= " {$forUpdate}";
         }
 
-        if (!empty($selections)){
-            echo $sql.PHP_EOL;
-        }
-
         $stmt = $this->getPDO()->prepare($sql);
 
         $stmt->bindValue(':_uid', $id);
@@ -1693,8 +1689,6 @@ abstract class SQL extends Adapter
      */
     protected function addHiddenAttribute(array $selects): string
     {
-        //return '';
-
         $alias = Query::DEFAULT_ALIAS;
 
         $strings = [];

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -397,6 +397,12 @@ abstract class SQL extends Adapter
             unset($document['_permissions']);
         }
 
+        $document['main::$permissions'] = json_decode($document['main::$permissions'], true);
+
+        if ($this->sharedTables) {
+            $document['main::$tenant'] = $document['main::$tenant'] === null ? null : (int)$document['main::$tenant'];
+        }
+
         return new Document($document);
     }
 
@@ -1720,21 +1726,10 @@ abstract class SQL extends Adapter
             return "{$this->quote($prefix)}.* {$this->addHiddenAttribute($selections)}";
         }
 
-        $internalKeys = [
-            '$id',
-            '$sequence',
-            '$permissions',
-            '$createdAt',
-            '$updatedAt',
-        ];
-
-        $selections = \array_diff($selections, [...$internalKeys, '$collection']);
-
-        foreach ($internalKeys as $internalKey) {
-            $selections[] = $this->getInternalKeyForAttribute($internalKey);
-        }
+        $selections = array_diff($selections, ['$collection']);
 
         foreach ($selections as &$selection) {
+            $selection = $this->getInternalKeyForAttribute($selection);
             $selection = "{$this->quote($prefix)}.{$this->quote($this->filter($selection))}";
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4613,7 +4613,7 @@ class Database
                                 $related = $this->skipRelationships(
                                     fn () => $this->getDocument($relatedCollection->getId(), $value, [Query::select(['$id'])])
                                 );
-                                var_dump($related);
+
                                 if ($related->isEmpty()) {
                                     // If no such document exists in related collection
                                     // For one-one we need to update the related key to null if no relation exists
@@ -4636,13 +4636,7 @@ class Database
                                     $related->getId(),
                                     $related->setAttribute($twoWayKey, $document->getId())
                                 ));
-                                var_dump($relatedCollection->getId());
-                                var_dump($value);
-                                var_dump(\gettype($value));
-                                var_dump($twoWay);
-                                var_dump($twoWayKey);
-                                var_dump($related);
-                                var_dump($document->getId());
+
                                 break;
                             case 'object':
                                 if ($value instanceof Document) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6134,7 +6134,7 @@ class Database
 
             if (!$node->isEmpty()) {
                 $node->setAttribute('$collection', $collection->getId());
-                $node->setAttribute('main::$collection', DateTime::formatTz($node->getAttribute('main::$collection')));
+                $node->setAttribute('main::$collection', $collection->getId());
                 $node->setAttribute('main::$createdAt', DateTime::formatTz($node->getAttribute('main::$createdAt')));
                 $node->setAttribute('main::$updatedAt', DateTime::formatTz($node->getAttribute('main::$updatedAt')));
             }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4146,10 +4146,6 @@ class Database
 
         $document = $this->withTransaction(function () use ($collection, $id, $document) {
             $time = DateTime::now();
-
-            /**
-             * @var $old Document
-             */
             $old = Authorization::skip(fn () => $this->silent(
                 fn () => $this->getDocument($collection->getId(), $id, forUpdate: true)
             ));

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3694,8 +3694,10 @@ class Database
         $document->setAttribute('main::$permissions', $document->getPermissions());
         $document->setAttribute('main::$createdAt', $document->getCreatedAt());
         $document->setAttribute('main::$updatedAt', $document->getUpdatedAt());
-        $document->setAttribute('main::$tenant', $document->getTenant());
         $document->setAttribute('main::$collection', $document->getCollection());
+        if ($this->adapter->getSharedTables()) {
+            $document->setAttribute('main::$tenant', $document->getTenant());
+        }
 
         return $document;
     }
@@ -4333,8 +4335,10 @@ class Database
         $document->setAttribute('main::$permissions', $document->getPermissions());
         $document->setAttribute('main::$createdAt', $document->getCreatedAt());
         $document->setAttribute('main::$updatedAt', $document->getUpdatedAt());
-        $document->setAttribute('main::$tenant', $document->getTenant());
         $document->setAttribute('main::$collection', $document->getCollection());
+        if ($this->adapter->getSharedTables()) {
+            $document->setAttribute('main::$tenant', $document->getTenant());
+        }
 
         return $document;
     }

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -80,17 +80,17 @@ class Document extends ArrayObject
     /**
      * @return array<string>
      */
-    public function getPermissions(): array
+    public function getPermissions(string $attribute = '$permissions'): array
     {
-        return \array_values(\array_unique($this->getAttribute('$permissions', [])));
+        return \array_values(\array_unique($this->getAttribute($attribute, [])));
     }
 
     /**
      * @return array<string>
      */
-    public function getRead(): array
+    public function getRead(string $attribute = '$permissions'): array
     {
-        return $this->getPermissionsByType(Database::PERMISSION_READ);
+        return $this->getPermissionsByType(Database::PERMISSION_READ, $attribute);
     }
 
     /**
@@ -132,11 +132,11 @@ class Document extends ArrayObject
     /**
      * @return array<string>
      */
-    public function getPermissionsByType(string $type): array
+    public function getPermissionsByType(string $type, string $attribute = '$permissions'): array
     {
         $typePermissions = [];
 
-        foreach ($this->getPermissions() as $permission) {
+        foreach ($this->getPermissions($attribute) as $permission) {
             if (!\str_starts_with($permission, $type)) {
                 continue;
             }

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -183,13 +183,8 @@ class Document extends ArrayObject
     {
         $attributes = [];
 
-        $internalKeys = \array_map(
-            fn ($attr) => $attr['$id'],
-            Database::INTERNAL_ATTRIBUTES
-        );
-
         foreach ($this as $attribute => $value) {
-            if (\in_array($attribute, $internalKeys)) {
+            if (Database::isInternalAttribute($attribute)){
                 continue;
             }
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -1129,26 +1129,38 @@ var_dump($docs);
         $this->assertArrayNotHasKey('boolean', $document->getAttributes());
         $this->assertArrayNotHasKey('colors', $document->getAttributes());
         $this->assertArrayNotHasKey('with-dash', $document->getAttributes());
-        $this->assertArrayHasKey('$id', $document);
-        $this->assertArrayHasKey('$sequence', $document);
-        $this->assertArrayHasKey('$createdAt', $document);
-        $this->assertArrayHasKey('$updatedAt', $document);
-        $this->assertArrayHasKey('$permissions', $document);
-        $this->assertArrayHasKey('$collection', $document);
+        $this->assertArrayNotHasKey('$id', $document);
+        $this->assertArrayNotHasKey('$sequence', $document);
+        $this->assertArrayNotHasKey('$createdAt', $document);
+        $this->assertArrayNotHasKey('$updatedAt', $document);
+        $this->assertArrayNotHasKey('$permissions', $document);
+        //$this->assertArrayNotHasKey('$collection', $document);
+        $this->assertArrayHasKey('main::$id', $document);
+        $this->assertArrayHasKey('main::$sequence', $document);
+        $this->assertArrayHasKey('main::$createdAt', $document);
+        $this->assertArrayHasKey('main::$updatedAt', $document);
+        $this->assertArrayHasKey('main::$permissions', $document);
+        $this->assertArrayHasKey('main::$collection', $document);
 
         $document = $database->getDocument('documents', $documentId, [
             Query::select(['string', 'integer_signed', '$id']),
         ]);
 
-        $this->assertArrayHasKey('$id', $document);
-        $this->assertArrayHasKey('$sequence', $document);
-        $this->assertArrayHasKey('$createdAt', $document);
-        $this->assertArrayHasKey('$updatedAt', $document);
-        $this->assertArrayHasKey('$permissions', $document);
-        $this->assertArrayHasKey('$collection', $document);
         $this->assertArrayHasKey('string', $document);
         $this->assertArrayHasKey('integer_signed', $document);
+        $this->assertArrayHasKey('$id', $document);
+        $this->assertArrayNotHasKey('$sequence', $document);
+        $this->assertArrayNotHasKey('$createdAt', $document);
+        $this->assertArrayNotHasKey('$updatedAt', $document);
+        $this->assertArrayNotHasKey('$permissions', $document);
+        //$this->assertArrayNotHasKey('$collection', $document);
         $this->assertArrayNotHasKey('float', $document);
+        $this->assertArrayHasKey('main::$id', $document);
+        $this->assertArrayHasKey('main::$sequence', $document);
+        $this->assertArrayHasKey('main::$createdAt', $document);
+        $this->assertArrayHasKey('main::$updatedAt', $document);
+        $this->assertArrayHasKey('main::$permissions', $document);
+        $this->assertArrayHasKey('main::$collection', $document);
 
         return $document;
     }
@@ -2806,12 +2818,18 @@ var_dump($docs);
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayHasKey('$sequence', $document);
-            $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayHasKey('$permissions', $document);
+            $this->assertArrayNotHasKey('$id', $document);
+            $this->assertArrayNotHasKey('$sequence', $document);
+            //$this->assertArrayNotHasKey('$collection', $document);
+            $this->assertArrayNotHasKey('$createdAt', $document);
+            $this->assertArrayNotHasKey('$updatedAt', $document);
+            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$id', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
 
         $documents = $database->find('movies', [
@@ -2825,11 +2843,17 @@ var_dump($docs);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
             $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayHasKey('$sequence', $document);
-            $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayHasKey('$permissions', $document);
+            $this->assertArrayNotHasKey('$sequence', $document);
+            //$this->assertArrayNotHasKey('$collection', $document);
+            $this->assertArrayNotHasKey('$createdAt', $document);
+            $this->assertArrayNotHasKey('$updatedAt', $document);
+            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$id', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
 
         $documents = $database->find('movies', [
@@ -2842,12 +2866,18 @@ var_dump($docs);
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayHasKey('$id', $document);
+            $this->assertArrayNotHasKey('$id', $document);
             $this->assertArrayHasKey('$sequence', $document);
-            $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayHasKey('$permissions', $document);
+            //$this->assertArrayNotHasKey('$collection', $document);
+            $this->assertArrayNotHasKey('$createdAt', $document);
+            $this->assertArrayNotHasKey('$updatedAt', $document);
+            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$id', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
 
         $documents = $database->find('movies', [
@@ -2860,12 +2890,17 @@ var_dump($docs);
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayHasKey('$sequence', $document);
+            $this->assertArrayNotHasKey('$id', $document);
+            $this->assertArrayNotHasKey('$sequence', $document);
             $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayHasKey('$permissions', $document);
+            $this->assertArrayNotHasKey('$createdAt', $document);
+            $this->assertArrayNotHasKey('$updatedAt', $document);
+            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
 
         $documents = $database->find('movies', [
@@ -2878,12 +2913,17 @@ var_dump($docs);
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayHasKey('$sequence', $document);
-            $this->assertArrayHasKey('$collection', $document);
+            $this->assertArrayNotHasKey('$id', $document);
+            $this->assertArrayNotHasKey('$sequence', $document);
+           // $this->assertArrayNotHasKey('$collection', $document);
             $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayHasKey('$permissions', $document);
+            $this->assertArrayNotHasKey('$updatedAt', $document);
+            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
 
         $documents = $database->find('movies', [
@@ -2896,12 +2936,17 @@ var_dump($docs);
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayHasKey('$sequence', $document);
-            $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayHasKey('$createdAt', $document);
+            $this->assertArrayNotHasKey('$id', $document);
+            $this->assertArrayNotHasKey('$sequence', $document);
+          //  $this->assertArrayNotHasKey('$collection', $document);
+            $this->assertArrayNotHasKey('$createdAt', $document);
             $this->assertArrayHasKey('$updatedAt', $document);
-            $this->assertArrayHasKey('$permissions', $document);
+            $this->assertArrayNotHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
 
         $documents = $database->find('movies', [
@@ -2914,12 +2959,17 @@ var_dump($docs);
             $this->assertArrayNotHasKey('director', $document);
             $this->assertArrayNotHasKey('price', $document);
             $this->assertArrayNotHasKey('active', $document);
-            $this->assertArrayHasKey('$id', $document);
-            $this->assertArrayHasKey('$sequence', $document);
-            $this->assertArrayHasKey('$collection', $document);
-            $this->assertArrayHasKey('$createdAt', $document);
-            $this->assertArrayHasKey('$updatedAt', $document);
+            $this->assertArrayNotHasKey('$id', $document);
+            $this->assertArrayNotHasKey('$sequence', $document);
+            //$this->assertArrayNotHasKey('$collection', $document);
+            $this->assertArrayNotHasKey('$createdAt', $document);
+            $this->assertArrayNotHasKey('$updatedAt', $document);
             $this->assertArrayHasKey('$permissions', $document);
+            $this->assertArrayHasKey('main::$sequence', $document);
+            $this->assertArrayHasKey('main::$collection', $document);
+            $this->assertArrayHasKey('main::$createdAt', $document);
+            $this->assertArrayHasKey('main::$updatedAt', $document);
+            $this->assertArrayHasKey('main::$permissions', $document);
         }
     }
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -741,7 +741,7 @@ trait DocumentTests
             $newDocument
                 ->setAttribute('last', 'last')
         ]);
-var_dump($docs);
+
         $this->assertEquals(1, $docs);
 
         $this->assertEquals('first', $existingDocument->getAttribute('first'));

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -741,8 +741,9 @@ trait DocumentTests
             $newDocument
                 ->setAttribute('last', 'last')
         ]);
-
+var_dump($docs);
         $this->assertEquals(1, $docs);
+
         $this->assertEquals('first', $existingDocument->getAttribute('first'));
         $this->assertEquals(null, $existingDocument->getAttribute('last'));
         $this->assertEquals('second', $newDocument->getAttribute('first'));

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -750,13 +750,8 @@ trait RelationshipTests
             ],
         ]));
 
-var_dump($level1);
-
-        //$level1 = $database->getDocument('level1', $level1->getId());
-
         $database->updateDocument('level1', $level1->getId(), new Document($level1->getArrayCopy()));
         $updatedLevel1 = $database->getDocument('level1', $level1->getId());
-
         $this->assertEquals($level1, $updatedLevel1);
 
         try {
@@ -978,7 +973,7 @@ var_dump($level1);
 
         // Select some parent attributes, some child attributes
         $make = $database->findOne('make', [
-            Query::select(['name', 'models.name']),
+            Query::select(['name', 'models.name', '*']),
         ]);
 
         if ($make->isEmpty()) {
@@ -1009,11 +1004,11 @@ var_dump($level1);
 
         $this->assertArrayHasKey('name', $make);
         $this->assertArrayHasKey('$id', $make);
-        $this->assertArrayHasKey('$sequence', $make);
-        $this->assertArrayHasKey('$collection', $make);
-        $this->assertArrayHasKey('$createdAt', $make);
-        $this->assertArrayHasKey('$updatedAt', $make);
-        $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
+        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$sequence']),
@@ -1024,12 +1019,12 @@ var_dump($level1);
         }
 
         $this->assertArrayHasKey('name', $make);
-        $this->assertArrayHasKey('$id', $make);
         $this->assertArrayHasKey('$sequence', $make);
-        $this->assertArrayHasKey('$collection', $make);
-        $this->assertArrayHasKey('$createdAt', $make);
-        $this->assertArrayHasKey('$updatedAt', $make);
-        $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
+        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$collection']),
@@ -1040,12 +1035,12 @@ var_dump($level1);
         }
 
         $this->assertArrayHasKey('name', $make);
-        $this->assertArrayHasKey('$id', $make);
-        $this->assertArrayHasKey('$sequence', $make);
         $this->assertArrayHasKey('$collection', $make);
-        $this->assertArrayHasKey('$createdAt', $make);
-        $this->assertArrayHasKey('$updatedAt', $make);
-        $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
+        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$createdAt']),
@@ -1056,12 +1051,12 @@ var_dump($level1);
         }
 
         $this->assertArrayHasKey('name', $make);
-        $this->assertArrayHasKey('$id', $make);
-        $this->assertArrayHasKey('$sequence', $make);
-        $this->assertArrayHasKey('$collection', $make);
         $this->assertArrayHasKey('$createdAt', $make);
-        $this->assertArrayHasKey('$updatedAt', $make);
-        $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
+        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$updatedAt']),
@@ -1072,12 +1067,12 @@ var_dump($level1);
         }
 
         $this->assertArrayHasKey('name', $make);
-        $this->assertArrayHasKey('$id', $make);
-        $this->assertArrayHasKey('$sequence', $make);
-        $this->assertArrayHasKey('$collection', $make);
-        $this->assertArrayHasKey('$createdAt', $make);
         $this->assertArrayHasKey('$updatedAt', $make);
-        $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
+        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$permissions']),
@@ -1088,12 +1083,12 @@ var_dump($level1);
         }
 
         $this->assertArrayHasKey('name', $make);
-        $this->assertArrayHasKey('$id', $make);
-        $this->assertArrayHasKey('$sequence', $make);
-        $this->assertArrayHasKey('$collection', $make);
-        $this->assertArrayHasKey('$createdAt', $make);
-        $this->assertArrayHasKey('$updatedAt', $make);
         $this->assertArrayHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
 
         // Select all parent attributes, some child attributes
         $make = $database->findOne('make', [

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -749,7 +749,6 @@ trait RelationshipTests
                 ],
             ],
         ]));
-
         $database->updateDocument('level1', $level1->getId(), new Document($level1->getArrayCopy()));
         $updatedLevel1 = $database->getDocument('level1', $level1->getId());
         $this->assertEquals($level1, $updatedLevel1);
@@ -899,9 +898,6 @@ trait RelationshipTests
                 ]
             ]
         ]));
-
-        //$species = $database->getDocument('species', $species->getId());
-
         $database->updateDocument('species', $species->getId(), new Document([
             '$id' => ID::custom('1'),
             '$collection' => 'species',

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -751,10 +751,12 @@ trait RelationshipTests
         ]));
 
 var_dump($level1);
+
         //$level1 = $database->getDocument('level1', $level1->getId());
 
         $database->updateDocument('level1', $level1->getId(), new Document($level1->getArrayCopy()));
         $updatedLevel1 = $database->getDocument('level1', $level1->getId());
+
         $this->assertEquals($level1, $updatedLevel1);
 
         try {

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -749,6 +749,10 @@ trait RelationshipTests
                 ],
             ],
         ]));
+
+var_dump($level1);
+        //$level1 = $database->getDocument('level1', $level1->getId());
+
         $database->updateDocument('level1', $level1->getId(), new Document($level1->getArrayCopy()));
         $updatedLevel1 = $database->getDocument('level1', $level1->getId());
         $this->assertEquals($level1, $updatedLevel1);
@@ -898,6 +902,9 @@ trait RelationshipTests
                 ]
             ]
         ]));
+
+        //$species = $database->getDocument('species', $species->getId());
+
         $database->updateDocument('species', $species->getId(), new Document([
             '$id' => ID::custom('1'),
             '$collection' => 'species',

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -988,6 +988,11 @@ trait RelationshipTests
         $this->assertArrayHasKey('$collection', $make);
         $this->assertArrayHasKey('$createdAt', $make);
         $this->assertArrayHasKey('$updatedAt', $make);
+        $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
 
         // Select internal attributes
         $make = $database->findOne('make', [
@@ -1000,11 +1005,16 @@ trait RelationshipTests
 
         $this->assertArrayHasKey('name', $make);
         $this->assertArrayHasKey('$id', $make);
+        $this->assertArrayNotHasKey('$sequence', $make);
+        //$this->assertArrayNotHasKey('$collection', $make);
+        $this->assertArrayNotHasKey('$createdAt', $make);
+        $this->assertArrayNotHasKey('$updatedAt', $make);
+        $this->assertArrayNotHasKey('$permissions', $make);
+        $this->assertArrayHasKey('main::$id', $make);
         $this->assertArrayHasKey('main::$sequence', $make);
         $this->assertArrayHasKey('main::$collection', $make);
         $this->assertArrayHasKey('main::$createdAt', $make);
         $this->assertArrayHasKey('main::$updatedAt', $make);
-        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$sequence']),
@@ -1015,12 +1025,17 @@ trait RelationshipTests
         }
 
         $this->assertArrayHasKey('name', $make);
+        $this->assertArrayNotHasKey('$id', $make);
         $this->assertArrayHasKey('$sequence', $make);
+        //$this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayNotHasKey('$createdAt', $make);
+        $this->assertArrayNotHasKey('$updatedAt', $make);
+        $this->assertArrayNotHasKey('$permissions', $make);
         $this->assertArrayHasKey('main::$id', $make);
+        $this->assertArrayHasKey('main::$sequence', $make);
         $this->assertArrayHasKey('main::$collection', $make);
         $this->assertArrayHasKey('main::$createdAt', $make);
         $this->assertArrayHasKey('main::$updatedAt', $make);
-        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$collection']),
@@ -1031,12 +1046,17 @@ trait RelationshipTests
         }
 
         $this->assertArrayHasKey('name', $make);
+        $this->assertArrayNotHasKey('$id', $make);
+        $this->assertArrayNotHasKey('$sequence', $make);
         $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayNotHasKey('$createdAt', $make);
+        $this->assertArrayNotHasKey('$updatedAt', $make);
+        $this->assertArrayNotHasKey('$permissions', $make);
         $this->assertArrayHasKey('main::$id', $make);
         $this->assertArrayHasKey('main::$sequence', $make);
+        $this->assertArrayHasKey('main::$collection', $make);
         $this->assertArrayHasKey('main::$createdAt', $make);
         $this->assertArrayHasKey('main::$updatedAt', $make);
-        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$createdAt']),
@@ -1047,12 +1067,17 @@ trait RelationshipTests
         }
 
         $this->assertArrayHasKey('name', $make);
+        $this->assertArrayNotHasKey('$id', $make);
+        $this->assertArrayNotHasKey('$sequence', $make);
+        //$this->assertArrayHasKey('$collection', $make);
         $this->assertArrayHasKey('$createdAt', $make);
+        $this->assertArrayNotHasKey('$updatedAt', $make);
+        $this->assertArrayNotHasKey('$permissions', $make);
         $this->assertArrayHasKey('main::$id', $make);
         $this->assertArrayHasKey('main::$sequence', $make);
         $this->assertArrayHasKey('main::$collection', $make);
+        $this->assertArrayHasKey('main::$createdAt', $make);
         $this->assertArrayHasKey('main::$updatedAt', $make);
-        $this->assertArrayHasKey('main::$permissions', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$updatedAt']),
@@ -1063,12 +1088,17 @@ trait RelationshipTests
         }
 
         $this->assertArrayHasKey('name', $make);
+        $this->assertArrayNotHasKey('$id', $make);
+        $this->assertArrayNotHasKey('$sequence', $make);
+        //$this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayNotHasKey('$createdAt', $make);
         $this->assertArrayHasKey('$updatedAt', $make);
+        $this->assertArrayNotHasKey('$permissions', $make);
         $this->assertArrayHasKey('main::$id', $make);
         $this->assertArrayHasKey('main::$sequence', $make);
         $this->assertArrayHasKey('main::$collection', $make);
         $this->assertArrayHasKey('main::$createdAt', $make);
-        $this->assertArrayHasKey('main::$permissions', $make);
+        $this->assertArrayHasKey('main::$updatedAt', $make);
 
         $make = $database->findOne('make', [
             Query::select(['name', '$permissions']),
@@ -1079,6 +1109,11 @@ trait RelationshipTests
         }
 
         $this->assertArrayHasKey('name', $make);
+        $this->assertArrayNotHasKey('$id', $make);
+        $this->assertArrayNotHasKey('$sequence', $make);
+       // $this->assertArrayHasKey('$collection', $make);
+        $this->assertArrayNotHasKey('$createdAt', $make);
+        $this->assertArrayNotHasKey('$updatedAt', $make);
         $this->assertArrayHasKey('$permissions', $make);
         $this->assertArrayHasKey('main::$id', $make);
         $this->assertArrayHasKey('main::$sequence', $make);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Internal metadata fields are now consistently included in query results with a new prefixed naming convention.
	- Permission checks and timestamp formatting on documents have been refined for accuracy.
	- Internal attributes are now properly filtered during document encoding to prevent exposure.

- **Tests**
	- Updated tests to expect internal attributes with the new prefixed keys.
	- Adjusted test assertions to match the revised document structure and selection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->