### PR TITLE
Throw conflict on upsert

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5025,6 +5025,19 @@ class Database
                 throw new StructureException($validator->getDescription());
             }
 
+            if (!$old->isEmpty()) {
+                // Check if document was updated after the request timestamp
+                try {
+                    $oldUpdatedAt = new \DateTime($old->getUpdatedAt());
+                } catch (Exception $e) {
+                    throw new DatabaseException($e->getMessage(), $e->getCode(), $e);
+                }
+
+                if (!\is_null($this->timestamp) && $oldUpdatedAt > $this->timestamp) {
+                    throw new ConflictException('Document was updated after the request timestamp');
+                }
+            }
+
             if ($this->resolveRelationships) {
                 $document = $this->silent(fn () => $this->createDocumentRelationships($collection, $document));
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrency control to prevent overwriting documents that have been updated since the request was initiated. Users will now receive a conflict error if attempting to update a document that has changed after their request timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->