### PR TITLE
Add error handling callbacks for batch document operations

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5893,7 +5893,7 @@ class Database
                 try {
                     $onNext && $onNext($document);
                 } catch (Exception $e) {
-                    $onError && $onError($e);
+                    $onError ? $onError($e) : throw $e;
                 }
                 $modified++;
             }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3,6 +3,7 @@
 namespace Utopia\Database;
 
 use Exception;
+use Throwable;
 use Utopia\Cache\Cache;
 use Utopia\CLI\Console;
 use Utopia\Database\Exception as DatabaseException;
@@ -5892,8 +5893,8 @@ class Database
                 }
                 try {
                     $onNext && $onNext($document);
-                } catch (Exception $e) {
-                    $onError ? $onError($e) : throw $e;
+                } catch (Throwable $th) {
+                    $onError ? $onError($th) : throw $th;
                 }
                 $modified++;
             }

--- a/src/Database/Mirror.php
+++ b/src/Database/Mirror.php
@@ -827,6 +827,7 @@ class Mirror extends Database
         array $queries = [],
         int $batchSize = self::DELETE_BATCH_SIZE,
         ?callable $onNext = null,
+        ?callable $onError = null,
     ): int {
         $modified = 0;
 
@@ -838,6 +839,7 @@ class Mirror extends Database
                 $onNext && $onNext($doc);
                 $modified++;
             },
+            $onError
         );
 
         if (

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -3953,6 +3953,31 @@ trait DocumentTests
          */
         $selects = ['$sequence', '$id', '$collection', '$permissions', '$updatedAt'];
 
+        try {
+            // a non existent document to test the error thrown
+            $database->deleteDocuments(
+                collection: 'bulk_delete',
+                queries: [
+                    Query::select([...$selects, '$createdAt']),
+                    Query::lessThan('$createdAt', '1800-01-01'),
+                    Query::orderAsc('$createdAt'),
+                    Query::orderAsc(),
+                    Query::limit(1),
+                ],
+                batchSize: 1,
+                onNext: function () {
+                    throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
+                }
+            );
+        } catch (Exception $e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        }
+
         $count = $database->deleteDocuments(
             collection: 'bulk_delete',
             queries: [

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -3963,13 +3963,33 @@ trait DocumentTests
                 Query::orderAsc(),
                 Query::limit(2),
             ],
-            batchSize: 1
+            batchSize: 1,
+            onNext: function () {
+                throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            },
+            onError:function ($e) {
+                if ($e instanceof Exception) {
+                    $this->assertInstanceOf(Exception::class, $e);
+                    $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                } else {
+                    $this->fail("Caught value is not an Exception.");
+                }
+            }
         );
 
         $this->assertEquals(2, $count);
 
         // TEST: Bulk Delete All Documents
-        $this->assertEquals(8, $database->deleteDocuments('bulk_delete'));
+        $this->assertEquals(8, $database->deleteDocuments('bulk_delete', onNext: function () {
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        }));
 
         $docs = $database->find('bulk_delete');
         $this->assertCount(0, $docs);
@@ -3982,6 +4002,14 @@ trait DocumentTests
             Query::greaterThanEqual('integer', 5)
         ], onNext: function ($doc) use (&$results) {
             $results[] = $doc;
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
         });
 
         $this->assertEquals(5, $count);
@@ -3998,7 +4026,16 @@ trait DocumentTests
 
         try {
             $this->getDatabase()->withRequestTimestamp($oneHourAgo, function () {
-                return $this->getDatabase()->deleteDocuments('bulk_delete');
+                return $this->getDatabase()->deleteDocuments('bulk_delete', onNext: function () {
+                    throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+                }, onError:function ($e) {
+                    if ($e instanceof Exception) {
+                        $this->assertInstanceOf(Exception::class, $e);
+                        $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                    } else {
+                        $this->fail("Caught value is not an Exception.");
+                    }
+                });
             });
             $this->fail('Failed to throw exception');
         } catch (ConflictException $e) {
@@ -4042,7 +4079,16 @@ trait DocumentTests
             Permission::delete(Role::any())
         ], false);
 
-        $database->deleteDocuments('bulk_delete');
+        $database->deleteDocuments('bulk_delete', onNext: function () {
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        });
 
         $this->assertEquals(0, \count($this->getDatabase()->find('bulk_delete')));
 
@@ -4087,10 +4133,28 @@ trait DocumentTests
         // Test limit
         $this->propagateBulkDocuments('bulk_delete_queries');
 
-        $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)]));
+        $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)], onNext: function () {
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        }));
         $this->assertEquals(5, \count($database->find('bulk_delete_queries')));
 
-        $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)]));
+        $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)], onNext: function () {
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        }));
         $this->assertEquals(0, \count($database->find('bulk_delete_queries')));
 
         // Test Limit more than batchSize

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -3965,12 +3965,12 @@ trait DocumentTests
             ],
             batchSize: 1,
             onNext: function () {
-                throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+                throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
             },
             onError:function ($e) {
                 if ($e instanceof Exception) {
                     $this->assertInstanceOf(Exception::class, $e);
-                    $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                    $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
                 } else {
                     $this->fail("Caught value is not an Exception.");
                 }
@@ -3981,11 +3981,11 @@ trait DocumentTests
 
         // TEST: Bulk Delete All Documents
         $this->assertEquals(8, $database->deleteDocuments('bulk_delete', onNext: function () {
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }
@@ -4002,11 +4002,11 @@ trait DocumentTests
             Query::greaterThanEqual('integer', 5)
         ], onNext: function ($doc) use (&$results) {
             $results[] = $doc;
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }
@@ -4027,11 +4027,11 @@ trait DocumentTests
         try {
             $this->getDatabase()->withRequestTimestamp($oneHourAgo, function () {
                 return $this->getDatabase()->deleteDocuments('bulk_delete', onNext: function () {
-                    throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+                    throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
                 }, onError:function ($e) {
                     if ($e instanceof Exception) {
                         $this->assertInstanceOf(Exception::class, $e);
-                        $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                        $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
                     } else {
                         $this->fail("Caught value is not an Exception.");
                     }
@@ -4080,11 +4080,11 @@ trait DocumentTests
         ], false);
 
         $database->deleteDocuments('bulk_delete', onNext: function () {
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }
@@ -4134,11 +4134,11 @@ trait DocumentTests
         $this->propagateBulkDocuments('bulk_delete_queries');
 
         $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)], onNext: function () {
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }
@@ -4146,11 +4146,11 @@ trait DocumentTests
         $this->assertEquals(5, \count($database->find('bulk_delete_queries')));
 
         $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)], onNext: function () {
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -3970,12 +3970,8 @@ trait DocumentTests
                 }
             );
         } catch (Exception $e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         }
 
         $count = $database->deleteDocuments(
@@ -3993,12 +3989,8 @@ trait DocumentTests
                 throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
             },
             onError:function ($e) {
-                if ($e instanceof Exception) {
-                    $this->assertInstanceOf(Exception::class, $e);
-                    $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-                } else {
-                    $this->fail("Caught value is not an Exception.");
-                }
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             }
         );
 
@@ -4008,12 +4000,8 @@ trait DocumentTests
         $this->assertEquals(8, $database->deleteDocuments('bulk_delete', onNext: function () {
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         }));
 
         $docs = $database->find('bulk_delete');
@@ -4029,12 +4017,8 @@ trait DocumentTests
             $results[] = $doc;
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         });
 
         $this->assertEquals(5, $count);
@@ -4107,12 +4091,8 @@ trait DocumentTests
         $database->deleteDocuments('bulk_delete', onNext: function () {
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         });
 
         $this->assertEquals(0, \count($this->getDatabase()->find('bulk_delete')));
@@ -4161,24 +4141,16 @@ trait DocumentTests
         $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)], onNext: function () {
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         }));
         $this->assertEquals(5, \count($database->find('bulk_delete_queries')));
 
         $this->assertEquals(5, $database->deleteDocuments('bulk_delete_queries', [Query::limit(5)], onNext: function () {
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         }));
         $this->assertEquals(0, \count($database->find('bulk_delete_queries')));
 

--- a/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
@@ -1581,7 +1581,16 @@ trait ManyToManyTests
 
         // Delete person
         try {
-            $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m');
+            $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
+                throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            }, onError:function ($e) {
+                if ($e instanceof Exception) {
+                    $this->assertInstanceOf(Exception::class, $e);
+                    $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                } else {
+                    $this->fail("Caught value is not an Exception.");
+                }
+            });
             $this->fail('Failed to throw exception');
         } catch (RestrictedException $e) {
             $this->assertEquals('Cannot delete document because it has at least one related document.', $e->getMessage());
@@ -1589,10 +1598,28 @@ trait ManyToManyTests
 
         // Restrict Cleanup
         $this->getDatabase()->deleteRelationship('bulk_delete_person_m2m', 'bulk_delete_library_m2m');
-        $this->getDatabase()->deleteDocuments('bulk_delete_library_m2m');
+        $this->getDatabase()->deleteDocuments('bulk_delete_library_m2m', onNext: function () {
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        });
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_library_m2m'));
 
-        $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m');
+        $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
+            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+        }, onError:function ($e) {
+            if ($e instanceof Exception) {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+            } else {
+                $this->fail("Caught value is not an Exception.");
+            }
+        });
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_person_m2m'));
     }
 }

--- a/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
@@ -1582,11 +1582,11 @@ trait ManyToManyTests
         // Delete person
         try {
             $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
-                throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+                throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
             }, onError:function ($e) {
                 if ($e instanceof Exception) {
                     $this->assertInstanceOf(Exception::class, $e);
-                    $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                    $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
                 } else {
                     $this->fail("Caught value is not an Exception.");
                 }
@@ -1599,11 +1599,11 @@ trait ManyToManyTests
         // Restrict Cleanup
         $this->getDatabase()->deleteRelationship('bulk_delete_person_m2m', 'bulk_delete_library_m2m');
         $this->getDatabase()->deleteDocuments('bulk_delete_library_m2m', onNext: function () {
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }
@@ -1611,11 +1611,11 @@ trait ManyToManyTests
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_library_m2m'));
 
         $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
-            throw new Exception("Error thrown to test update doesn't stopped and error is caught");
+            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
             if ($e instanceof Exception) {
                 $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test update doesn't stopped and error is caught", $e->getMessage());
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             } else {
                 $this->fail("Caught value is not an Exception.");
             }

--- a/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
@@ -1581,12 +1581,7 @@ trait ManyToManyTests
 
         // Delete person
         try {
-            $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
-                throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
-            }, onError:function ($e) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            });
+            $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m');
             $this->fail('Failed to throw exception');
         } catch (RestrictedException $e) {
             $this->assertEquals('Cannot delete document because it has at least one related document.', $e->getMessage());
@@ -1594,20 +1589,10 @@ trait ManyToManyTests
 
         // Restrict Cleanup
         $this->getDatabase()->deleteRelationship('bulk_delete_person_m2m', 'bulk_delete_library_m2m');
-        $this->getDatabase()->deleteDocuments('bulk_delete_library_m2m', onNext: function () {
-            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
-        }, onError:function ($e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-        });
+        $this->getDatabase()->deleteDocuments('bulk_delete_library_m2m');
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_library_m2m'));
 
-        $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
-            throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
-        }, onError:function ($e) {
-            $this->assertInstanceOf(Exception::class, $e);
-            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-        });
+        $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m');
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_person_m2m'));
     }
 }

--- a/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
@@ -1595,4 +1595,63 @@ trait ManyToManyTests
         $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m');
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_person_m2m'));
     }
+    public function testDeleteDocumentsRelationshipErrorDoesNotDeleteParent_ManyToMany(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForRelationships() || !$database->getAdapter()->getSupportForBatchOperations()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $parentCollection = 'parent_relationship_many_to_many';
+        $childCollection = 'child_relationship_many_to_many';
+
+        $database->createCollection($parentCollection);
+        $database->createCollection($childCollection);
+        $database->createAttribute($parentCollection, 'name', Database::VAR_STRING, 255, true);
+        $database->createAttribute($childCollection, 'name', Database::VAR_STRING, 255, true);
+
+        $database->createRelationship(
+            collection: $parentCollection,
+            relatedCollection: $childCollection,
+            type: Database::RELATION_MANY_TO_MANY,
+            onDelete: Database::RELATION_MUTATE_RESTRICT
+        );
+
+        $parent = $database->createDocument($parentCollection, new Document([
+            '$id' => 'parent1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Parent 1',
+            $childCollection => [
+                [
+                    '$id' => 'child1',
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                        Permission::delete(Role::any()),
+                    ],
+                    'name' => 'Child 1',
+                ]
+            ]
+        ]));
+
+        try {
+            $database->deleteDocuments($parentCollection, [Query::equal('$id', ['parent1'])]);
+            $this->fail('Expected exception was not thrown');
+        } catch (RestrictedException $e) {
+            $this->assertEquals('Cannot delete document because it has at least one related document.', $e->getMessage());
+        }
+        $parentDoc = $database->getDocument($parentCollection, 'parent1');
+        $childDoc = $database->getDocument($childCollection, 'child1');
+        $this->assertFalse($parentDoc->isEmpty(), 'Parent should not be deleted');
+        $this->assertFalse($childDoc->isEmpty(), 'Child should not be deleted');
+        $database->deleteCollection($parentCollection);
+        $database->deleteCollection($childCollection);
+    }
 }

--- a/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/ManyToManyTests.php
@@ -1584,12 +1584,8 @@ trait ManyToManyTests
             $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
                 throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
             }, onError:function ($e) {
-                if ($e instanceof Exception) {
-                    $this->assertInstanceOf(Exception::class, $e);
-                    $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-                } else {
-                    $this->fail("Caught value is not an Exception.");
-                }
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
             });
             $this->fail('Failed to throw exception');
         } catch (RestrictedException $e) {
@@ -1601,24 +1597,16 @@ trait ManyToManyTests
         $this->getDatabase()->deleteDocuments('bulk_delete_library_m2m', onNext: function () {
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         });
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_library_m2m'));
 
         $this->getDatabase()->deleteDocuments('bulk_delete_person_m2m', onNext: function () {
             throw new Exception("Error thrown to test that deletion doesn't stop and error is caught");
         }, onError:function ($e) {
-            if ($e instanceof Exception) {
-                $this->assertInstanceOf(Exception::class, $e);
-                $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
-            } else {
-                $this->fail("Caught value is not an Exception.");
-            }
+            $this->assertInstanceOf(Exception::class, $e);
+            $this->assertEquals("Error thrown to test that deletion doesn't stop and error is caught", $e->getMessage());
         });
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_person_m2m'));
     }

--- a/tests/e2e/Adapter/Scopes/Relationships/ManyToOneTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/ManyToOneTests.php
@@ -1677,4 +1677,64 @@ trait ManyToOneTests
         $this->getDatabase()->deleteDocuments('bulk_delete_person_m2o');
         $this->assertCount(0, $this->getDatabase()->find('bulk_delete_person_m2o'));
     }
+
+    public function testDeleteDocumentsRelationshipErrorDoesNotDeleteParent_ManyToOne(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForRelationships() || !$database->getAdapter()->getSupportForBatchOperations()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $parentCollection = 'parent_relationship_error_many_to_one';
+        $childCollection = 'child_relationship_error_many_to_one';
+
+        $database->createCollection($parentCollection);
+        $database->createCollection($childCollection);
+        $database->createAttribute($parentCollection, 'name', Database::VAR_STRING, 255, true);
+        $database->createAttribute($childCollection, 'name', Database::VAR_STRING, 255, true);
+
+        $database->createRelationship(
+            collection: $childCollection,
+            relatedCollection: $parentCollection,
+            type: Database::RELATION_MANY_TO_ONE,
+            onDelete: Database::RELATION_MUTATE_RESTRICT
+        );
+
+        $parent = $database->createDocument($parentCollection, new Document([
+            '$id' => 'parent1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Parent 1',
+        ]));
+
+        $child = $database->createDocument($childCollection, new Document([
+            '$id' => 'child1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Child 1',
+            $parentCollection => 'parent1'
+        ]));
+
+        try {
+            $database->deleteDocuments($parentCollection, [Query::equal('$id', ['parent1'])]);
+            $this->fail('Expected exception was not thrown');
+        } catch (RestrictedException $e) {
+            $this->assertEquals('Cannot delete document because it has at least one related document.', $e->getMessage());
+        }
+        $parentDoc = $database->getDocument($parentCollection, 'parent1');
+        $childDoc = $database->getDocument($childCollection, 'child1');
+        $this->assertFalse($parentDoc->isEmpty(), 'Parent should not be deleted');
+        $this->assertFalse($childDoc->isEmpty(), 'Child should not be deleted');
+        $database->deleteCollection($parentCollection);
+        $database->deleteCollection($childCollection);
+    }
 }

--- a/tests/e2e/Adapter/Scopes/Relationships/OneToOneTests.php
+++ b/tests/e2e/Adapter/Scopes/Relationships/OneToOneTests.php
@@ -2289,4 +2289,62 @@ trait OneToOneTests
 
         $this->assertEquals(true, $junction->isEmpty());
     }
+
+    public function testDeleteDocumentsRelationshipErrorDoesNotDeleteParent_OneToOne(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForRelationships() || !$database->getAdapter()->getSupportForBatchOperations()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $parentCollection = 'parent_relationship_error_one_to_one';
+        $childCollection = 'child_relationship_error_one_to_one';
+
+        $database->createCollection($parentCollection);
+        $database->createCollection($childCollection);
+        $database->createAttribute($parentCollection, 'name', Database::VAR_STRING, 255, true);
+        $database->createAttribute($childCollection, 'name', Database::VAR_STRING, 255, true);
+
+        $database->createRelationship(
+            collection: $parentCollection,
+            relatedCollection: $childCollection,
+            type: Database::RELATION_ONE_TO_ONE,
+            onDelete: Database::RELATION_MUTATE_RESTRICT
+        );
+
+        $parent = $database->createDocument($parentCollection, new Document([
+            '$id' => 'parent1',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+                Permission::delete(Role::any()),
+            ],
+            'name' => 'Parent 1',
+            $childCollection => [
+                '$id' => 'child1',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::delete(Role::any()),
+                ],
+                'name' => 'Child 1',
+            ]
+        ]));
+
+        try {
+            $database->deleteDocuments($parentCollection, [Query::equal('$id', ['parent1'])]);
+            $this->fail('Expected exception was not thrown');
+        } catch (RestrictedException $e) {
+            $this->assertEquals('Cannot delete document because it has at least one related document.', $e->getMessage());
+        }
+        $parentDoc = $database->getDocument($parentCollection, 'parent1');
+        $childDoc = $database->getDocument($childCollection, 'child1');
+        $this->assertFalse($parentDoc->isEmpty(), 'Parent should not be deleted');
+        $this->assertFalse($childDoc->isEmpty(), 'Child should not be deleted');
+        $database->deleteCollection($parentCollection);
+        $database->deleteCollection($childCollection);
+    }
 }


### PR DESCRIPTION
* Changes made to ensure an ongoing delete doesn't stop due to exceptions in the onNext callable
* If exceptions coming in onNext passing them to the onError callback
* Relationship deletes moved inside the transaction to ensure both relations and the original documents are deleted instead of relation deleted and the original not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional error handling callback during document deletions to improve robustness.

* **Bug Fixes**
  * Enhanced error handling to catch exceptions in deletion callbacks without interrupting the deletion process.

* **Tests**
  * Added comprehensive tests verifying bulk document deletion with callback support.
  * Added tests ensuring restricted deletions in various relationship types prevent parent document removal when related child documents exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->