### PR TITLE
Revert "Skip permissions update"

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -697,11 +697,10 @@ abstract class Adapter
      * @param string $collection
      * @param string $id
      * @param Document $document
-     * @param bool $skipPermissions
      *
      * @return Document
      */
-    abstract public function updateDocument(string $collection, string $id, Document $document, bool $skipPermissions): Document;
+    abstract public function updateDocument(string $collection, string $id, Document $document): Document;
 
     /**
      * Update documents

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -926,14 +926,13 @@ class MariaDB extends SQL
      * @param string $collection
      * @param string $id
      * @param Document $document
-     * @param bool $skipPermissions
      * @return Document
      * @throws Exception
      * @throws PDOException
      * @throws DuplicateException
      * @throws \Throwable
      */
-    public function updateDocument(string $collection, string $id, Document $document, bool $skipPermissions): Document
+    public function updateDocument(string $collection, string $id, Document $document): Document
     {
         try {
             $attributes = $document->getAttributes();
@@ -944,151 +943,149 @@ class MariaDB extends SQL
             $name = $this->filter($collection);
             $columns = '';
 
-            if (!$skipPermissions) {
-                $sql = "
+            $sql = "
 			    SELECT _type, _permission
 			    FROM {$this->getSQLTable($name . '_perms')}
 			    WHERE _document = :_uid
 			    {$this->getTenantQuery($collection)}
 			";
 
-                $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
+            $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
 
-                /**
-                 * Get current permissions from the database
-                 */
-                $sqlPermissions = $this->getPDO()->prepare($sql);
-                $sqlPermissions->bindValue(':_uid', $document->getId());
+            /**
+             * Get current permissions from the database
+             */
+            $sqlPermissions = $this->getPDO()->prepare($sql);
+            $sqlPermissions->bindValue(':_uid', $document->getId());
 
-                if ($this->sharedTables) {
-                    $sqlPermissions->bindValue(':_tenant', $this->tenant);
+            if ($this->sharedTables) {
+                $sqlPermissions->bindValue(':_tenant', $this->tenant);
+            }
+
+            $sqlPermissions->execute();
+            $permissions = $sqlPermissions->fetchAll();
+            $sqlPermissions->closeCursor();
+
+            $initial = [];
+            foreach (Database::PERMISSIONS as $type) {
+                $initial[$type] = [];
+            }
+
+            $permissions = array_reduce($permissions, function (array $carry, array $item) {
+                $carry[$item['_type']][] = $item['_permission'];
+
+                return $carry;
+            }, $initial);
+
+            /**
+             * Get removed Permissions
+             */
+            $removals = [];
+            foreach (Database::PERMISSIONS as $type) {
+                $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
+                if (!empty($diff)) {
+                    $removals[$type] = $diff;
                 }
+            }
 
-                $sqlPermissions->execute();
-                $permissions = $sqlPermissions->fetchAll();
-                $sqlPermissions->closeCursor();
-
-                $initial = [];
-                foreach (Database::PERMISSIONS as $type) {
-                    $initial[$type] = [];
+            /**
+             * Get added Permissions
+             */
+            $additions = [];
+            foreach (Database::PERMISSIONS as $type) {
+                $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
+                if (!empty($diff)) {
+                    $additions[$type] = $diff;
                 }
+            }
 
-                $permissions = array_reduce($permissions, function (array $carry, array $item) {
-                    $carry[$item['_type']][] = $item['_permission'];
-
-                    return $carry;
-                }, $initial);
-
-                /**
-                 * Get removed Permissions
-                 */
-                $removals = [];
-                foreach (Database::PERMISSIONS as $type) {
-                    $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
-                    if (!empty($diff)) {
-                        $removals[$type] = $diff;
-                    }
-                }
-
-                /**
-                 * Get added Permissions
-                 */
-                $additions = [];
-                foreach (Database::PERMISSIONS as $type) {
-                    $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
-                    if (!empty($diff)) {
-                        $additions[$type] = $diff;
-                    }
-                }
-
-                /**
-                 * Query to remove permissions
-                 */
-                $removeQuery = '';
-                if (!empty($removals)) {
-                    $removeQuery = ' AND (';
-                    foreach ($removals as $type => $permissions) {
-                        $removeQuery .= "(
+            /**
+             * Query to remove permissions
+             */
+            $removeQuery = '';
+            if (!empty($removals)) {
+                $removeQuery = ' AND (';
+                foreach ($removals as $type => $permissions) {
+                    $removeQuery .= "(
                     _type = '{$type}'
                     AND _permission IN (" . implode(', ', \array_map(fn (string $i) => ":_remove_{$type}_{$i}", \array_keys($permissions))) . ")
                 )";
-                        if ($type !== \array_key_last($removals)) {
-                            $removeQuery .= ' OR ';
-                        }
+                    if ($type !== \array_key_last($removals)) {
+                        $removeQuery .= ' OR ';
                     }
                 }
-                if (!empty($removeQuery)) {
-                    $removeQuery .= ')';
-                    $sql = "
+            }
+            if (!empty($removeQuery)) {
+                $removeQuery .= ')';
+                $sql = "
 				    DELETE
                     FROM {$this->getSQLTable($name . '_perms')}
                     WHERE _document = :_uid
                     {$this->getTenantQuery($collection)}
                 ";
 
-                    $removeQuery = $sql . $removeQuery;
+                $removeQuery = $sql . $removeQuery;
 
-                    $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
+                $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
 
-                    $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                    $stmtRemovePermissions->bindValue(':_uid', $document->getId());
+                $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
+                $stmtRemovePermissions->bindValue(':_uid', $document->getId());
 
-                    if ($this->sharedTables) {
-                        $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+                if ($this->sharedTables) {
+                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+                }
+
+                foreach ($removals as $type => $permissions) {
+                    foreach ($permissions as $i => $permission) {
+                        $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
                     }
+                }
+            }
 
-                    foreach ($removals as $type => $permissions) {
-                        foreach ($permissions as $i => $permission) {
-                            $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
+            /**
+             * Query to add permissions
+             */
+            if (!empty($additions)) {
+                $values = [];
+                foreach ($additions as $type => $permissions) {
+                    foreach ($permissions as $i => $_) {
+                        $value = "( :_uid, '{$type}', :_add_{$type}_{$i}";
+
+                        if ($this->sharedTables) {
+                            $value .= ", :_tenant)";
+                        } else {
+                            $value .= ")";
                         }
+
+                        $values[] = $value;
                     }
                 }
 
-                /**
-                 * Query to add permissions
-                 */
-                if (!empty($additions)) {
-                    $values = [];
-                    foreach ($additions as $type => $permissions) {
-                        foreach ($permissions as $i => $_) {
-                            $value = "( :_uid, '{$type}', :_add_{$type}_{$i}";
-
-                            if ($this->sharedTables) {
-                                $value .= ", :_tenant)";
-                            } else {
-                                $value .= ")";
-                            }
-
-                            $values[] = $value;
-                        }
-                    }
-
-                    $sql = "
+                $sql = "
 				    INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission
 				";
 
-                    if ($this->sharedTables) {
-                        $sql .= ', _tenant)';
-                    } else {
-                        $sql .= ')';
-                    }
+                if ($this->sharedTables) {
+                    $sql .= ', _tenant)';
+                } else {
+                    $sql .= ')';
+                }
 
-                    $sql .= " VALUES " . \implode(', ', $values);
+                $sql .= " VALUES " . \implode(', ', $values);
 
-                    $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
+                $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
-                    $stmtAddPermissions = $this->getPDO()->prepare($sql);
+                $stmtAddPermissions = $this->getPDO()->prepare($sql);
 
-                    $stmtAddPermissions->bindValue(":_uid", $document->getId());
+                $stmtAddPermissions->bindValue(":_uid", $document->getId());
 
-                    if ($this->sharedTables) {
-                        $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
-                    }
+                if ($this->sharedTables) {
+                    $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+                }
 
-                    foreach ($additions as $type => $permissions) {
-                        foreach ($permissions as $i => $permission) {
-                            $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
-                        }
+                foreach ($additions as $type => $permissions) {
+                    foreach ($permissions as $i => $permission) {
+                        $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
                     }
                 }
             }

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -235,7 +235,7 @@ class Pool extends Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
-    public function updateDocument(string $collection, string $id, Document $document, bool $skipPermissions): Document
+    public function updateDocument(string $collection, string $id, Document $document): Document
     {
         return $this->delegate(__FUNCTION__, \func_get_args());
     }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1047,12 +1047,12 @@ class Postgres extends SQL
      * @param string $collection
      * @param string $id
      * @param Document $document
-     * @param bool $skipPermissions
+     *
      * @return Document
      * @throws DatabaseException
      * @throws DuplicateException
      */
-    public function updateDocument(string $collection, string $id, Document $document, bool $skipPermissions): Document
+    public function updateDocument(string $collection, string $id, Document $document): Document
     {
         $attributes = $document->getAttributes();
         $attributes['_createdAt'] = $document->getCreatedAt();
@@ -1062,136 +1062,134 @@ class Postgres extends SQL
         $name = $this->filter($collection);
         $columns = '';
 
-        if (!$skipPermissions) {
-            $sql = "
+        $sql = "
 			SELECT _type, _permission
 			FROM {$this->getSQLTable($name . '_perms')}
 			WHERE _document = :_uid
 			{$this->getTenantQuery($collection)}
-			";
+		";
 
-            $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
+        $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
 
-            /**
-             * Get current permissions from the database
-             */
-            $permissionsStmt = $this->getPDO()->prepare($sql);
-            $permissionsStmt->bindValue(':_uid', $document->getId());
+        /**
+         * Get current permissions from the database
+         */
+        $permissionsStmt = $this->getPDO()->prepare($sql);
+        $permissionsStmt->bindValue(':_uid', $document->getId());
 
-            if ($this->sharedTables) {
-                $permissionsStmt->bindValue(':_tenant', $this->tenant);
+        if ($this->sharedTables) {
+            $permissionsStmt->bindValue(':_tenant', $this->tenant);
+        }
+
+        $this->execute($permissionsStmt);
+        $permissions = $permissionsStmt->fetchAll();
+        $permissionsStmt->closeCursor();
+
+        $initial = [];
+        foreach (Database::PERMISSIONS as $type) {
+            $initial[$type] = [];
+        }
+
+        $permissions = array_reduce($permissions, function (array $carry, array $item) {
+            $carry[$item['_type']][] = $item['_permission'];
+
+            return $carry;
+        }, $initial);
+
+        /**
+         * Get removed Permissions
+         */
+        $removals = [];
+        foreach (Database::PERMISSIONS as $type) {
+            $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
+            if (!empty($diff)) {
+                $removals[$type] = $diff;
             }
+        }
 
-            $this->execute($permissionsStmt);
-            $permissions = $permissionsStmt->fetchAll();
-            $permissionsStmt->closeCursor();
-
-            $initial = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $initial[$type] = [];
+        /**
+         * Get added Permissions
+         */
+        $additions = [];
+        foreach (Database::PERMISSIONS as $type) {
+            $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
+            if (!empty($diff)) {
+                $additions[$type] = $diff;
             }
+        }
 
-            $permissions = array_reduce($permissions, function (array $carry, array $item) {
-                $carry[$item['_type']][] = $item['_permission'];
-
-                return $carry;
-            }, $initial);
-
-            /**
-             * Get removed Permissions
-             */
-            $removals = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
-                if (!empty($diff)) {
-                    $removals[$type] = $diff;
-                }
-            }
-
-            /**
-             * Get added Permissions
-             */
-            $additions = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
-                if (!empty($diff)) {
-                    $additions[$type] = $diff;
-                }
-            }
-
-            /**
-             * Query to remove permissions
-             */
-            $removeQuery = '';
-            if (!empty($removals)) {
-                $removeQuery = ' AND (';
-                foreach ($removals as $type => $permissions) {
-                    $removeQuery .= "(
+        /**
+         * Query to remove permissions
+         */
+        $removeQuery = '';
+        if (!empty($removals)) {
+            $removeQuery = ' AND (';
+            foreach ($removals as $type => $permissions) {
+                $removeQuery .= "(
                     _type = '{$type}'
                     AND _permission IN (" . implode(', ', \array_map(fn (string $i) => ":_remove_{$type}_{$i}", \array_keys($permissions))) . ")
                 )";
-                    if ($type !== \array_key_last($removals)) {
-                        $removeQuery .= ' OR ';
-                    }
+                if ($type !== \array_key_last($removals)) {
+                    $removeQuery .= ' OR ';
                 }
             }
-            if (!empty($removeQuery)) {
-                $removeQuery .= ')';
+        }
+        if (!empty($removeQuery)) {
+            $removeQuery .= ')';
 
-                $sql = "
+            $sql = "
 				DELETE
                 FROM {$this->getSQLTable($name . '_perms')}
                 WHERE _document = :_uid
                 {$this->getTenantQuery($collection)}
 			";
 
-                $removeQuery = $sql . $removeQuery;
+            $removeQuery = $sql . $removeQuery;
 
-                $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
-                $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                $stmtRemovePermissions->bindValue(':_uid', $document->getId());
+            $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
+            $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
+            $stmtRemovePermissions->bindValue(':_uid', $document->getId());
 
-                if ($this->sharedTables) {
-                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+            if ($this->sharedTables) {
+                $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+            }
+
+            foreach ($removals as $type => $permissions) {
+                foreach ($permissions as $i => $permission) {
+                    $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
                 }
+            }
+        }
 
-                foreach ($removals as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
-                    }
+        /**
+         * Query to add permissions
+         */
+        if (!empty($additions)) {
+            $values = [];
+            foreach ($additions as $type => $permissions) {
+                foreach ($permissions as $i => $_) {
+                    $sqlTenant = $this->sharedTables ? ', :_tenant' : '';
+                    $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i} {$sqlTenant})";
                 }
             }
 
-            /**
-             * Query to add permissions
-             */
-            if (!empty($additions)) {
-                $values = [];
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $_) {
-                        $sqlTenant = $this->sharedTables ? ', :_tenant' : '';
-                        $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i} {$sqlTenant})";
-                    }
-                }
+            $sqlTenant = $this->sharedTables ? ', _tenant' : '';
 
-                $sqlTenant = $this->sharedTables ? ', _tenant' : '';
-
-                $sql = "
+            $sql = "
 				INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission {$sqlTenant})
 				VALUES" . \implode(', ', $values);
 
-                $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
+            $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
-                $stmtAddPermissions = $this->getPDO()->prepare($sql);
-                $stmtAddPermissions->bindValue(":_uid", $document->getId());
-                if ($this->sharedTables) {
-                    $stmtAddPermissions->bindValue(':_tenant', $this->tenant);
-                }
+            $stmtAddPermissions = $this->getPDO()->prepare($sql);
+            $stmtAddPermissions->bindValue(":_uid", $document->getId());
+            if ($this->sharedTables) {
+                $stmtAddPermissions->bindValue(':_tenant', $this->tenant);
+            }
 
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
-                    }
+            foreach ($additions as $type => $permissions) {
+                foreach ($permissions as $i => $permission) {
+                    $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
                 }
             }
         }

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -626,15 +626,16 @@ class SQLite extends MariaDB
     }
 
     /**
+     * Update Document
+     *
      * @param string $collection
-     * @param string $id
      * @param Document $document
-     * @param bool $skipPermissions
      * @return Document
-     * @throws DatabaseException
-     * @throws DuplicateException
+     * @throws Exception
+     * @throws PDOException
+     * @throws Duplicate
      */
-    public function updateDocument(string $collection, string $id, Document $document, bool $skipPermissions): Document
+    public function updateDocument(string $collection, string $id, Document $document): Document
     {
         $attributes = $document->getAttributes();
         $attributes['_createdAt'] = $document->getCreatedAt();
@@ -648,136 +649,134 @@ class SQLite extends MariaDB
         $name = $this->filter($collection);
         $columns = '';
 
-        if (!$skipPermissions) {
-            $sql = "
+        $sql = "
 			SELECT _type, _permission
 			FROM `{$this->getNamespace()}_{$name}_perms`
 			WHERE _document = :_uid
 			{$this->getTenantQuery($collection)}
 		";
 
-            $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
+        $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
 
-            /**
-             * Get current permissions from the database
-             */
-            $permissionsStmt = $this->getPDO()->prepare($sql);
-            $permissionsStmt->bindValue(':_uid', $document->getId());
+        /**
+         * Get current permissions from the database
+         */
+        $permissionsStmt = $this->getPDO()->prepare($sql);
+        $permissionsStmt->bindValue(':_uid', $document->getId());
 
-            if ($this->sharedTables) {
-                $permissionsStmt->bindValue(':_tenant', $this->tenant);
+        if ($this->sharedTables) {
+            $permissionsStmt->bindValue(':_tenant', $this->tenant);
+        }
+
+        $permissionsStmt->execute();
+        $permissions = $permissionsStmt->fetchAll();
+        $permissionsStmt->closeCursor();
+
+        $initial = [];
+        foreach (Database::PERMISSIONS as $type) {
+            $initial[$type] = [];
+        }
+
+        $permissions = array_reduce($permissions, function (array $carry, array $item) {
+            $carry[$item['_type']][] = $item['_permission'];
+
+            return $carry;
+        }, $initial);
+
+        /**
+         * Get removed Permissions
+         */
+        $removals = [];
+        foreach (Database::PERMISSIONS as $type) {
+            $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
+            if (!empty($diff)) {
+                $removals[$type] = $diff;
             }
+        }
 
-            $permissionsStmt->execute();
-            $permissions = $permissionsStmt->fetchAll();
-            $permissionsStmt->closeCursor();
-
-            $initial = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $initial[$type] = [];
+        /**
+         * Get added Permissions
+         */
+        $additions = [];
+        foreach (Database::PERMISSIONS as $type) {
+            $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
+            if (!empty($diff)) {
+                $additions[$type] = $diff;
             }
+        }
 
-            $permissions = array_reduce($permissions, function (array $carry, array $item) {
-                $carry[$item['_type']][] = $item['_permission'];
-
-                return $carry;
-            }, $initial);
-
-            /**
-             * Get removed Permissions
-             */
-            $removals = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
-                if (!empty($diff)) {
-                    $removals[$type] = $diff;
-                }
-            }
-
-            /**
-             * Get added Permissions
-             */
-            $additions = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
-                if (!empty($diff)) {
-                    $additions[$type] = $diff;
-                }
-            }
-
-            /**
-             * Query to remove permissions
-             */
-            $removeQuery = '';
-            if (!empty($removals)) {
-                $removeQuery = ' AND (';
-                foreach ($removals as $type => $permissions) {
-                    $removeQuery .= "(
+        /**
+         * Query to remove permissions
+         */
+        $removeQuery = '';
+        if (!empty($removals)) {
+            $removeQuery = ' AND (';
+            foreach ($removals as $type => $permissions) {
+                $removeQuery .= "(
                     _type = '{$type}'
                     AND _permission IN (" . implode(', ', \array_map(fn (string $i) => ":_remove_{$type}_{$i}", \array_keys($permissions))) . ")
                 )";
-                    if ($type !== \array_key_last($removals)) {
-                        $removeQuery .= ' OR ';
-                    }
+                if ($type !== \array_key_last($removals)) {
+                    $removeQuery .= ' OR ';
                 }
             }
-            if (!empty($removeQuery)) {
-                $removeQuery .= ')';
-                $sql = "
+        }
+        if (!empty($removeQuery)) {
+            $removeQuery .= ')';
+            $sql = "
 				DELETE
                 FROM `{$this->getNamespace()}_{$name}_perms`
                 WHERE _document = :_uid
                 {$this->getTenantQuery($collection)}
 			";
 
-                $removeQuery = $sql . $removeQuery;
-                $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
+            $removeQuery = $sql . $removeQuery;
+            $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
 
-                $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                $stmtRemovePermissions->bindValue(':_uid', $document->getId());
+            $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
+            $stmtRemovePermissions->bindValue(':_uid', $document->getId());
 
-                if ($this->sharedTables) {
-                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+            if ($this->sharedTables) {
+                $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+            }
+
+            foreach ($removals as $type => $permissions) {
+                foreach ($permissions as $i => $permission) {
+                    $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
                 }
+            }
+        }
 
-                foreach ($removals as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
-                    }
+        /**
+         * Query to add permissions
+         */
+        if (!empty($additions)) {
+            $values = [];
+            foreach ($additions as $type => $permissions) {
+                foreach ($permissions as $i => $_) {
+                    $tenantQuery = $this->sharedTables ? ', :_tenant' : '';
+                    $values[] = "(:_uid, '{$type}', :_add_{$type}_{$i} {$tenantQuery})";
                 }
             }
 
-            /**
-             * Query to add permissions
-             */
-            if (!empty($additions)) {
-                $values = [];
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $_) {
-                        $tenantQuery = $this->sharedTables ? ', :_tenant' : '';
-                        $values[] = "(:_uid, '{$type}', :_add_{$type}_{$i} {$tenantQuery})";
-                    }
-                }
+            $tenantQuery = $this->sharedTables ? ', _tenant' : '';
 
-                $tenantQuery = $this->sharedTables ? ', _tenant' : '';
-
-                $sql = "
+            $sql = "
 			   INSERT INTO `{$this->getNamespace()}_{$name}_perms` (_document, _type, _permission {$tenantQuery})
 			   VALUES " . \implode(', ', $values);
 
-                $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
+            $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
-                $stmtAddPermissions = $this->getPDO()->prepare($sql);
+            $stmtAddPermissions = $this->getPDO()->prepare($sql);
 
-                $stmtAddPermissions->bindValue(":_uid", $document->getId());
-                if ($this->sharedTables) {
-                    $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
-                }
+            $stmtAddPermissions->bindValue(":_uid", $document->getId());
+            if ($this->sharedTables) {
+                $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+            }
 
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
-                    }
+            foreach ($additions as $type => $permissions) {
+                foreach ($permissions as $i => $permission) {
+                    $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
                 }
             }
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4126,14 +4126,6 @@ class Database
                 fn () => $this->getDocument($collection->getId(), $id, forUpdate: true)
             ));
 
-            $originalPermissions = $old->getPermissions();
-            $currentPermissions  = $document->getPermissions();
-
-            sort($originalPermissions);
-            sort($currentPermissions);
-
-            $skipPermissionsUpdate = ($originalPermissions === $currentPermissions && $document->getAttribute('$permissions') !== null);
-
             $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
             $document['$collection'] = $old->getAttribute('$collection');   // Make sure user doesn't switch collection ID
             $document['$createdAt'] = $old->getCreatedAt();                 // Make sure user doesn't switch createdAt
@@ -4290,7 +4282,7 @@ class Database
                 $document = $this->silent(fn () => $this->updateDocumentRelationships($collection, $old, $document));
             }
 
-            $this->adapter->updateDocument($collection->getId(), $id, $document, $skipPermissionsUpdate);
+            $this->adapter->updateDocument($collection->getId(), $id, $document);
             $this->purgeCachedDocument($collection->getId(), $id);
 
             return $document;


### PR DESCRIPTION
Reverts utopia-php/database#611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * The document update process now always synchronizes permissions during updates. The option to skip permission handling has been removed, ensuring that permission changes are consistently applied whenever a document is updated. No changes to the user interface or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->