### PR TITLE
Fix many to many select across collections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ./dev/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.yml:/usr/src/code/docker-compose.yml
+    environment:
+      PHP_IDE_CONFIG: serverName=tests
 
   adminer:
     image: adminer

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3527,11 +3527,23 @@ class Database
 
                     $related = [];
                     if (!empty($relatedIds)) {
-                        $related = $this->find($relatedCollection->getId(), [
+                        $foundRelated = $this->find($relatedCollection->getId(), [
                             Query::equal('$id', $relatedIds),
                             Query::limit(PHP_INT_MAX),
                             ...$queries
                         ]);
+
+                        // Preserve the order of related documents to match the junction order
+                        $relatedById = [];
+                        foreach ($foundRelated as $doc) {
+                            $relatedById[$doc->getId()] = $doc;
+                        }
+
+                        foreach ($relatedIds as $relatedId) {
+                            if (isset($relatedById[$relatedId])) {
+                                $related[] = $relatedById[$relatedId];
+                            }
+                        }
                     }
 
                     $this->relationshipFetchDepth--;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4628,7 +4628,7 @@ class Database
                                     $this->skipRelationships(fn () => $this->updateDocument(
                                         $relatedCollection->getId(),
                                         $oldRelated->getId(),
-                                        $oldRelated->setAttribute($twoWayKey, null)
+                                        new Document([$twoWayKey => null])
                                     ));
                                 }
                                 break;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved efficiency when fetching many-to-many relationships, resulting in faster data retrieval.
  * Clarified error messages for invalid relationship values and cursor document collection mismatches.

* **Tests**
  * Added tests to verify that selection queries on many-to-many relationships return only requested fields, including nested relationships.

* **Chores**
  * Updated environment configuration for testing services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->