### PR TITLE
Fix encoding decoding

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6293,9 +6293,7 @@ class Database
         $attributes = $collection->getAttribute('attributes', []);
 
         foreach ($this->getInternalAttributes() as $attribute) {
-            if ($attribute['$id'] !== '$permissions') { // Don't encode permissions into a JSON string
-                $attributes[] = new Document($attribute);
-            }
+            $attributes[] = $attribute;
         }
 
         foreach ($attributes as $attribute) {
@@ -6304,6 +6302,13 @@ class Database
             $default = $attribute['default'] ?? null;
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key);
+
+            if ($attribute['$id'] === '$permissions') {
+                if (empty($value)){
+                    $document->setAttribute('$permissions', []); // set default value
+                }
+                continue;
+            }
 
             // Continue on optional param with no default
             if (is_null($value) && is_null($default)) {
@@ -6370,12 +6375,13 @@ class Database
         }
 
         foreach ($this->getInternalAttributes() as $attribute) {
-            if ($attribute['$id'] !== '$permissions') {
-                $attributes[] = new Document($attribute);
-            }
+            $attributes[] = $attribute;
         }
 
         foreach ($attributes as $attribute) {
+//            if ($attribute['$id'] === '$permissions') {
+//                continue;
+//            }
             $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $filters = $attribute['filters'] ?? [];
@@ -6428,12 +6434,13 @@ class Database
         $attributes = $collection->getAttribute('attributes', []);
 
         foreach ($this->getInternalAttributes() as $attribute) {
-            if ($attribute['$id'] !== '$permissions') {
-                $attributes[] = new Document($attribute);
-            }
+            $attributes[] = $attribute;
         }
 
         foreach ($attributes as $attribute) {
+//            if ($attribute['$id'] === '$permissions') {
+//                continue;
+//            }
             $key = $attribute['$id'] ?? '';
             $type = $attribute['type'] ?? '';
             $array = $attribute['array'] ?? false;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6303,7 +6303,7 @@ class Database
             $filters = $attribute['filters'] ?? [];
             $value = $document->getAttribute($key);
 
-            if ($attribute['$id'] === '$permissions') {
+            if ($key === '$permissions') {
                 if (empty($value)){
                     $document->setAttribute('$permissions', []); // set default value
                 }
@@ -6379,9 +6379,6 @@ class Database
         }
 
         foreach ($attributes as $attribute) {
-//            if ($attribute['$id'] === '$permissions') {
-//                continue;
-//            }
             $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $filters = $attribute['filters'] ?? [];
@@ -6398,11 +6395,11 @@ class Database
             $value = ($array) ? $value : [$value];
             $value = (is_null($value)) ? [] : $value;
 
-            foreach ($value as $k => $node) {
+            foreach ($value as $index => $node) {
                 foreach (array_reverse($filters) as $filter) {
                     $node = $this->decodeAttribute($filter, $node, $document, $key);
                 }
-                $value[$k] = $node;
+                $value[$index] = $node;
             }
 
             if (
@@ -6438,9 +6435,6 @@ class Database
         }
 
         foreach ($attributes as $attribute) {
-//            if ($attribute['$id'] === '$permissions') {
-//                continue;
-//            }
             $key = $attribute['$id'] ?? '';
             $type = $attribute['type'] ?? '';
             $array = $attribute['array'] ?? false;
@@ -6457,7 +6451,7 @@ class Database
                 $value = [$value];
             }
 
-            foreach ($value as $k => $node) {
+            foreach ($value as $index => $node) {
                 switch ($type) {
                     case self::VAR_BOOLEAN:
                         $node = (bool)$node;
@@ -6472,7 +6466,7 @@ class Database
                         break;
                 }
 
-                $value[$k] = $node;
+                $value[$index] = $node;
             }
 
             $document->setAttribute($key, ($array) ? $value : $value[0]);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6304,7 +6304,7 @@ class Database
             $value = $document->getAttribute($key);
 
             if ($key === '$permissions') {
-                if (empty($value)){
+                if (empty($value)) {
                     $document->setAttribute('$permissions', []); // set default value
                 }
                 continue;
@@ -6366,7 +6366,10 @@ class Database
         foreach ($relationships as $relationship) {
             $key = $relationship['$id'] ?? '';
 
-            if ($document->offsetExists($key) || $document->offsetExists($this->adapter->filter($key))) {
+            if (
+                \array_key_exists($key, (array)$document)
+                || \array_key_exists($this->adapter->filter($key), (array)$document)
+            ) {
                 $value = $document->getAttribute($key);
                 $value ??= $document->getAttribute($this->adapter->filter($key));
                 $document->removeAttribute($this->adapter->filter($key));

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4107,7 +4107,7 @@ class Database
             $old = Authorization::skip(fn () => $this->silent(
                 fn () => $this->getDocument($collection->getId(), $id, forUpdate: true)
             ));
-
+var_dump($document);
             $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
             $document['$collection'] = $old->getAttribute('$collection');   // Make sure user doesn't switch collection ID
             $document['$createdAt'] = $old->getCreatedAt();                 // Make sure user doesn't switch createdAt
@@ -4211,6 +4211,11 @@ class Database
 
                     // If values are not equal we need to update document.
                     if ($value !== $oldValue) {
+                        var_dump('==========================');
+                        var_dump($key);
+                        var_dump($oldValue);
+                        var_dump($value);
+
                         $shouldUpdate = true;
                         break;
                     }
@@ -6292,14 +6297,21 @@ class Database
     {
         $attributes = $collection->getAttribute('attributes', []);
 
-        $internalAttributes = \array_filter(Database::INTERNAL_ATTRIBUTES, function ($attribute) {
-            // We don't want to encode permissions into a JSON string
-            return $attribute['$id'] !== '$permissions';
-        });
+//        $internalAttributes = \array_filter(Database::INTERNAL_ATTRIBUTES, function ($attribute) {
+//            // We don't want to encode permissions into a JSON string
+//            return $attribute['$id'] !== '$permissions';
+//        });
 
-        $attributes = \array_merge($attributes, $internalAttributes);
+        //$attributes = \array_merge($attributes, $this->getInternalAttributes());
+        //$attributes = \array_merge($attributes, $internalAttributes);
+
+        $attributes += $this->getInternalAttributes();
 
         foreach ($attributes as $attribute) {
+            if ($attribute['$id'] === '$permissions') {
+                continue; // We don't want to encode permissions into a JSON string
+            }
+
             $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $default = $attribute['default'] ?? null;
@@ -6373,9 +6385,14 @@ class Database
             }
         }
 
-        $attributes = \array_merge($attributes, $this->getInternalAttributes());
+        //$attributes = \array_merge($attributes, $this->getInternalAttributes());
+        $attributes += $this->getInternalAttributes();
 
         foreach ($attributes as $attribute) {
+            if ($attribute['$id'] === '$permissions') {
+                continue;
+            }
+
             $key = $attribute['$id'] ?? '';
             $array = $attribute['array'] ?? false;
             $filters = $attribute['filters'] ?? [];
@@ -6426,9 +6443,15 @@ class Database
 
         $attributes = $collection->getAttribute('attributes', []);
 
-        $attributes = \array_merge($attributes, $this->getInternalAttributes());
+        $attributes += $this->getInternalAttributes();
+
+        //$attributes = \array_merge($attributes, $this->getInternalAttributes());
 
         foreach ($attributes as $attribute) {
+            if ($attribute['$id'] === '$permissions') {
+                continue;
+            }
+
             $key = $attribute['$id'] ?? '';
             $type = $attribute['type'] ?? '';
             $array = $attribute['array'] ?? false;

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6450,7 +6450,7 @@ class Database
                 $value = [$value];
             }
 
-            foreach ($value as &$node) {
+            foreach ($value as $k => $node) {
                 switch ($type) {
                     case self::VAR_BOOLEAN:
                         $node = (bool)$node;
@@ -6464,6 +6464,8 @@ class Database
                     default:
                         break;
                 }
+
+                $value[$k] = $node;
             }
 
             $document->setAttribute($key, ($array) ? $value : $value[0]);

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -27,11 +27,11 @@ class Document extends ArrayObject
      */
     public function __construct(array $input = [])
     {
-        if (isset($input['$id']) && !\is_string($input['$id'])) {
+        if (array_key_exists('$id', $input) && !\is_string($input['$id'])) {
             throw new StructureException('$id must be of type string');
         }
 
-        if (isset($input['$permissions']) && !is_array($input['$permissions'])) {
+        if (array_key_exists('$permissions', $input) && !is_array($input['$permissions'])) {
             throw new StructureException('$permissions must be of type array');
         }
 

--- a/tests/e2e/Adapter/Scopes/PermissionTests.php
+++ b/tests/e2e/Adapter/Scopes/PermissionTests.php
@@ -27,8 +27,8 @@ trait PermissionTests
 
         $document = $database->createDocument(__FUNCTION__, new Document());
 
-        $this->assertArrayNotHasKey('$permissions', $document);
-        $this->assertEquals(null, $document->getAttribute('$permissions'));
+        $this->assertArrayHasKey('$permissions', $document);
+        $this->assertEquals([], $document->getAttribute('$permissions'));
 
         $documents = [];
 
@@ -43,8 +43,8 @@ trait PermissionTests
 
         $this->assertEquals(2, $count);
         foreach ($results as $result) {
-            $this->assertArrayNotHasKey('$permissions', $result);
-            $this->assertEquals(null, $result->getAttribute('$permissions'));
+            $this->assertArrayHasKey('$permissions', $result);
+            $this->assertEquals([], $result->getAttribute('$permissions'));
         }
     }
 

--- a/tests/e2e/Adapter/Scopes/PermissionTests.php
+++ b/tests/e2e/Adapter/Scopes/PermissionTests.php
@@ -14,6 +14,40 @@ use Utopia\Database\Validator\Authorization;
 
 trait PermissionTests
 {
+    public function testCreateDocumentsEmptyPermission(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        $database->createCollection(__FUNCTION__);
+
+        /**
+         * Validate the decode function does not add $permissions null entry when no permissions are provided
+         */
+
+        $document = $database->createDocument(__FUNCTION__, new Document());
+
+        $this->assertArrayNotHasKey('$permissions', $document);
+        $this->assertEquals(null, $document->getAttribute('$permissions'));
+
+        $documents = [];
+
+        for ($i = 0; $i < 2; $i++) {
+            $documents[] = new Document();
+        }
+
+        $results = [];
+        $count = $database->createDocuments(__FUNCTION__, $documents, onNext: function ($doc) use (&$results) {
+            $results[] = $doc;
+        });
+
+        $this->assertEquals(2, $count);
+        foreach ($results as $result) {
+            $this->assertArrayNotHasKey('$permissions', $result);
+            $this->assertEquals(null, $result->getAttribute('$permissions'));
+        }
+    }
+
     public function testReadPermissionsFailure(): Document
     {
         Authorization::cleanRoles();


### PR DESCRIPTION
Fix Null permissions issue added in decode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of document permissions to ensure documents created without explicit permissions include a `$permissions` key set to an empty array.
  * Enhanced robustness in internal attribute processing by standardizing attribute handling and refining encoding and decoding of `$permissions`.
  * Strengthened validation of document attributes to correctly check presence and types of `$id` and `$permissions`.

* **Tests**
  * Added tests to verify that documents created without permissions contain a `$permissions` key with an empty array as its value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->