### PR TITLE
Revert "Merge pull request #627 from utopia-php/disable-array-index-m…

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -2001,9 +2001,6 @@ class MariaDB extends SQL
 
     public function getSupportForIndexArray(): bool
     {
-        /**
-         * Disabled to be compatible with Mysql adapter
-         */
-        return false;
+        return true;
     }
 }

--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -81,10 +81,9 @@ class MySQL extends MariaDB
     public function getSupportForIndexArray(): bool
     {
         /**
-         * Disabling index creation due to Mysql bug
          * @link https://bugs.mysql.com/bug.php?id=111037
          */
-        return false;
+        return true;
     }
 
     public function getSupportForCastIndexArray(): bool


### PR DESCRIPTION
…ysql"

This reverts commit 83278d663f9c63c25a11d9e71c7922da7ec48636, reversing changes made to eb2f759020bba617e99dd67973a9bd949b47f54e.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enabled index array support for MySQL and MariaDB adapters, allowing creation and use of array-based indexes.
  - Related cast-index array behavior now reflects the enabled index array support in MySQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->