### PR TITLE
Fix missing throw on no FTS on not search

### DIFF
--- a/src/Database/Validator/IndexedQueries.php
+++ b/src/Database/Validator/IndexedQueries.php
@@ -91,7 +91,10 @@ class IndexedQueries extends Queries
         $filters = $grouped['filters'];
 
         foreach ($filters as $filter) {
-            if ($filter->getMethod() === Query::TYPE_SEARCH) {
+            if (
+                $filter->getMethod() === Query::TYPE_SEARCH ||
+                $filter->getMethod() === Query::TYPE_NOT_SEARCH
+            ) {
                 $matched = false;
 
                 foreach ($this->indexes as $index) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Full-text filter validation now also applies to negated search filters, ensuring a matching full-text index is required. This prevents unindexed queries from bypassing validation and aligns behavior with standard search filters. Users may encounter clearer validation errors when using negated full-text filters without an appropriate index, prompting index creation for consistent performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->