### PR TITLE
Enhance permission handling in SQL adapter and add tests for document…

### DIFF
--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -369,6 +369,38 @@ trait DocumentTests
             $this->assertIsInt($document->getAttribute('bigint'));
             $this->assertEquals(9223372036854775807, $document->getAttribute('bigint'));
         }
+
+        // with different set of attributes
+        $colName = "docs_with_diff";
+        $database->createCollection($colName);
+        $database->createAttribute($colName, 'key', Database::VAR_STRING, 50, true);
+        $database->createAttribute($colName, 'value', Database::VAR_STRING, 50, false);
+        $permissions = [Permission::read(Role::any()), Permission::write(Role::any()),Permission::update(Role::any())];
+        $docs =  [
+            new Document([
+                '$id' => 'doc1',
+                'key' => 'doc1',
+            ]),
+            new Document([
+                '$id' => 'doc2',
+                'key' => 'doc2',
+            ]),
+            new Document([
+                '$id' => 'doc3',
+                '$permissions' => $permissions,
+                'key' => 'doc3',
+                'value' => 'test'
+            ]),
+        ];
+        $this->assertEquals(3, $database->createDocuments($colName, $docs));
+        // we should get only one document as read permission provided to the last document only
+        $addedDocs = $database->find($colName);
+        $this->assertCount(1, $addedDocs);
+        $doc = $addedDocs[0];
+        $this->assertEquals('doc3', $doc->getId());
+        $this->assertNotEmpty($doc->getPermissions());
+        $this->assertCount(3, $doc->getPermissions());
+        $database->deleteCollection($colName);
     }
 
     public function testCreateDocumentsWithAutoIncrement(): void


### PR DESCRIPTION
### Previous issue 

Case => Permissions not provided in any of the documents in the createDocuments

Problem => Invalid number of token in the sql query

Reason => 
* For each permission we are binding document to the bindkey
* if 5 documents and 4 permissions => 20 bindings 
* If shared table => then again 5 keys for each tenant
* Total binding keys => 25

During binding of the value
we were doing
```
$sqlPermissions = "
                    INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document {$tenantColumn})
                    VALUES {$permissions};
                ";
   
foreach ($documents as $index => $document) {
    $stmtPermissions->bindValue(":_uid_{$index}", $document->getId());
    if ($this->sharedTables) {
        $stmtPermissions->bindValue(":_tenant_{$index}", $document->getTenant());
    }
}
```
Here number of bindings => 5 document

Now added all the permissons in the sql statement but the value was going short

### Solution
Storing the binding key, values together in a separate array during the permission iteration itself