### PR TITLE
Don't wait to return empty

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4449,6 +4449,10 @@ class Database
             return $document;
         });
 
+        if ($document->isEmpty()) {
+            return $document;
+        }
+
         if ($this->resolveRelationships) {
             $document = $this->silent(fn () => $this->populateDocumentRelationships($collection, $document));
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5576,7 +5576,9 @@ class Database
             return $result;
         });
 
-        $this->trigger(self::EVENT_DOCUMENT_DELETE, $document);
+        if ($deleted) {
+            $this->trigger(self::EVENT_DOCUMENT_DELETE, $document);
+        }
 
         return $deleted;
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4275,6 +4275,9 @@ class Database
             $old = Authorization::skip(fn () => $this->silent(
                 fn () => $this->getDocument($collection->getId(), $id, forUpdate: true)
             ));
+            if ($old->isEmpty()) {
+                return new Document();
+            }
 
             $skipPermissionsUpdate = true;
 
@@ -4412,10 +4415,6 @@ class Database
                 } elseif (!$shouldUpdate && !$readValidator->isValid($readPermissions)) {
                     throw new AuthorizationException($readValidator->getDescription());
                 }
-            }
-
-            if ($old->isEmpty()) {
-                return new Document();
             }
 
             if ($shouldUpdate) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a non-existent document now cleanly returns an empty result, preventing downstream processing and avoiding unexpected errors.
  * Skips relationship population and decoding when an update yields no document, ensuring consistent, predictable responses.
  * Delete notifications/events are only emitted when a record is actually deleted, avoiding false signals and improving system reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->