### PR TITLE
Add support for schemaless attributes in Database and Structure classes

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3906,6 +3906,7 @@ class Database
             $this->adapter->getIdAttributeType(),
             $this->adapter->getMinDateTime(),
             $this->adapter->getMaxDateTime(),
+            $this->adapter->getSupportForAttributes()
         );
         if (!$structure->isValid($document)) {
             throw new StructureException($structure->getDescription());
@@ -4006,6 +4007,7 @@ class Database
                 $this->adapter->getIdAttributeType(),
                 $this->adapter->getMinDateTime(),
                 $this->adapter->getMaxDateTime(),
+                $this->adapter->getSupportForAttributes()
             );
             if (!$validator->isValid($document)) {
                 throw new StructureException($validator->getDescription());
@@ -4559,6 +4561,7 @@ class Database
                 $this->adapter->getIdAttributeType(),
                 $this->adapter->getMinDateTime(),
                 $this->adapter->getMaxDateTime(),
+                $this->adapter->getSupportForAttributes()
             );
             if (!$structureValidator->isValid($document)) { // Make sure updated structure still apply collection rules (if any)
                 throw new StructureException($structureValidator->getDescription());
@@ -4693,6 +4696,7 @@ class Database
             $this->adapter->getIdAttributeType(),
             $this->adapter->getMinDateTime(),
             $this->adapter->getMaxDateTime(),
+            $this->adapter->getSupportForAttributes()
         );
 
         if (!$validator->isValid($updates)) {
@@ -5404,6 +5408,7 @@ class Database
                 $this->adapter->getIdAttributeType(),
                 $this->adapter->getMinDateTime(),
                 $this->adapter->getMaxDateTime(),
+                $this->adapter->getSupportForAttributes()
             );
 
             if (!$validator->isValid($document)) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1411,6 +1411,7 @@ class Database
                 $this->adapter->getSupportForSpatialAttributes(),
                 $this->adapter->getSupportForSpatialIndexNull(),
                 $this->adapter->getSupportForSpatialIndexOrder(),
+                $this->adapter->getSupportForAttributes()
             );
             foreach ($indexes as $index) {
                 if (!$validator->isValid($index)) {
@@ -2420,6 +2421,7 @@ class Database
                         $this->adapter->getSupportForSpatialAttributes(),
                         $this->adapter->getSupportForSpatialIndexNull(),
                         $this->adapter->getSupportForSpatialIndexOrder(),
+                        $this->adapter->getSupportForAttributes()
                     );
 
                     foreach ($indexes as $index) {
@@ -3363,6 +3365,7 @@ class Database
                 $this->adapter->getSupportForSpatialAttributes(),
                 $this->adapter->getSupportForSpatialIndexNull(),
                 $this->adapter->getSupportForSpatialIndexOrder(),
+                $this->adapter->getSupportForAttributes()
             );
             if (!$validator->isValid($index)) {
                 throw new IndexException($validator->getDescription());
@@ -6402,6 +6405,7 @@ class Database
                 $this->maxQueryValues,
                 $this->adapter->getMinDateTime(),
                 $this->adapter->getMaxDateTime(),
+                $this->adapter->getSupportForAttributes()
             );
             if (!$validator->isValid($queries)) {
                 throw new QueryException($validator->getDescription());

--- a/src/Database/Validator/Index.php
+++ b/src/Database/Validator/Index.php
@@ -31,7 +31,6 @@ class Index extends Validator
     protected bool $spatialIndexOrderSupport;
 
     protected bool $supportForAttributes;
-
     /**
      * @param array<Document> $attributes
      * @param int $maxLength

--- a/src/Database/Validator/Queries/Documents.php
+++ b/src/Database/Validator/Queries/Documents.php
@@ -30,6 +30,7 @@ class Documents extends IndexedQueries
         int $maxValuesCount = 100,
         \DateTime $minAllowedDate = new \DateTime('0000-01-01'),
         \DateTime $maxAllowedDate = new \DateTime('9999-12-31'),
+        private bool $supportForAttributes = true
     ) {
         $attributes[] = new Document([
             '$id' => '$id',
@@ -66,9 +67,10 @@ class Documents extends IndexedQueries
                 $maxValuesCount,
                 $minAllowedDate,
                 $maxAllowedDate,
+                $this->supportForAttributes
             ),
-            new Order($attributes),
-            new Select($attributes),
+            new Order($attributes, $this->supportForAttributes),
+            new Select($attributes, $this->supportForAttributes),
         ];
 
         parent::__construct($attributes, $indexes, $validators);

--- a/src/Database/Validator/Queries/Documents.php
+++ b/src/Database/Validator/Queries/Documents.php
@@ -30,7 +30,7 @@ class Documents extends IndexedQueries
         int $maxValuesCount = 100,
         \DateTime $minAllowedDate = new \DateTime('0000-01-01'),
         \DateTime $maxAllowedDate = new \DateTime('9999-12-31'),
-        private bool $supportForAttributes = true
+        bool $supportForAttributes = true
     ) {
         $attributes[] = new Document([
             '$id' => '$id',
@@ -67,10 +67,10 @@ class Documents extends IndexedQueries
                 $maxValuesCount,
                 $minAllowedDate,
                 $maxAllowedDate,
-                $this->supportForAttributes
+                $supportForAttributes
             ),
-            new Order($attributes, $this->supportForAttributes),
-            new Select($attributes, $this->supportForAttributes),
+            new Order($attributes, $supportForAttributes),
+            new Select($attributes, $supportForAttributes),
         ];
 
         parent::__construct($attributes, $indexes, $validators);

--- a/src/Database/Validator/Query/Filter.php
+++ b/src/Database/Validator/Query/Filter.php
@@ -98,7 +98,6 @@ class Filter extends Base
         if (!$this->supportForAttributes && !isset($this->schema[$attribute])) {
             return true;
         }
-
         $attributeSchema = $this->schema[$attribute];
 
         if (count($values) > $this->maxValuesCount) {

--- a/src/Database/Validator/Query/Filter.php
+++ b/src/Database/Validator/Query/Filter.php
@@ -31,6 +31,7 @@ class Filter extends Base
         private readonly int $maxValuesCount = 100,
         private readonly \DateTime $minAllowedDate = new \DateTime('0000-01-01'),
         private readonly \DateTime $maxAllowedDate = new \DateTime('9999-12-31'),
+        private bool $supportForAttributes = true
     ) {
         foreach ($attributes as $attribute) {
             $this->schema[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute->getArrayCopy();
@@ -67,7 +68,7 @@ class Filter extends Base
         }
 
         // Search for attribute in schema
-        if (!isset($this->schema[$attribute])) {
+        if ($this->supportForAttributes && !isset($this->schema[$attribute])) {
             $this->message = 'Attribute not found in schema: ' . $attribute;
             return false;
         }
@@ -92,6 +93,10 @@ class Filter extends Base
             // For relationships, just validate the top level.
             // Utopia will validate each nested level during the recursive calls.
             $attribute = \explode('.', $attribute)[0];
+        }
+
+        if (!$this->supportForAttributes && !isset($this->schema[$attribute])) {
+            return true;
         }
 
         $attributeSchema = $this->schema[$attribute];

--- a/src/Database/Validator/Query/Order.php
+++ b/src/Database/Validator/Query/Order.php
@@ -11,12 +11,15 @@ class Order extends Base
      * @var array<int|string, mixed>
      */
     protected array $schema = [];
+    protected bool $supportForAttributes;
 
     /**
      * @param array<Document> $attributes
+     * @param bool $supportForAttributes
      */
-    public function __construct(array $attributes = [])
+    public function __construct(array $attributes = [], bool $supportForAttributes = true)
     {
+        $this->supportForAttributes = $supportForAttributes;
         foreach ($attributes as $attribute) {
             $this->schema[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute->getArrayCopy();
         }
@@ -29,7 +32,7 @@ class Order extends Base
     protected function isValidAttribute(string $attribute): bool
     {
         // Search for attribute in schema
-        if (!isset($this->schema[$attribute])) {
+        if ($this->supportForAttributes && !isset($this->schema[$attribute])) {
             $this->message = 'Attribute not found in schema: ' . $attribute;
             return false;
         }

--- a/src/Database/Validator/Query/Order.php
+++ b/src/Database/Validator/Query/Order.php
@@ -11,15 +11,13 @@ class Order extends Base
      * @var array<int|string, mixed>
      */
     protected array $schema = [];
-    protected bool $supportForAttributes;
 
     /**
      * @param array<Document> $attributes
      * @param bool $supportForAttributes
      */
-    public function __construct(array $attributes = [], bool $supportForAttributes = true)
+    public function __construct(array $attributes = [], protected bool $supportForAttributes = true)
     {
-        $this->supportForAttributes = $supportForAttributes;
         foreach ($attributes as $attribute) {
             $this->schema[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute->getArrayCopy();
         }

--- a/src/Database/Validator/Query/Select.php
+++ b/src/Database/Validator/Query/Select.php
@@ -12,6 +12,7 @@ class Select extends Base
      * @var array<int|string, mixed>
      */
     protected array $schema = [];
+    protected bool $supportForAttributes;
 
     /**
      * List of internal attributes
@@ -29,9 +30,11 @@ class Select extends Base
 
     /**
      * @param array<Document> $attributes
+     * @param bool $supportForAttributes
      */
-    public function __construct(array $attributes = [])
+    public function __construct(array $attributes = [], bool $supportForAttributes = true)
     {
+        $this->supportForAttributes = $supportForAttributes;
         foreach ($attributes as $attribute) {
             $this->schema[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute->getArrayCopy();
         }
@@ -89,7 +92,7 @@ class Select extends Base
                 continue;
             }
 
-            if (!isset($this->schema[$attribute]) && $attribute !== '*') {
+            if ($this->supportForAttributes && !isset($this->schema[$attribute]) && $attribute !== '*') {
                 $this->message = 'Attribute not found in schema: ' . $attribute;
                 return false;
             }

--- a/src/Database/Validator/Query/Select.php
+++ b/src/Database/Validator/Query/Select.php
@@ -12,7 +12,6 @@ class Select extends Base
      * @var array<int|string, mixed>
      */
     protected array $schema = [];
-    protected bool $supportForAttributes;
 
     /**
      * List of internal attributes
@@ -32,9 +31,8 @@ class Select extends Base
      * @param array<Document> $attributes
      * @param bool $supportForAttributes
      */
-    public function __construct(array $attributes = [], bool $supportForAttributes = true)
+    public function __construct(array $attributes = [], protected bool $supportForAttributes = true)
     {
-        $this->supportForAttributes = $supportForAttributes;
         foreach ($attributes as $attribute) {
             $this->schema[$attribute->getAttribute('key', $attribute->getAttribute('$id'))] = $attribute->getArrayCopy();
         }

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -86,6 +86,9 @@ class Structure extends Validator
             'filters' => [],
         ]
     ];
+    /**
+     * @var array<string,int>
+     */
     private array $internalAttributes = [];
 
     /**

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -252,11 +252,16 @@ class Structure extends Validator
      */
     protected function checkForAllRequiredValues(array $structure, array $attributes, array &$keys): bool
     {
+        if (!$this->supportForAttributes) {
+            return true;
+        }
+
         foreach ($attributes as $attribute) { // Check all required attributes are set
             $name = $attribute['$id'] ?? '';
             $required = $attribute['required'] ?? false;
 
             $keys[$name] = $attribute; // List of allowed attributes to help find unknown ones
+
             if ($required && !isset($structure[$name])) {
                 $this->message = 'Missing required attribute "'.$name.'"';
                 return false;

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -253,10 +253,6 @@ class Structure extends Validator
     protected function checkForAllRequiredValues(array $structure, array $attributes, array &$keys): bool
     {
         foreach ($attributes as $attribute) { // Check all required attributes are set
-            $isInternalAttribute = in_array($attribute['$id'], array_column($this->attributes, '$id'));
-            if (!$this->supportForAttributes && $isInternalAttribute) {
-                return true;
-            }
             $name = $attribute['$id'] ?? '';
             $required = $attribute['required'] ?? false;
 

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -86,10 +86,6 @@ class Structure extends Validator
             'filters' => [],
         ]
     ];
-    /**
-     * @var array<string,int>
-     */
-    private array $internalAttributes = [];
 
     /**
      * @var array<string, array{callback: callable, type: string}>
@@ -112,10 +108,6 @@ class Structure extends Validator
         private readonly \DateTime $maxAllowedDate = new \DateTime('9999-12-31'),
         private bool $supportForAttributes = true
     ) {
-        $this->internalAttributes = array_reduce($this->attributes, function ($carry, $attribute) {
-            $carry[$attribute['$id']] = 1;
-            return $carry;
-        }, []);
     }
 
     /**
@@ -261,8 +253,8 @@ class Structure extends Validator
     protected function checkForAllRequiredValues(array $structure, array $attributes, array &$keys): bool
     {
         foreach ($attributes as $key => $attribute) { // Check all required attributes are set
-            // schemaless adapter and not an internal attribute
-            if (!$this->supportForAttributes && !isset($this->internalAttributes[$key])) {
+            $isInternalAttribute = in_array($key, array_column($this->attributes, '$id'));
+            if (!$this->supportForAttributes && $isInternalAttribute) {
                 return true;
             }
             $name = $attribute['$id'] ?? '';

--- a/src/Database/Validator/Structure.php
+++ b/src/Database/Validator/Structure.php
@@ -252,8 +252,8 @@ class Structure extends Validator
      */
     protected function checkForAllRequiredValues(array $structure, array $attributes, array &$keys): bool
     {
-        foreach ($attributes as $key => $attribute) { // Check all required attributes are set
-            $isInternalAttribute = in_array($key, array_column($this->attributes, '$id'));
+        foreach ($attributes as $attribute) { // Check all required attributes are set
+            $isInternalAttribute = in_array($attribute['$id'], array_column($this->attributes, '$id'));
             if (!$this->supportForAttributes && $isInternalAttribute) {
                 return true;
             }

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -1470,20 +1470,28 @@ trait AttributeTests
         if ($database->getAdapter()->getSupportForIndexArray()) {
             try {
                 $database->createIndex($collection, 'indx', Database::INDEX_FULLTEXT, ['names']);
-                $this->fail('Failed to throw exception');
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    $this->fail('Failed to throw exception');
+                }
             } catch (Throwable $e) {
-                if ($database->getAdapter()->getSupportForFulltextIndex()) {
-                    $this->assertEquals('"Fulltext" index is forbidden on array attributes', $e->getMessage());
-                } else {
-                    $this->assertEquals('Fulltext index is not supported', $e->getMessage());
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    if ($database->getAdapter()->getSupportForFulltextIndex()) {
+                        $this->assertEquals('"Fulltext" index is forbidden on array attributes', $e->getMessage());
+                    } else {
+                        $this->assertEquals('Fulltext index is not supported', $e->getMessage());
+                    }
                 }
             }
 
             try {
                 $database->createIndex($collection, 'indx', Database::INDEX_KEY, ['numbers', 'names'], [100,100]);
-                $this->fail('Failed to throw exception');
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    $this->fail('Failed to throw exception');
+                }
             } catch (Throwable $e) {
-                $this->assertEquals('An index may only contain one array attribute', $e->getMessage());
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    $this->assertEquals('An index may only contain one array attribute', $e->getMessage());
+                }
             }
         }
 
@@ -1517,8 +1525,10 @@ trait AttributeTests
             $database->createIndex($collection, 'indx3', Database::INDEX_KEY, ['names'], [255], ['desc']);
 
             try {
-                $database->createIndex($collection, 'indx4', Database::INDEX_KEY, ['age', 'names'], [10, 255], []);
-                $this->fail('Failed to throw exception');
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    $database->createIndex($collection, 'indx4', Database::INDEX_KEY, ['age', 'names'], [10, 255], []);
+                    $this->fail('Failed to throw exception');
+                }
             } catch (Throwable $e) {
                 $this->assertEquals('Cannot set a length on "integer" attributes', $e->getMessage());
             }

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -394,6 +394,7 @@ trait AttributeTests
 
         if (!$database->getAdapter()->getSupportForAttributes()) {
             $this->expectNotToPerformAssertions();
+            return;
         }
 
         $database->updateAttributeRequired('flowers', 'inStock', true);
@@ -454,6 +455,7 @@ trait AttributeTests
         $database = static::getDatabase();
         if (!$database->getAdapter()->getSupportForAttributes()) {
             $this->expectNotToPerformAssertions();
+            return;
         }
         $database->createAttribute('flowers', 'price', Database::VAR_INTEGER, 0, false);
 
@@ -656,6 +658,7 @@ trait AttributeTests
         $database = static::getDatabase();
         if (!$database->getAdapter()->getSupportForAttributes()) {
             $this->expectNotToPerformAssertions();
+            return;
         }
 
         $database->createCollection('rename_test');

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -393,7 +393,7 @@ trait AttributeTests
         $database = static::getDatabase();
 
         if (!$database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schema-enforced adapters');
+            $this->expectNotToPerformAssertions();
         }
 
         $database->updateAttributeRequired('flowers', 'inStock', true);
@@ -453,7 +453,7 @@ trait AttributeTests
         /** @var Database $database */
         $database = static::getDatabase();
         if (!$database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schema-enforced adapters');
+            $this->expectNotToPerformAssertions();
         }
         $database->createAttribute('flowers', 'price', Database::VAR_INTEGER, 0, false);
 
@@ -655,7 +655,7 @@ trait AttributeTests
         /** @var Database $database */
         $database = static::getDatabase();
         if (!$database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schema-enforced adapters');
+            $this->expectNotToPerformAssertions();
         }
 
         $database->createCollection('rename_test');

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -392,6 +392,10 @@ trait AttributeTests
         /** @var Database $database */
         $database = static::getDatabase();
 
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->markTestSkipped('This test is only for schema-enforced adapters');
+        }
+
         $database->updateAttributeRequired('flowers', 'inStock', true);
 
         $this->expectExceptionMessage('Invalid document structure: Missing required attribute "inStock"');
@@ -448,7 +452,9 @@ trait AttributeTests
     {
         /** @var Database $database */
         $database = static::getDatabase();
-
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->markTestSkipped('This test is only for schema-enforced adapters');
+        }
         $database->createAttribute('flowers', 'price', Database::VAR_INTEGER, 0, false);
 
         $doc = $database->createDocument('flowers', new Document([
@@ -648,6 +654,9 @@ trait AttributeTests
     {
         /** @var Database $database */
         $database = static::getDatabase();
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->markTestSkipped('This test is only for schema-enforced adapters');
+        }
 
         $database->createCollection('rename_test');
 
@@ -1330,7 +1339,9 @@ trait AttributeTests
             $database->createDocument($collection, new Document([]));
             $this->fail('Failed to throw exception');
         } catch (Throwable $e) {
-            $this->assertEquals('Invalid document structure: Missing required attribute "booleans"', $e->getMessage());
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertEquals('Invalid document structure: Missing required attribute "booleans"', $e->getMessage());
+            }
         }
 
         $database->updateAttribute($collection, 'booleans', required: false);
@@ -1350,7 +1361,9 @@ trait AttributeTests
             ]));
             $this->fail('Failed to throw exception');
         } catch (Throwable $e) {
-            $this->assertEquals('Invalid document structure: Attribute "short[\'0\']" has invalid type. Value must be a valid string and no longer than 5 chars', $e->getMessage());
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertEquals('Invalid document structure: Attribute "short[\'0\']" has invalid type. Value must be a valid string and no longer than 5 chars', $e->getMessage());
+            }
         }
 
         try {
@@ -1359,7 +1372,9 @@ trait AttributeTests
             ]));
             $this->fail('Failed to throw exception');
         } catch (Throwable $e) {
-            $this->assertEquals('Invalid document structure: Attribute "names[\'1\']" has invalid type. Value must be a valid string and no longer than 255 chars', $e->getMessage());
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertEquals('Invalid document structure: Attribute "names[\'1\']" has invalid type. Value must be a valid string and no longer than 255 chars', $e->getMessage());
+            }
         }
 
         try {
@@ -1368,7 +1383,9 @@ trait AttributeTests
             ]));
             $this->fail('Failed to throw exception');
         } catch (Throwable $e) {
-            $this->assertEquals('Invalid document structure: Attribute "age" has invalid type. Value must be a valid integer', $e->getMessage());
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertEquals('Invalid document structure: Attribute "age" has invalid type. Value must be a valid integer', $e->getMessage());
+            }
         }
 
         try {
@@ -1377,7 +1394,9 @@ trait AttributeTests
             ]));
             $this->fail('Failed to throw exception');
         } catch (Throwable $e) {
-            $this->assertEquals('Invalid document structure: Attribute "age" has invalid type. Value must be a valid range between 0 and 2,147,483,647', $e->getMessage());
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertEquals('Invalid document structure: Attribute "age" has invalid type. Value must be a valid range between 0 and 2,147,483,647', $e->getMessage());
+            }
         }
 
         $database->createDocument($collection, new Document([
@@ -1566,17 +1585,22 @@ trait AttributeTests
         $database = static::getDatabase();
 
         $database->createCollection('datetime');
-
-        $this->assertEquals(true, $database->createAttribute('datetime', 'date', Database::VAR_DATETIME, 0, true, null, true, false, null, [], ['datetime']));
-        $this->assertEquals(true, $database->createAttribute('datetime', 'date2', Database::VAR_DATETIME, 0, false, null, true, false, null, [], ['datetime']));
+        if ($database->getAdapter()->getSupportForAttributes()) {
+            $this->assertEquals(true, $database->createAttribute('datetime', 'date', Database::VAR_DATETIME, 0, true, null, true, false, null, [], ['datetime']));
+            $this->assertEquals(true, $database->createAttribute('datetime', 'date2', Database::VAR_DATETIME, 0, false, null, true, false, null, [], ['datetime']));
+        }
 
         try {
             $database->createDocument('datetime', new Document([
                 'date' => ['2020-01-01'], // array
             ]));
-            $this->fail('Failed to throw exception');
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->fail('Failed to throw exception');
+            }
         } catch (Exception $e) {
-            $this->assertInstanceOf(StructureException::class, $e);
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertInstanceOf(StructureException::class, $e);
+            }
         }
 
         $doc = $database->createDocument('datetime', new Document([
@@ -1619,20 +1643,29 @@ trait AttributeTests
 
         try {
             $database->createDocument('datetime', new Document([
-                'date' => "1975-12-06 00:00:61" // 61 seconds is invalid
+                '$id' => 'datenew1',
+                'date' => "1975-12-06 00:00:61", // 61 seconds is invalid,
             ]));
-            $this->fail('Failed to throw exception');
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->fail('Failed to throw exception');
+            }
         } catch (Exception $e) {
-            $this->assertInstanceOf(StructureException::class, $e);
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertInstanceOf(StructureException::class, $e);
+            }
         }
 
         try {
             $database->createDocument('datetime', new Document([
                 'date' => '+055769-02-14T17:56:18.000Z'
             ]));
-            $this->fail('Failed to throw exception');
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->fail('Failed to throw exception');
+            }
         } catch (Exception $e) {
-            $this->assertInstanceOf(StructureException::class, $e);
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->assertInstanceOf(StructureException::class, $e);
+            }
         }
 
         $invalidDates = [
@@ -1656,10 +1689,14 @@ trait AttributeTests
                 $database->find('datetime', [
                     Query::equal('date', [$date])
                 ]);
-                $this->fail('Failed to throw exception');
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    $this->fail('Failed to throw exception');
+                }
             } catch (Throwable $e) {
-                $this->assertTrue($e instanceof QueryException);
-                $this->assertEquals('Invalid query: Query value is invalid for attribute "date"', $e->getMessage());
+                if ($database->getAdapter()->getSupportForAttributes()) {
+                    $this->assertTrue($e instanceof QueryException);
+                    $this->assertEquals('Invalid query: Query value is invalid for attribute "date"', $e->getMessage());
+                }
             }
         }
 

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -1474,12 +1474,10 @@ trait AttributeTests
                     $this->fail('Failed to throw exception');
                 }
             } catch (Throwable $e) {
-                if ($database->getAdapter()->getSupportForAttributes()) {
-                    if ($database->getAdapter()->getSupportForFulltextIndex()) {
-                        $this->assertEquals('"Fulltext" index is forbidden on array attributes', $e->getMessage());
-                    } else {
-                        $this->assertEquals('Fulltext index is not supported', $e->getMessage());
-                    }
+                if ($database->getAdapter()->getSupportForFulltextIndex()) {
+                    $this->assertEquals('"Fulltext" index is forbidden on array attributes', $e->getMessage());
+                } else {
+                    $this->assertEquals('Fulltext index is not supported', $e->getMessage());
                 }
             }
 
@@ -1491,6 +1489,8 @@ trait AttributeTests
             } catch (Throwable $e) {
                 if ($database->getAdapter()->getSupportForAttributes()) {
                     $this->assertEquals('An index may only contain one array attribute', $e->getMessage());
+                } else {
+                    $this->assertEquals('Index already exists', $e->getMessage());
                 }
             }
         }
@@ -1703,10 +1703,8 @@ trait AttributeTests
                     $this->fail('Failed to throw exception');
                 }
             } catch (Throwable $e) {
-                if ($database->getAdapter()->getSupportForAttributes()) {
-                    $this->assertTrue($e instanceof QueryException);
-                    $this->assertEquals('Invalid query: Query value is invalid for attribute "date"', $e->getMessage());
-                }
+                $this->assertTrue($e instanceof QueryException);
+                $this->assertEquals('Invalid query: Query value is invalid for attribute "date"', $e->getMessage());
             }
         }
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -5169,7 +5169,8 @@ trait DocumentTests
 
             $database->createIndex('documents', 'fulltext_integer', Database::INDEX_FULLTEXT, ['string','integer_signed']);
         } else {
-            $this->markTestSkipped('This test is only for schema based adapters');
+            $this->expectNotToPerformAssertions();
+            return;
         }
     }
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -6054,7 +6054,7 @@ trait DocumentTests
         $database->deleteCollection($colName);
     }
 
-    public function testSchemalessCreateDocumentWithExtraAttribute()
+    public function testSchemalessDocumentOperation(): void
     {
         /** @var Database $database */
         $database = static::getDatabase();
@@ -6152,7 +6152,45 @@ trait DocumentTests
         $database->deleteCollection($colName);
     }
 
-    public function testSchemaEnforcedDocumentCreation()
+    public function testSchemalessDocumentInvalidInteralAttributeValidation(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        // test to ensure internal attributes are checked during creating schemaless document
+        if ($database->getAdapter()->getSupportForAttributes()) {
+            $this->markTestSkipped('This test is only for schemaless adapters');
+        }
+
+        $colName = uniqid("schemaless");
+        $database->createCollection($colName);
+        try {
+            $docs = [
+                new Document(['$id' => true, 'freeA' => 'doc1']),
+                new Document(['$id' => true, 'freeB' => 'test']),
+                new Document(['$id' => true]),
+            ];
+            $database->createDocuments($colName, $docs);
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(StructureException::class, $e);
+        }
+
+        try {
+            $docs = [
+                new Document(['$createdAt' => true, 'freeA' => 'doc1']),
+                new Document(['$updatedAt' => true, 'freeB' => 'test']),
+                new Document(['$permissions' => 12]),
+            ];
+            $database->createDocuments($colName, $docs);
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(StructureException::class, $e);
+        }
+
+        $database->deleteCollection($colName);
+
+    }
+
+    public function testSchemaEnforcedDocumentCreation(): void
     {
         /** @var Database $database */
         $database = static::getDatabase();

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -6070,7 +6070,8 @@ trait DocumentTests
         $database = static::getDatabase();
 
         if ($database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schemaless adapters');
+            $this->expectNotToPerformAssertions();
+            return;
         }
 
         $colName = uniqid("schemaless");
@@ -6169,7 +6170,8 @@ trait DocumentTests
 
         // test to ensure internal attributes are checked during creating schemaless document
         if ($database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schemaless adapters');
+            $this->expectNotToPerformAssertions();
+            return;
         }
 
         $colName = uniqid("schemaless");
@@ -6207,6 +6209,7 @@ trait DocumentTests
 
         if (!$database->getAdapter()->getSupportForAttributes()) {
             $this->expectNotToPerformAssertions();
+            return;
         }
 
         $colName = uniqid("schema");

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -6206,7 +6206,7 @@ trait DocumentTests
         $database = static::getDatabase();
 
         if (!$database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schema-enforced adapters');
+            $this->expectNotToPerformAssertions();
         }
 
         $colName = uniqid("schema");

--- a/tests/e2e/Adapter/Scopes/GeneralTests.php
+++ b/tests/e2e/Adapter/Scopes/GeneralTests.php
@@ -95,6 +95,9 @@ trait GeneralTests
 
         /** @var Database $database */
         $database = static::getDatabase();
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->markTestSkipped('This test is only for schema based adapters');
+        }
 
         $database->setPreserveDates(true);
 
@@ -190,6 +193,9 @@ trait GeneralTests
 
         /** @var Database $database */
         $database = static::getDatabase();
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->markTestSkipped('This test is only for schema based adapters');
+        }
 
         $database->setPreserveDates(true);
 

--- a/tests/e2e/Adapter/Scopes/GeneralTests.php
+++ b/tests/e2e/Adapter/Scopes/GeneralTests.php
@@ -96,7 +96,8 @@ trait GeneralTests
         /** @var Database $database */
         $database = static::getDatabase();
         if (!$database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schema based adapters');
+            $this->expectNotToPerformAssertions();
+            return;
         }
 
         $database->setPreserveDates(true);
@@ -194,7 +195,8 @@ trait GeneralTests
         /** @var Database $database */
         $database = static::getDatabase();
         if (!$database->getAdapter()->getSupportForAttributes()) {
-            $this->markTestSkipped('This test is only for schema based adapters');
+            $this->expectNotToPerformAssertions();
+            return;
         }
 
         $database->setPreserveDates(true);

--- a/tests/e2e/Adapter/Scopes/IndexTests.php
+++ b/tests/e2e/Adapter/Scopes/IndexTests.php
@@ -249,7 +249,9 @@ trait IndexTests
 
         try {
             $database->createCollection($collection->getId(), $attributes, $indexes);
-            $this->fail('Failed to throw exception');
+            if ($database->getAdapter()->getSupportForAttributes()) {
+                $this->fail('Failed to throw exception');
+            }
         } catch (Exception $e) {
             $this->assertEquals($errorMessage, $e->getMessage());
         }


### PR DESCRIPTION
## Schema behaviour
### Previous
Structure Validations were coming for collection attributes along with the internal attributes resulting to structure exceptions for free form document structure in the mongodb adapter

### Current
Structure validations happening for the internal attributes only and not for the free form document in the mongodb

## Attributes and query behaviour
### Previous
Previously due to attributes metadata storage , validations were able to able run and validations were getting done on the each attribute. 
Same for query

### Current
For mongodb, the attributes validation are getting skipped -> data directly getting dumped in the underlying db.
For query, we can query on both existing and non existing fields

## Index
Same for index