### PR TITLE
Delete schema fails

### DIFF
--- a/tests/e2e/Adapter/Scopes/GeneralTests.php
+++ b/tests/e2e/Adapter/Scopes/GeneralTests.php
@@ -424,7 +424,9 @@ trait GeneralTests
 
     public function testSharedTablesTenantPerDocument(): void
     {
+        /** @var Database $database */
         $database = static::getDatabase();
+
         $sharedTables = $database->getSharedTables();
         $tenantPerDocument = $database->getTenantPerDocument();
         $namespace = $database->getNamespace();
@@ -435,8 +437,13 @@ trait GeneralTests
             return;
         }
 
-        if ($database->exists(__FUNCTION__)) {
+        try {
+            /**
+             * MirrorTest returning false $database->exists(__FUNCTION__)
+             */
             $database->delete(__FUNCTION__);
+        } catch (\Throwable $e) {
+
         }
 
         $database


### PR DESCRIPTION
Seems like MirrorTest returning false on $database->exists(__FUNCTION__)

So $database->delete(__FUNCTION__); 
does not happen