### PR TITLE
Fix bulk update encoding with defaults

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5013,7 +5013,6 @@ class Database
         $updatedAt = $updates->getUpdatedAt();
         $updates['$updatedAt'] = ($updatedAt === null || !$this->preserveDates) ? DateTime::now() : $updatedAt;
 
-        $updates = $this->encode($collection, $updates);
         // Check new document structure
         $validator = new PartialStructure(
             $collection,

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -6433,4 +6433,109 @@ trait DocumentTests
 
         $database->deleteCollection($collectionId);
     }
+
+    public function testUpdateDocumentsSuccessiveCallsDoNotResetDefaults(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForBatchOperations()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $collectionId = 'successive_updates';
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
+        // Create collection with two attributes that have default values
+        $database->createCollection($collectionId);
+        $database->createAttribute($collectionId, 'attrA', Database::VAR_STRING, 50, false, 'defaultA');
+        $database->createAttribute($collectionId, 'attrB', Database::VAR_STRING, 50, false, 'defaultB');
+
+        // Create a document without setting attrA or attrB (should use defaults)
+        $doc = $database->createDocument($collectionId, new Document([
+            '$id' => 'testdoc',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+            ],
+        ]));
+
+        // Verify initial defaults
+        $this->assertEquals('defaultA', $doc->getAttribute('attrA'));
+        $this->assertEquals('defaultB', $doc->getAttribute('attrB'));
+
+        // First update: set attrA to a new value
+        $count = $database->updateDocuments($collectionId, new Document([
+            'attrA' => 'updatedA',
+        ]));
+        $this->assertEquals(1, $count);
+
+        // Verify attrA was updated
+        $doc = $database->getDocument($collectionId, 'testdoc');
+        $this->assertEquals('updatedA', $doc->getAttribute('attrA'));
+        $this->assertEquals('defaultB', $doc->getAttribute('attrB'));
+
+        // Second update: set attrB to a new value
+        $count = $database->updateDocuments($collectionId, new Document([
+            'attrB' => 'updatedB',
+        ]));
+        $this->assertEquals(1, $count);
+
+        // Verify attrB was updated AND attrA is still 'updatedA' (not reset to 'defaultA')
+        $doc = $database->getDocument($collectionId, 'testdoc');
+        $this->assertEquals('updatedA', $doc->getAttribute('attrA'), 'attrA should not be reset to default');
+        $this->assertEquals('updatedB', $doc->getAttribute('attrB'));
+
+        $database->deleteCollection($collectionId);
+    }
+
+    public function testUpdateDocumentSuccessiveCallsDoNotResetDefaults(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        $collectionId = 'successive_update_single';
+        Authorization::cleanRoles();
+        Authorization::setRole(Role::any()->toString());
+
+        // Create collection with two attributes that have default values
+        $database->createCollection($collectionId);
+        $database->createAttribute($collectionId, 'attrA', Database::VAR_STRING, 50, false, 'defaultA');
+        $database->createAttribute($collectionId, 'attrB', Database::VAR_STRING, 50, false, 'defaultB');
+
+        // Create a document without setting attrA or attrB (should use defaults)
+        $doc = $database->createDocument($collectionId, new Document([
+            '$id' => 'testdoc',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+            ],
+        ]));
+
+        // Verify initial defaults
+        $this->assertEquals('defaultA', $doc->getAttribute('attrA'));
+        $this->assertEquals('defaultB', $doc->getAttribute('attrB'));
+
+        // First update: set attrA to a new value
+        $doc = $database->updateDocument($collectionId, 'testdoc', new Document([
+            '$id' => 'testdoc',
+            'attrA' => 'updatedA',
+        ]));
+        $this->assertEquals('updatedA', $doc->getAttribute('attrA'));
+        $this->assertEquals('defaultB', $doc->getAttribute('attrB'));
+
+        // Second update: set attrB to a new value
+        $doc = $database->updateDocument($collectionId, 'testdoc', new Document([
+            '$id' => 'testdoc',
+            'attrB' => 'updatedB',
+        ]));
+
+        // Verify attrB was updated AND attrA is still 'updatedA' (not reset to 'defaultA')
+        $this->assertEquals('updatedA', $doc->getAttribute('attrA'), 'attrA should not be reset to default');
+        $this->assertEquals('updatedB', $doc->getAttribute('attrB'));
+
+        $database->deleteCollection($collectionId);
+    }
 }

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -4355,7 +4355,7 @@ trait RelationshipTests
             Query::lessThan('author.age', 30),
             Query::equal('published', [true]),
         ]);
-        $this->assertEquals(1, $count); // Only Bob's published post
+        $this->assertEquals(1, $count);
 
         // Count posts by author name (different author)
         $count = $database->count('postsCount', [
@@ -4380,13 +4380,13 @@ trait RelationshipTests
             Query::lessThan('author.age', 30),
             Query::equal('published', [true]),
         ]);
-        $this->assertEquals(150, $sum); // Only Bob's published post
+        $this->assertEquals(150, $sum);
 
         // Sum views for Bob's posts
         $sum = $database->sum('postsCount', 'views', [
             Query::equal('author.name', ['Bob']),
         ]);
-        $this->assertEquals(225, $sum); // 150 + 75
+        $this->assertEquals(225, $sum);
 
         // Sum with no matches
         $sum = $database->sum('postsCount', 'views', [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Successive document updates no longer reset attributes with default values; updates now preserve defaults and previously set values for single and batch operations.

* **Tests**
  * Added end-to-end tests verifying defaults persist across successive batch and single-document updates.
  * Minor test cleanup to improve readability of assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->