### PR TITLE
Non null arrays to allow index usage

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -980,6 +980,13 @@ abstract class Adapter
     abstract public function getSupportForCastIndexArray(): bool;
 
     /**
+     * Does the adapter use GIN indexes for array columns?
+     *
+     * @return bool
+     */
+    abstract public function getSupportForGinIndex(): bool;
+
+    /**
      * Is unique index supported?
      *
      * @return bool

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1684,7 +1684,7 @@ class MariaDB extends SQL
             return $this->getSpatialSQLType($type, $required);
         }
         if ($array === true) {
-            return 'JSON';
+            return 'JSON NOT NULL DEFAULT (JSON_ARRAY())';
         }
 
         switch ($type) {
@@ -2082,12 +2082,12 @@ class MariaDB extends SQL
             case Operator::TYPE_ARRAY_APPEND:
                 $bindKey = "op_{$bindIndex}";
                 $bindIndex++;
-                return "{$quotedColumn} = JSON_MERGE_PRESERVE(IFNULL({$quotedColumn}, JSON_ARRAY()), :$bindKey)";
+                return "{$quotedColumn} = JSON_MERGE_PRESERVE({$quotedColumn}, :$bindKey)";
 
             case Operator::TYPE_ARRAY_PREPEND:
                 $bindKey = "op_{$bindIndex}";
                 $bindIndex++;
-                return "{$quotedColumn} = JSON_MERGE_PRESERVE(:$bindKey, IFNULL({$quotedColumn}, JSON_ARRAY()))";
+                return "{$quotedColumn} = JSON_MERGE_PRESERVE(:$bindKey, {$quotedColumn})";
 
             case Operator::TYPE_ARRAY_INSERT:
                 $indexKey = "op_{$bindIndex}";

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -3221,6 +3221,11 @@ class Mongo extends Adapter
         return false;
     }
 
+    public function getSupportForGinIndex(): bool
+    {
+        return false;
+    }
+
     public function getSupportForUpserts(): bool
     {
         return true;

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -388,6 +388,11 @@ class Pool extends Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
+    public function getSupportForGinIndex(): bool
+    {
+        return $this->delegate(__FUNCTION__, \func_get_args());
+    }
+
     public function getSupportForUniqueIndex(): bool
     {
         return $this->delegate(__FUNCTION__, \func_get_args());

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -2142,6 +2142,11 @@ class Postgres extends SQL
         return true;
     }
 
+    public function getSupportForGinIndex(): bool
+    {
+        return true;
+    }
+
     /**
      * Does the adapter handle Query Array Overlaps?
      *

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1545,6 +1545,11 @@ abstract class SQL extends Adapter
         return false;
     }
 
+    public function getSupportForGinIndex(): bool
+    {
+        return false;
+    }
+
     public function getSupportForRelationships(): bool
     {
         return true;

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -2599,8 +2599,12 @@ abstract class SQL extends Adapter
             $spatialAttributes = $this->getSpatialAttributes($collection);
 
             $attributeDefaults = [];
+            $arrayAttributes = [];
             foreach ($collection->getAttribute('attributes', []) as $attr) {
                 $attributeDefaults[$attr['$id']] = $attr['default'] ?? null;
+                if ($attr['array'] ?? false) {
+                    $arrayAttributes[$attr['$id']] = true;
+                }
             }
 
             $collection = $collection->getId();
@@ -2670,6 +2674,11 @@ abstract class SQL extends Adapter
 
                     foreach ($allColumnNames as $attributeKey) {
                         $attrValue = $currentRegularAttributes[$attributeKey] ?? null;
+
+                        // Array columns are NOT NULL DEFAULT '[]', so coerce null to empty array
+                        if ($attrValue === null && isset($arrayAttributes[$attributeKey])) {
+                            $attrValue = '[]';
+                        }
 
                         if (\is_array($attrValue)) {
                             $attrValue = \json_encode($attrValue);
@@ -2797,6 +2806,11 @@ abstract class SQL extends Adapter
 
                         foreach ($allColumnNames as $attributeKey) {
                             $attrValue = $currentRegularAttributes[$attributeKey] ?? null;
+
+                            // Array columns are NOT NULL DEFAULT '[]', so coerce null to empty array
+                            if ($attrValue === null && isset($arrayAttributes[$attributeKey])) {
+                                $attrValue = '[]';
+                            }
 
                             if (\is_array($attrValue)) {
                                 $attrValue = \json_encode($attrValue);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8200,6 +8200,12 @@ class Database
 
             // Continue on optional param with no default
             if (is_null($value) && is_null($default)) {
+                // Non-required array columns are NOT NULL with DEFAULT '[]', so coerce null to empty array.
+                // Required arrays must remain null so the Structure validator catches the missing value.
+                $required = $attribute['required'] ?? false;
+                if ($array && !$required) {
+                    $document->setAttribute($key, []);
+                }
                 continue;
             }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8202,8 +8202,9 @@ class Database
             if (is_null($value) && is_null($default)) {
                 // Non-required array columns are NOT NULL with DEFAULT '[]', so coerce null to empty array.
                 // Required arrays must remain null so the Structure validator catches the missing value.
+                // Only coerce when applying defaults (inserts) to avoid clearing existing values during partial updates.
                 $required = $attribute['required'] ?? false;
-                if ($array && !$required) {
+                if ($applyDefaults && $array && !$required) {
                     $document->setAttribute($key, []);
                 }
                 continue;

--- a/tests/e2e/Adapter/Base.php
+++ b/tests/e2e/Adapter/Base.php
@@ -50,6 +50,11 @@ abstract class Base extends TestCase
     abstract protected function getDatabase(): Database;
 
     /**
+     * @return \Utopia\Database\PDO|\PDO|null
+     */
+    abstract protected function getPDO(): mixed;
+
+    /**
      * @param string $collection
      * @param string $column
      *

--- a/tests/e2e/Adapter/MariaDBTest.php
+++ b/tests/e2e/Adapter/MariaDBTest.php
@@ -52,6 +52,11 @@ class MariaDBTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getDatabase() . "`.`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/MirrorTest.php
+++ b/tests/e2e/Adapter/MirrorTest.php
@@ -313,6 +313,11 @@ class MirrorTest extends Base
         $this->assertTrue($database->getDestination()->getDocument('testDeleteMirroredDocument', $document->getId())->isEmpty());
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$sourcePdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . self::$source->getDatabase() . "`.`" . self::$source->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/MongoDBTest.php
+++ b/tests/e2e/Adapter/MongoDBTest.php
@@ -98,6 +98,11 @@ class MongoDBTest extends Base
         $this->assertTrue(true);
     }
 
+    protected function getPDO(): mixed
+    {
+        return null;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         return true;

--- a/tests/e2e/Adapter/MySQLTest.php
+++ b/tests/e2e/Adapter/MySQLTest.php
@@ -58,6 +58,11 @@ class MySQLTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getDatabase() . "`.`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/PoolTest.php
+++ b/tests/e2e/Adapter/PoolTest.php
@@ -79,6 +79,18 @@ class PoolTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        $pdo = null;
+        self::$pool->use(function (Adapter $adapter) use (&$pdo) {
+            $class = new ReflectionClass($adapter);
+            $property = $class->getProperty('pdo');
+            $property->setAccessible(true);
+            $pdo = $property->getValue($adapter);
+        });
+        return $pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getDatabase() . "`.`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/PostgresTest.php
+++ b/tests/e2e/Adapter/PostgresTest.php
@@ -51,6 +51,11 @@ class PostgresTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = '"' . $this->getDatabase()->getDatabase(). '"."' . $this->getDatabase()->getNamespace() . '_' . $collection . '"';

--- a/tests/e2e/Adapter/SQLiteTest.php
+++ b/tests/e2e/Adapter/SQLiteTest.php
@@ -55,6 +55,11 @@ class SQLiteTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -1620,10 +1620,11 @@ trait AttributeTests
                 $this->assertEquals('Invalid query: Cannot query contains on attribute "age" because it is not an array, string, or object.', $e->getMessage());
             }
 
+            // Array columns are NOT NULL with DEFAULT empty array, so isNull returns nothing
             $documents = $database->find($collection, [
                 Query::isNull('long_size')
             ]);
-            $this->assertCount(1, $documents);
+            $this->assertCount(0, $documents);
 
             $documents = $database->find($collection, [
                 Query::contains('tv_show', ['love'])

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -569,10 +569,10 @@ trait CollectionTests
 
         $attribute = $attributes['string_list'];
         $this->assertEquals('string_list', $attribute['$id']);
-        $this->assertTrue(in_array($attribute['dataType'], ['json', 'longtext'])); // mysql vs maria
-        $this->assertTrue(in_array($attribute['columnType'], ['json', 'longtext']));
+        $this->assertTrue(in_array($attribute['dataType'], ['json', 'jsonb', 'longtext']));
+        $this->assertTrue(in_array($attribute['columnType'], ['json', 'jsonb', 'longtext']));
         $this->assertTrue(in_array($attribute['characterMaximumLength'], [null, '4294967295']));
-        $this->assertEquals('YES', $attribute['isNullable']);
+        $this->assertEquals('NO', $attribute['isNullable']);
 
         $attribute = $attributes['dob'];
         $this->assertEquals('dob', $attribute['$id']);

--- a/tests/e2e/Adapter/Scopes/IndexTests.php
+++ b/tests/e2e/Adapter/Scopes/IndexTests.php
@@ -1150,7 +1150,7 @@ trait IndexTests
         $ns = $database->getNamespace();
         $db = $database->getDatabase();
 
-        if ($adapter instanceof \Utopia\Database\Adapter\Postgres) {
+        if ($adapter->getSupportForGinIndex()) {
             $table = "\"{$db}\".\"{$ns}_{$collection}\"";
 
             // Verify GIN index exists

--- a/tests/e2e/Adapter/Scopes/IndexTests.php
+++ b/tests/e2e/Adapter/Scopes/IndexTests.php
@@ -1048,4 +1048,148 @@ trait IndexTests
         // Cleanup
         $database->deleteCollection($col);
     }
+
+    /**
+     * Verifies that array attributes backed by JSON columns are created as
+     * NOT NULL DEFAULT (empty array). This is required because:
+     *
+     * 1. MySQL bug #111037: the optimizer can skip functional indexes
+     *    (CAST ... AS ARRAY) on nullable columns in complex query plans.
+     * 2. Correctness: JSON_CONTAINS(NULL, ...) returns NULL, not FALSE,
+     *    so rows with NULL array columns are invisible to both positive
+     *    and negative array queries (containsAny / notContains).
+     *
+     * @link https://bugs.mysql.com/bug.php?id=111037
+     */
+    public function testArrayAttributeNotNullSchema(): void
+    {
+        $database = $this->getDatabase();
+        $adapter = $database->getAdapter();
+
+        if (!$adapter->getSupportForSchemaAttributes()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $collection = 'arrayNotNull';
+
+        $database->createCollection($collection, permissions: [
+            Permission::create(Role::any()),
+            Permission::read(Role::any()),
+        ]);
+
+        $database->createAttribute($collection, 'tags', Database::VAR_STRING, 255, false, array: true);
+
+        // Verify the physical column is NOT NULL via INFORMATION_SCHEMA
+        $pdo = $this->getPDO();
+
+        $ns = $database->getNamespace();
+        $db = $database->getDatabase();
+        $tableName = "{$ns}_{$collection}";
+
+        $stmt = $pdo->prepare(
+            'SELECT IS_NULLABLE, COLUMN_DEFAULT '
+            . 'FROM INFORMATION_SCHEMA.COLUMNS '
+            . 'WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?'
+        );
+        $stmt->execute([$db, $tableName, 'tags']);
+        $col = $stmt->fetch(\PDO::FETCH_ASSOC);
+        // PostgreSQL returns lowercase keys from INFORMATION_SCHEMA
+        $col = $col ? \array_change_key_case($col, CASE_UPPER) : false;
+
+        $this->assertNotFalse($col, 'Column "tags" should exist in INFORMATION_SCHEMA');
+        $this->assertEquals(
+            'NO',
+            $col['IS_NULLABLE'],
+            'Array (JSON) column must be NOT NULL so the optimizer can use multi-valued indexes '
+            . 'and JSON_CONTAINS/JSON_OVERLAPS never encounter NULL'
+        );
+
+        $database->deleteCollection($collection);
+    }
+
+    /**
+     * Verifies that the index on an array attribute is picked by the
+     * optimizer and that queries return correct results.
+     */
+    public function testArrayIndexUsedInQuery(): void
+    {
+        $database = $this->getDatabase();
+        $adapter = $database->getAdapter();
+
+        if (!$adapter->getSupportForCastIndexArray()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $collection = 'arrayIndexExplain';
+
+        $database->createCollection($collection, permissions: [
+            Permission::create(Role::any()),
+            Permission::read(Role::any()),
+        ]);
+
+        $database->createAttribute($collection, 'tags', Database::VAR_STRING, 255, false, array: true);
+        $database->createIndex($collection, 'idx_tags', Database::INDEX_KEY, ['tags'], [255]);
+
+        // Insert enough documents for the optimizer to prefer the index over a full table scan
+        $documents = [];
+        for ($i = 0; $i < 500; $i++) {
+            $documents[] = new Document([
+                '$id' => ID::unique(),
+                '$permissions' => [Permission::read(Role::any())],
+                'tags' => ['tag_' . ($i % 50), 'common'],
+            ]);
+        }
+
+        foreach (\array_chunk($documents, 100) as $chunk) {
+            $database->createDocuments($collection, $chunk);
+        }
+
+        $pdo = $this->getPDO();
+        $ns = $database->getNamespace();
+        $db = $database->getDatabase();
+
+        if ($adapter instanceof \Utopia\Database\Adapter\Postgres) {
+            $table = "\"{$db}\".\"{$ns}_{$collection}\"";
+
+            // Verify GIN index exists
+            $stmt = $pdo->prepare(
+                "SELECT indexdef FROM pg_indexes WHERE tablename = ? AND indexname LIKE ?"
+            );
+            $stmt->execute(["{$ns}_{$collection}", '%idx_tags%']);
+            $indexDef = $stmt->fetchColumn();
+            $this->assertNotFalse($indexDef, 'GIN index should exist for array column');
+            $this->assertStringContainsString('gin', \strtolower($indexDef), 'Index on array column should be a GIN index');
+        } else {
+            $table = "`{$db}`.`{$ns}_{$collection}`";
+
+            $pdo->prepare("ANALYZE TABLE {$table}")->execute();
+
+            $sql = "EXPLAIN SELECT * FROM {$table} WHERE JSON_CONTAINS(`tags`, '[\"tag_1\"]')";
+            $stmt = $pdo->prepare($sql);
+            $stmt->execute();
+            $explain = $stmt->fetchAll();
+
+            $usedKey = $explain[0]['key'] ?? null;
+            $this->assertNotNull(
+                $usedKey,
+                'MySQL should use an index for JSON_CONTAINS on a NOT NULL JSON column. '
+                . "EXPLAIN output:\n" . \print_r($explain, true)
+            );
+            $this->assertStringContainsString(
+                'idx_tags',
+                $usedKey,
+                "Expected the 'idx_tags' index to be used. EXPLAIN output:\n" . \print_r($explain, true)
+            );
+        }
+
+        // Verify the query also returns correct functional results
+        $results = $database->find($collection, [
+            Query::containsAny('tags', ['tag_1']),
+        ]);
+        $this->assertCount(10, $results);
+
+        $database->deleteCollection($collection);
+    }
 }

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -157,7 +157,7 @@ trait RelationshipTests
             'price' => 1000,
             'dateOfBirth' => '1975-06-12',
             'isActive' => true,
-            'integers' => null,
+            'integers' => [],
             'email' => null,
             'enum' => null,
             'ip' => '255.0.0.1',

--- a/tests/e2e/Adapter/SharedTables/MariaDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MariaDBTest.php
@@ -67,6 +67,11 @@ class MariaDBTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getDatabase() . "`.`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/SharedTables/MongoDBTest.php
+++ b/tests/e2e/Adapter/SharedTables/MongoDBTest.php
@@ -100,6 +100,11 @@ class MongoDBTest extends Base
         $this->assertTrue(true);
     }
 
+    protected function getPDO(): mixed
+    {
+        return null;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         return true;

--- a/tests/e2e/Adapter/SharedTables/MySQLTest.php
+++ b/tests/e2e/Adapter/SharedTables/MySQLTest.php
@@ -69,6 +69,11 @@ class MySQLTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getDatabase() . "`.`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";

--- a/tests/e2e/Adapter/SharedTables/PostgresTest.php
+++ b/tests/e2e/Adapter/SharedTables/PostgresTest.php
@@ -64,6 +64,11 @@ class PostgresTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = '"' . $this->getDatabase()->getDatabase() . '"."' . $this->getDatabase()->getNamespace() . '_' . $collection . '"';

--- a/tests/e2e/Adapter/SharedTables/SQLiteTest.php
+++ b/tests/e2e/Adapter/SharedTables/SQLiteTest.php
@@ -70,6 +70,11 @@ class SQLiteTest extends Base
         return self::$database = $database;
     }
 
+    protected function getPDO(): mixed
+    {
+        return self::$pdo;
+    }
+
     protected function deleteColumn(string $collection, string $column): bool
     {
         $sqlTable = "`" . $this->getDatabase()->getNamespace() . "_" . $collection . "`";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Indexing now prefers appropriate index types for JSON/array attributes; adapters expose Gin/index capability flags.

* **Bug Fixes**
  * JSON/JSONB-backed array attributes are NOT NULL with an empty-array default.
  * Array append/prepend now merge directly with provided values.
  * Upserts/coercion ensure optional array nulls are coerced to empty arrays where applicable.

* **Tests**
  * Added e2e and regression tests for array-schema, index usage, encoding/upsert behavior, and test DB accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->