### PR TITLE
Nested subqueries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk update && apk add --no-cache \
     gcc \
     g++ \
     linux-headers \
- && docker-php-ext-install opcache pgsql \
+ && docker-php-ext-install opcache pgsql pdo_mysql pdo_pgsql \
  && apk del libpq-dev \
  && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,18 @@ FROM appwrite/utopia-base:php-8.4-1.0.0 AS compile
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apk update && apk add --no-cache \
+    libpq \
     libpq-dev \
     make \
     automake \
     autoconf \
     gcc \
     g++ \
+    git \
+    brotli-dev \
     linux-headers \
+    docker-cli \
+    docker-cli-compose \
  && docker-php-ext-install opcache pgsql pdo_mysql pdo_pgsql \
  && apk del libpq-dev \
  && rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install \
     --no-scripts \
     --prefer-dist
 
-FROM appwrite/utopia-base:8.4-1.0.0 AS compile
+FROM appwrite/utopia-base:php-8.4-1.0.0 AS compile
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,30 +17,14 @@ FROM appwrite/utopia-base:php-8.4-1.0.0 AS compile
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apk update && apk add --no-cache \
-    libpq \
     libpq-dev \
     make \
     automake \
     autoconf \
     gcc \
     g++ \
-    git \
-    brotli-dev \
     linux-headers \
-    docker-cli \
-    docker-cli-compose \
- && (pecl install mongodb-$PHP_MONGODB_VERSION \
-    || (git clone --depth 1 --branch $PHP_MONGODB_VERSION --recurse-submodules https://github.com/mongodb/mongo-php-driver.git /tmp/mongodb \
-      && cd /tmp/mongodb \
-      && git submodule update --init --recursive \
-      && phpize \
-      && ./configure \
-      && make \
-      && make install \
-      && cd / \
-      && rm -rf /tmp/mongodb)) \
- && docker-php-ext-enable mongodb \
- && docker-php-ext-install opcache pgsql pdo_mysql pdo_pgsql \
+ && docker-php-ext-install opcache pgsql \
  && apk del libpq-dev \
  && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.8 AS composer
+FROM composer:2 AS composer
 
 WORKDIR /usr/local/src/
 
@@ -12,12 +12,8 @@ RUN composer install \
     --no-scripts \
     --prefer-dist
 
-FROM php:8.4.18-cli-alpine3.22 AS compile
+FROM appwrite/utopia-base:8.4-1.0.0 AS compile
 
-ENV PHP_REDIS_VERSION="6.3.0" \
-    PHP_SWOOLE_VERSION="v6.1.6" \
-    PHP_XDEBUG_VERSION="3.4.2" \
-    PHP_MONGODB_VERSION="2.1.1"
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apk update && apk add --no-cache \
@@ -48,23 +44,6 @@ RUN apk update && apk add --no-cache \
  && apk del libpq-dev \
  && rm -rf /var/cache/apk/*
 
-# Redis Extension
-FROM compile AS redis
-RUN \
-  git clone --depth 1 --branch $PHP_REDIS_VERSION https://github.com/phpredis/phpredis.git \
-  && cd phpredis \
-  && phpize \
-  && ./configure \
-  && make && make install
-
-## Swoole Extension
-FROM compile AS swoole
-RUN \
-  git clone --depth 1 --branch $PHP_SWOOLE_VERSION https://github.com/swoole/swoole-src.git \
-  && cd swoole-src \
-  && phpize \
-  && ./configure --enable-http2 \
-  && make && make install
 
 ## PCOV Extension
 FROM compile AS pcov
@@ -75,14 +54,6 @@ RUN \
    && ./configure --enable-pcov \
    && make && make install
 
-## XDebug Extension
-FROM compile AS xdebug
-RUN \
-  git clone --depth 1 --branch $PHP_XDEBUG_VERSION https://github.com/xdebug/xdebug && \
-  cd xdebug && \
-  phpize && \
-  ./configure && \
-  make && make install
 
 FROM compile AS final
 
@@ -93,8 +64,6 @@ ENV DEBUG=$DEBUG
 
 WORKDIR /usr/src/code
 
-RUN echo extension=redis.so >> /usr/local/etc/php/conf.d/redis.ini
-RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini
 RUN echo extension=pcov.so >> /usr/local/etc/php/conf.d/pcov.ini
 RUN echo extension=xdebug.so >> /usr/local/etc/php/conf.d/xdebug.ini
 
@@ -105,10 +74,6 @@ RUN echo "opcache.enable_cli=1" >> $PHP_INI_DIR/php.ini
 RUN echo "memory_limit=1024M" >> $PHP_INI_DIR/php.ini
 
 COPY --from=composer /usr/local/src/vendor /usr/src/code/vendor
-COPY --from=swoole /usr/local/lib/php/extensions/no-debug-non-zts-20240924/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-COPY --from=redis /usr/local/lib/php/extensions/no-debug-non-zts-20240924/redis.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-COPY --from=pcov /usr/local/lib/php/extensions/no-debug-non-zts-20240924/pcov.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-COPY --from=xdebug /usr/local/lib/php/extensions/no-debug-non-zts-20240924/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
 
 COPY ./bin /usr/src/code/bin
 COPY ./src /usr/src/code/src

--- a/bin/bench_m2m.php
+++ b/bin/bench_m2m.php
@@ -1,0 +1,335 @@
+<?php
+
+/**
+ * Standalone M2M Relationship Query Benchmark
+ *
+ * Seeds data and benchmarks M2M relationship query patterns.
+ * Run with: php bin/bench_m2m.php
+ *
+ * Requires MariaDB on localhost:8703 (docker compose up -d mariadb)
+ */
+
+ini_set('memory_limit', '2G');
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Utopia\Cache\Adapter\None as NoCache;
+use Utopia\Cache\Cache;
+use Utopia\Database\Adapter\MariaDB;
+use Utopia\Database\Adapter\SQL;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+use Utopia\Database\PDO;
+use Utopia\Database\Query;
+use Utopia\Database\Validator\Authorization;
+
+// --- Config ---
+$dbHost = getenv('MARIADB_HOST') ?: 'mariadb';
+$dbPort = getenv('MARIADB_PORT') ?: '3306';
+$numAuthors          = 500;
+$numArticlesPerAuthor = 50; // total articles = 500 * 50 = 25000
+$warmup   = 3;
+$runs     = 20;
+$dbName   = 'bench_m2m';
+$namespace = '_bench';
+
+// --- Setup ---
+echo "=== M2M Relationship Query Benchmark ===\n\n";
+
+$pdo = new PDO(
+    "mysql:host={$dbHost};port={$dbPort};charset=utf8mb4",
+    'root',
+    'password',
+    SQL::getPDOAttributes()
+);
+
+$cache = new Cache(new NoCache());
+$authorization = new Authorization();
+$authorization->addRole(Role::any()->toString());
+$authorization->setDefaultStatus(true);
+
+$database = new Database(new MariaDB($pdo), $cache);
+$database
+    ->setAuthorization($authorization)
+    ->setDatabase($dbName)
+    ->setNamespace($namespace);
+
+// Fresh database
+if ($database->exists($dbName)) {
+    $database->delete($dbName);
+}
+$database->create();
+
+// Schema
+$database->createCollection('authors', permissions: [
+    Permission::create(Role::any()),
+    Permission::read(Role::any()),
+]);
+$database->createAttribute('authors', 'name', Database::VAR_STRING, 256, true);
+
+$database->createCollection('articles', permissions: [
+    Permission::create(Role::any()),
+    Permission::read(Role::any()),
+]);
+$database->createAttribute('articles', 'title', Database::VAR_STRING, 256, true);
+$database->createAttribute('articles', 'genre', Database::VAR_STRING, 256, true);
+$database->createIndex('articles', 'idx_genre', Database::INDEX_KEY, ['genre']);
+
+$database->createRelationship(
+    'authors',
+    'articles',
+    Database::RELATION_MANY_TO_MANY,
+    true,
+    onDelete: Database::RELATION_MUTATE_SET_NULL
+);
+
+// --- Seed Data ---
+echo "Seeding: {$numAuthors} authors x {$numArticlesPerAuthor} articles = "
+   . ($numAuthors * $numArticlesPerAuthor) . " total articles\n";
+
+$genres = ['fashion', 'food', 'travel', 'music', 'lifestyle', 'fitness', 'diy', 'sports', 'finance'];
+$names  = ['Alice', 'Bob', 'Carol', 'Dave', 'Eve', 'Frank', 'Grace', 'Heidi', 'Ivan', 'Judy'];
+
+$allArticleIds = [];
+
+for ($a = 0; $a < $numAuthors; $a++) {
+    $articles = [];
+    for ($i = 0; $i < $numArticlesPerAuthor; $i++) {
+        $articleId = 'art_' . str_pad($a, 3, '0', STR_PAD_LEFT) . '_' . str_pad($i, 3, '0', STR_PAD_LEFT);
+        $articles[] = new Document([
+            '$id' => $articleId,
+            'title' => 'Article ' . ($i + 1) . ' by Author ' . $a,
+            'genre' => $genres[array_rand($genres)],
+        ]);
+        $allArticleIds[] = $articleId;
+    }
+
+    $database->createDocument('authors', new Document([
+        '$id' => 'author_' . str_pad($a, 3, '0', STR_PAD_LEFT),
+        'name' => $names[$a % count($names)] . ' ' . $a,
+        'articles' => $articles,
+        '$permissions' => ['read("any")'],
+    ]));
+
+    if (($a + 1) % 10 === 0) {
+        echo "  Created {$a}/{$numAuthors} authors...\n";
+    }
+}
+
+echo "  Seeding complete: " . count($allArticleIds) . " articles, {$numAuthors} authors\n\n";
+
+// --- Benchmark ---
+function bench(string $label, callable $fn, int $warmup, int $runs): void
+{
+    for ($i = 0; $i < $warmup; $i++) {
+        $fn();
+    }
+
+    $times = [];
+    $resultCount = 0;
+    for ($i = 0; $i < $runs; $i++) {
+        $start = hrtime(true);
+        $result = $fn();
+        $times[] = (hrtime(true) - $start) / 1e6;
+        $resultCount = is_countable($result) ? count($result) : 0;
+    }
+
+    sort($times);
+    $n = count($times);
+    $median = $times[(int)($n / 2)];
+    $mean   = array_sum($times) / $n;
+    $min    = $times[0];
+    $p95    = $times[(int)($n * 0.95)];
+
+    printf(
+        "  %-45s  median: %7.1f ms  mean: %7.1f ms  min: %7.1f ms  p95: %7.1f ms  (%d docs)\n",
+        $label,
+        $median, $mean, $min, $p95,
+        $resultCount
+    );
+}
+
+echo "Benchmarking ({$warmup} warmup + {$runs} measured runs each):\n\n";
+
+// =======================================
+// GENERAL QUERIES (no relationship traversal)
+// =======================================
+echo "--- General Queries (plain find, no relationship traversal) ---\n\n";
+
+// getDocument
+bench(
+    "getDocument('articles', id)",
+    fn () => $database->getDocument('articles', $allArticleIds[0]),
+    $warmup, $runs
+);
+
+// skipRelationships find (raw, no population)
+bench(
+    "find('articles') skip-rels limit(100)",
+    fn () => $database->skipRelationships(fn () => $database->find('articles', [Query::limit(100)])),
+    $warmup, $runs
+);
+bench(
+    "find('articles') skip-rels limit(1000)",
+    fn () => $database->skipRelationships(fn () => $database->find('articles', [Query::limit(1000)])),
+    $warmup, $runs
+);
+bench(
+    "find('articles') skip-rels limit(5000)",
+    fn () => $database->skipRelationships(fn () => $database->find('articles', [Query::limit(5000)])),
+    $warmup, $runs
+);
+
+// find WITH relationship population (authors populated on each article)
+bench(
+    "find('articles') + rels limit(100)",
+    fn () => $database->find('articles', [Query::limit(100)]),
+    $warmup, $runs
+);
+bench(
+    "find('articles') + rels limit(500)",
+    fn () => $database->find('articles', [Query::limit(500)]),
+    $warmup, $runs
+);
+
+// find authors WITH relationship population (articles populated on each author)
+bench(
+    "find('authors') + rels limit(25)",
+    fn () => $database->find('authors', [Query::limit(25)]),
+    $warmup, $runs
+);
+bench(
+    "find('authors') + rels limit(100)",
+    fn () => $database->find('authors', [Query::limit(100)]),
+    $warmup, $runs
+);
+
+// Filter queries (no relationship traversal)
+bench(
+    "find('articles') genre='fashion' skip-rels",
+    fn () => $database->skipRelationships(fn () => $database->find('articles', [
+        Query::equal('genre', ['fashion']),
+        Query::limit(5000),
+    ])),
+    $warmup, $runs
+);
+
+// Pagination
+bench(
+    "paginate('articles') skip-rels 100/page",
+    function () use ($database) {
+        $cursor = null;
+        $total = 0;
+        do {
+            $queries = [Query::limit(100)];
+            if ($cursor !== null) {
+                $queries[] = Query::cursorAfter($cursor);
+            }
+            $docs = $database->skipRelationships(fn () => $database->find('articles', $queries));
+            $count = count($docs);
+            $total += $count;
+            if ($count > 0) {
+                $cursor = $docs[$count - 1];
+            }
+        } while ($count === 100);
+        return range(1, $total);
+    },
+    $warmup, $runs
+);
+
+echo "\n--- M2M Relationship Queries ---\n\n";
+
+// Pick IDs
+$singleArticleId = $allArticleIds[0];
+$threeArticleIds = [$allArticleIds[0], $allArticleIds[1], $allArticleIds[2]];
+$twoArticleIds   = [$allArticleIds[0], $allArticleIds[1]];
+
+// 1) equal('articles.$id', [single])
+bench(
+    "equal('articles.\$id', [1 val])",
+    fn () => $database->find('authors', [
+        Query::equal('articles.$id', [$singleArticleId]),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 2) equal('articles.$id', [3 values])
+bench(
+    "equal('articles.\$id', [3 vals])",
+    fn () => $database->find('authors', [
+        Query::equal('articles.$id', $threeArticleIds),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 3) containsAll('articles.$id', [2 values])
+bench(
+    "containsAll('articles.\$id', [2 vals])",
+    fn () => $database->find('authors', [
+        Query::containsAll('articles.$id', $twoArticleIds),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 4) Reverse: find articles by author
+bench(
+    "equal('authors.\$id', [1 val]) [reverse]",
+    fn () => $database->find('articles', [
+        Query::equal('authors.$id', ['author_000']),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 5) equal('articles.$id', [1]) + attribute filter
+bench(
+    "equal('articles.\$id', [1]) + equal('name')",
+    fn () => $database->find('authors', [
+        Query::equal('articles.$id', [$singleArticleId]),
+        Query::equal('name', ['Alice 0']),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 6) Non-$id attribute query (genre) — not optimized by subquery, baseline comparison
+bench(
+    "equal('articles.genre', ['fashion'])",
+    fn () => $database->find('authors', [
+        Query::equal('articles.genre', ['fashion']),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 7) Genre query with select (no relationship population)
+bench(
+    "equal('articles.genre', ['fashion']) + select",
+    fn () => $database->find('authors', [
+        Query::equal('articles.genre', ['fashion']),
+        Query::select(['$id', 'name']),
+        Query::limit(5000),
+    ]),
+    $warmup, $runs
+);
+
+// 8) Genre query with small limit
+bench(
+    "equal('articles.genre', ['fashion']) + limit(5)",
+    fn () => $database->find('authors', [
+        Query::equal('articles.genre', ['fashion']),
+        Query::limit(5),
+    ]),
+    $warmup, $runs
+);
+
+echo "\n=== Done ===\n";
+
+// Cleanup
+$database->delete($dbName);
+echo "Database cleaned up.\n";

--- a/bin/bench_m2m.php
+++ b/bin/bench_m2m.php
@@ -146,7 +146,10 @@ function bench(string $label, callable $fn, int $warmup, int $runs): void
     printf(
         "  %-45s  median: %7.1f ms  mean: %7.1f ms  min: %7.1f ms  p95: %7.1f ms  (%d docs)\n",
         $label,
-        $median, $mean, $min, $p95,
+        $median,
+        $mean,
+        $min,
+        $p95,
         $resultCount
     );
 }
@@ -162,48 +165,56 @@ echo "--- General Queries (plain find, no relationship traversal) ---\n\n";
 bench(
     "getDocument('articles', id)",
     fn () => $database->getDocument('articles', $allArticleIds[0]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // skipRelationships find (raw, no population)
 bench(
     "find('articles') skip-rels limit(100)",
     fn () => $database->skipRelationships(fn () => $database->find('articles', [Query::limit(100)])),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 bench(
     "find('articles') skip-rels limit(1000)",
     fn () => $database->skipRelationships(fn () => $database->find('articles', [Query::limit(1000)])),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 bench(
     "find('articles') skip-rels limit(5000)",
     fn () => $database->skipRelationships(fn () => $database->find('articles', [Query::limit(5000)])),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // find WITH relationship population (authors populated on each article)
 bench(
     "find('articles') + rels limit(100)",
     fn () => $database->find('articles', [Query::limit(100)]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 bench(
     "find('articles') + rels limit(500)",
     fn () => $database->find('articles', [Query::limit(500)]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // find authors WITH relationship population (articles populated on each author)
 bench(
     "find('authors') + rels limit(25)",
     fn () => $database->find('authors', [Query::limit(25)]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 bench(
     "find('authors') + rels limit(100)",
     fn () => $database->find('authors', [Query::limit(100)]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // Filter queries (no relationship traversal)
@@ -213,7 +224,8 @@ bench(
         Query::equal('genre', ['fashion']),
         Query::limit(5000),
     ])),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // Pagination
@@ -236,7 +248,8 @@ bench(
         } while ($count === 100);
         return range(1, $total);
     },
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 echo "\n--- M2M Relationship Queries ---\n\n";
@@ -253,7 +266,8 @@ bench(
         Query::equal('articles.$id', [$singleArticleId]),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 2) equal('articles.$id', [3 values])
@@ -263,7 +277,8 @@ bench(
         Query::equal('articles.$id', $threeArticleIds),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 3) containsAll('articles.$id', [2 values])
@@ -273,7 +288,8 @@ bench(
         Query::containsAll('articles.$id', $twoArticleIds),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 4) Reverse: find articles by author
@@ -283,7 +299,8 @@ bench(
         Query::equal('authors.$id', ['author_000']),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 5) equal('articles.$id', [1]) + attribute filter
@@ -294,7 +311,8 @@ bench(
         Query::equal('name', ['Alice 0']),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 6) Non-$id attribute query (genre) — not optimized by subquery, baseline comparison
@@ -304,7 +322,8 @@ bench(
         Query::equal('articles.genre', ['fashion']),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 7) Genre query with select (no relationship population)
@@ -315,7 +334,8 @@ bench(
         Query::select(['$id', 'name']),
         Query::limit(5000),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 // 8) Genre query with small limit
@@ -325,7 +345,8 @@ bench(
         Query::equal('articles.genre', ['fashion']),
         Query::limit(5),
     ]),
-    $warmup, $runs
+    $warmup,
+    $runs
 );
 
 echo "\n=== Done ===\n";

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -1583,7 +1583,7 @@ abstract class Adapter
      * @param array<string> $parentIds Parent document IDs to look up
      * @return array<array<string, string>>
      */
-    public function findJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
+    public function getJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
     {
         // Default: use find() with select (adapters can override for raw performance)
         $results = $this->find(

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -1563,4 +1563,47 @@ abstract class Adapter
      * @return bool
      */
     abstract public function getSupportForNestedTransactions(): bool;
+
+    /**
+     * Does the adapter support inline subqueries for junction table resolution?
+     *
+     * @return bool
+     */
+    abstract public function getSupportForSubqueries(): bool;
+
+    /**
+     * Fetch junction table mappings as lightweight arrays (no Document hydration).
+     *
+     * Returns array of [parentColumn => parentId, childColumn => childId] rows.
+     * Override in SQL adapters for maximum performance; default falls back to find().
+     *
+     * @param Document $collection Junction collection document
+     * @param string $parentColumn Column name for parent FK
+     * @param string $childColumn Column name for child FK
+     * @param array<string> $parentIds Parent document IDs to look up
+     * @return array<array{string, string}>
+     */
+    public function findJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
+    {
+        // Default: use find() with select (adapters can override for raw performance)
+        $results = $this->find(
+            $collection,
+            [
+                Query::equal($parentColumn, $parentIds),
+                Query::select([$parentColumn, $childColumn]),
+                Query::limit(PHP_INT_MAX),
+            ],
+            PHP_INT_MAX
+        );
+
+        $mappings = [];
+        foreach ($results as $doc) {
+            $mappings[] = [
+                $parentColumn => $doc->getAttribute($parentColumn),
+                $childColumn => $doc->getAttribute($childColumn),
+            ];
+        }
+
+        return $mappings;
+    }
 }

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -1581,7 +1581,7 @@ abstract class Adapter
      * @param string $parentColumn Column name for parent FK
      * @param string $childColumn Column name for child FK
      * @param array<string> $parentIds Parent document IDs to look up
-     * @return array<array{string, string}>
+     * @return array<array<string, string>>
      */
     public function findJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
     {

--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -1598,9 +1598,14 @@ abstract class Adapter
 
         $mappings = [];
         foreach ($results as $doc) {
+            $parentId = $doc->getAttribute($parentColumn);
+            $childId = $doc->getAttribute($childColumn);
+            if ($parentId === null || $childId === null) {
+                continue;
+            }
             $mappings[] = [
-                $parentColumn => $doc->getAttribute($parentColumn),
-                $childColumn => $doc->getAttribute($childColumn),
+                $parentColumn => (string) $parentId,
+                $childColumn => (string) $childId,
             ];
         }
 

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1580,6 +1580,10 @@ class MariaDB extends SQL
         }
 
         switch ($query->getMethod()) {
+            case Query::TYPE_IN_SUBQUERY:
+            case Query::TYPE_IN_SUBQUERY_ALL:
+                return $this->getSQLSubqueryCondition($query, $binds, $alias, $attribute, $placeholder);
+
             case Query::TYPE_OR:
             case Query::TYPE_AND:
                 $conditions = [];

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -3702,6 +3702,11 @@ class Mongo extends Adapter
         return false;
     }
 
+    public function getSupportForSubqueries(): bool
+    {
+        return false;
+    }
+
     protected function isExtendedISODatetime(string $val): bool
     {
         /**

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -719,7 +719,7 @@ class Pool extends Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
-    public function findJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
+    public function getJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
     {
         return $this->delegate(__FUNCTION__, \func_get_args());
     }

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -713,4 +713,14 @@ class Pool extends Adapter
     {
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
+
+    public function getSupportForSubqueries(): bool
+    {
+        return $this->delegate(__FUNCTION__, \func_get_args());
+    }
+
+    public function findJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
+    {
+        return $this->delegate(__FUNCTION__, \func_get_args());
+    }
 }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1784,6 +1784,10 @@ class Postgres extends SQL
         }
 
         switch ($query->getMethod()) {
+            case Query::TYPE_IN_SUBQUERY:
+            case Query::TYPE_IN_SUBQUERY_ALL:
+                return $this->getSQLSubqueryCondition($query, $binds, $alias, $attribute, $placeholder);
+
             case Query::TYPE_OR:
             case Query::TYPE_AND:
                 $conditions = [];

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -2352,7 +2352,7 @@ abstract class SQL extends Adapter
 
         // Literal filter values
         $filterCol = $this->quote($this->filter($meta['filterColumn']));
-        $filterValues = $meta['filterValues'];
+        $filterValues = \array_values(\array_unique($meta['filterValues'], SORT_REGULAR));
 
         if (empty($filterValues)) {
             return '1 = 0';

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -3722,7 +3722,7 @@ abstract class SQL extends Adapter
     /**
      * @inheritDoc
      */
-    public function findJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
+    public function getJunctionMapping(Document $collection, string $parentColumn, string $childColumn, array $parentIds): array
     {
         if (empty($parentIds)) {
             return [];

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -10006,10 +10006,24 @@ class Database
                 Query::TYPE_OVERLAPS, Query::TYPE_NOT_OVERLAPS,
                 Query::TYPE_TOUCHES, Query::TYPE_NOT_TOUCHES,
             ];
+            // Dual-purpose methods (contains, equal) that are spatial when values are arrays
+            $dualPurposeMethods = [
+                Query::TYPE_CONTAINS, Query::TYPE_NOT_CONTAINS,
+                Query::TYPE_EQUAL, Query::TYPE_NOT_EQUAL,
+            ];
             foreach ($relatedQueries as $rq) {
                 if (\in_array($rq->getMethod(), $spatialMethods) || $rq->isSpatialAttribute()) {
                     $canUseSubquery = false;
                     break;
+                }
+                // Spatial queries carry array values (coordinates); string queries carry strings
+                if (\in_array($rq->getMethod(), $dualPurposeMethods)) {
+                    foreach ($rq->getValues() as $val) {
+                        if (\is_array($val)) {
+                            $canUseSubquery = false;
+                            break 2;
+                        }
+                    }
                 }
             }
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -10007,7 +10007,7 @@ class Database
                 Query::TYPE_TOUCHES, Query::TYPE_NOT_TOUCHES,
             ];
             foreach ($relatedQueries as $rq) {
-                if (\in_array($rq->getMethod(), $spatialMethods)) {
+                if (\in_array($rq->getMethod(), $spatialMethods) || $rq->isSpatialAttribute()) {
                     $canUseSubquery = false;
                     break;
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1171,7 +1171,9 @@ class Database
     public function skipValidation(callable $callback): mixed
     {
         $initial = $this->validate;
-        $this->disableValidation();
+        // Direct property assignment avoids delegation in subclasses (e.g. Mirror)
+        // that override disableValidation() to propagate to child instances.
+        $this->validate = false;
 
         try {
             return $callback();

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5319,7 +5319,7 @@ class Database
         if ($this->adapter->getSupportForSubqueries()) {
             // Lightweight junction fetch: raw arrays, no Document hydration
             $junctionDoc = $this->silent(fn () => $this->getCollection($junction));
-            $rows = $this->authorization->skip(fn () => $this->adapter->findJunctionMapping(
+            $rows = $this->authorization->skip(fn () => $this->adapter->getJunctionMapping(
                 $junctionDoc,
                 $twoWayKey,
                 $key,

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -9819,7 +9819,7 @@ class Database
                 if (isset($result['subquery'])) {
                     $additionalQueries[] = $this->createSubqueryFromResult($result);
                     $usedSubqueries = true;
-                } else {
+                } elseif (isset($result['ids'])) {
                     $resolvedAttribute = $result['attribute'];
                     $parentIdSets[] = $result['ids'];
                 }
@@ -9928,7 +9928,7 @@ class Database
 
                 if (isset($result['subquery'])) {
                     $additionalQueries[] = $this->createSubqueryFromResult($result);
-                } else {
+                } elseif (isset($result['ids'])) {
                     $additionalQueries[] = Query::equal($result['attribute'], $result['ids']);
                 }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5311,45 +5311,72 @@ class Database
 
         $junction = $this->getJunctionCollection($collection, $relatedCollection, $side);
 
-        $junctions = [];
-
-        foreach (\array_chunk($documentIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
-            $chunkJunctions = $this->skipRelationships(fn () => $this->find($junction, [
-                Query::equal($twoWayKey, $chunk),
-                Query::limit(PHP_INT_MAX)
-            ]));
-            \array_push($junctions, ...$chunkJunctions);
-        }
-
         $relatedIds = [];
         $junctionsByDocumentId = [];
 
-        foreach ($junctions as $junctionDoc) {
-            $documentId = $junctionDoc->getAttribute($twoWayKey);
-            $relatedId = $junctionDoc->getAttribute($key);
+        if ($this->adapter->getSupportForSubqueries()) {
+            // Lightweight junction fetch: raw arrays, no Document hydration
+            $junctionDoc = $this->silent(fn () => $this->getCollection($junction));
+            $rows = $this->authorization->skip(fn () => $this->adapter->findJunctionMapping(
+                $junctionDoc,
+                $twoWayKey,
+                $key,
+                $documentIds
+            ));
 
-            if (!\is_null($documentId) && !\is_null($relatedId)) {
-                if (!isset($junctionsByDocumentId[$documentId])) {
-                    $junctionsByDocumentId[$documentId] = [];
+            foreach ($rows as $row) {
+                $documentId = $row[$twoWayKey] ?? null;
+                $relatedId = $row[$key] ?? null;
+
+                if (!\is_null($documentId) && !\is_null($relatedId)) {
+                    $junctionsByDocumentId[$documentId][] = $relatedId;
+                    $relatedIds[] = $relatedId;
                 }
-                $junctionsByDocumentId[$documentId][] = $relatedId;
-                $relatedIds[] = $relatedId;
+            }
+        } else {
+            $junctions = [];
+            foreach (\array_chunk($documentIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+                $chunkJunctions = $this->skipRelationships(fn () => $this->find($junction, [
+                    Query::equal($twoWayKey, $chunk),
+                    Query::limit(PHP_INT_MAX)
+                ]));
+                \array_push($junctions, ...$chunkJunctions);
+            }
+
+            foreach ($junctions as $junctionDoc) {
+                $documentId = $junctionDoc->getAttribute($twoWayKey);
+                $relatedId = $junctionDoc->getAttribute($key);
+
+                if (!\is_null($documentId) && !\is_null($relatedId)) {
+                    $junctionsByDocumentId[$documentId][] = $relatedId;
+                    $relatedIds[] = $relatedId;
+                }
             }
         }
 
         $related = [];
         $allRelatedDocs = [];
         if (!empty($relatedIds)) {
-            $uniqueRelatedIds = array_unique($relatedIds);
             $foundRelated = [];
 
-            foreach (\array_chunk($uniqueRelatedIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
-                $chunkDocs = $this->find($relatedCollection->getId(), [
-                    Query::equal('$id', $chunk),
+            if ($this->adapter->getSupportForSubqueries()) {
+                // Single subquery replaces multiple chunked queries:
+                // SELECT * FROM articles WHERE _uid IN (SELECT key FROM junction WHERE twoWayKey IN (:parentIds))
+                $foundRelated = $this->skipValidation(fn () => $this->find($relatedCollection->getId(), [
+                    Query::inSubquery('$id', $junction, $key, $twoWayKey, $documentIds),
                     Query::limit(PHP_INT_MAX),
                     ...$queries
-                ]);
-                \array_push($foundRelated, ...$chunkDocs);
+                ]));
+            } else {
+                $uniqueRelatedIds = array_unique($relatedIds);
+                foreach (\array_chunk($uniqueRelatedIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+                    $chunkDocs = $this->find($relatedCollection->getId(), [
+                        Query::equal('$id', $chunk),
+                        Query::limit(PHP_INT_MAX),
+                        ...$queries
+                    ]);
+                    \array_push($foundRelated, ...$chunkDocs);
+                }
             }
 
             $allRelatedDocs = $foundRelated;
@@ -8333,22 +8360,7 @@ class Database
             }
         }
 
-        foreach ($results as $index => $node) {
-            $node = $this->adapter->castingAfter($collection, $node);
-            $node = $this->casting($collection, $node);
-            $node = $this->decode($collection, $node, $selections);
-
-            // Convert to custom document type if mapped
-            if (isset($this->documentTypes[$collection->getId()])) {
-                $node = $this->createDocumentInstance($collection->getId(), $node->getArrayCopy());
-            }
-
-            if (!$node->isEmpty()) {
-                $node->setAttribute('$collection', $collection->getId());
-            }
-
-            $results[$index] = $node;
-        }
+        $this->castAndDecodeBatch($collection, $results, $selections);
 
         $this->trigger(self::EVENT_DOCUMENT_FIND, $results);
 
@@ -8789,6 +8801,202 @@ class Database
             }
         }
         return $document;
+    }
+
+    /**
+     * Batch cast and decode for multiple documents.
+     *
+     * Combines casting() and decode() into a single pass per document,
+     * pre-computing attribute metadata once to avoid redundant work.
+     * Only processes attributes that actually need transformation.
+     *
+     * @param Document $collection
+     * @param array<Document> $results
+     * @param array<string> $selections
+     * @return void
+     */
+    private function castAndDecodeBatch(
+        Document $collection,
+        array &$results,
+        array $selections = []
+    ): void {
+        if (empty($results)) {
+            return;
+        }
+
+        $supportsCasting = $this->adapter->getSupportForCasting();
+        $collectionId = $collection->getId();
+        $hasDocumentTypes = isset($this->documentTypes[$collectionId]);
+
+        // Pre-compute attribute metadata once
+        $collectionAttributes = $collection->getAttribute('attributes', []);
+        $internalAttributes = $this->getInternalAttributes();
+
+        // Separate relationships for key renaming
+        $relationshipRenames = [];
+        $regularAttributes = [];
+
+        foreach ($collectionAttributes as $attribute) {
+            if (($attribute['type'] ?? '') === self::VAR_RELATIONSHIP) {
+                $key = $attribute['$id'] ?? '';
+                $filteredKey = $this->adapter->filter($key);
+                if ($filteredKey !== $key) {
+                    $relationshipRenames[] = ['key' => $key, 'filteredKey' => $filteredKey];
+                }
+            } else {
+                $regularAttributes[] = $attribute;
+            }
+        }
+
+        // Merge non-relationship + internal attributes
+        $allAttributes = $regularAttributes;
+        foreach ($internalAttributes as $attr) {
+            $allAttributes[] = $attr;
+        }
+
+        // Pre-compute which attributes need work (casting, decoding, or filtered key fallback)
+        $workAttributes = [];
+
+        foreach ($allAttributes as $attr) {
+            $key = $attr['$id'] ?? '';
+            $type = $attr['type'] ?? '';
+            $array = $attr['array'] ?? false;
+            $filters = $attr['filters'] ?? [];
+
+            if ($key === '$permissions') {
+                continue;
+            }
+
+            $needsCasting = $supportsCasting && \in_array($type, [
+                self::VAR_ID, self::VAR_BOOLEAN, self::VAR_INTEGER, self::VAR_FLOAT
+            ]);
+            $needsDecoding = !empty($filters);
+            $filteredKey = $this->adapter->filter($key);
+            $hasFilteredKey = ($filteredKey !== $key);
+
+            // Array attributes need json_decode even without casting/filters
+            if ($needsCasting || $needsDecoding || $hasFilteredKey || $array) {
+                $workAttributes[] = [
+                    'key' => $key,
+                    'type' => $type,
+                    'array' => $array,
+                    'needsCasting' => $needsCasting,
+                    'filters' => $needsDecoding ? \array_reverse($filters) : [],
+                    'filteredKey' => $hasFilteredKey ? $filteredKey : null,
+                ];
+            }
+        }
+
+        // Pre-compute selection info
+        $hasSelections = !empty($selections);
+        $hasWildcard = $hasSelections && \in_array('*', $selections);
+        $selectionsMap = [];
+        $hasRelationshipSelections = false;
+
+        if ($hasSelections) {
+            foreach ($selections as $sel) {
+                $selectionsMap[$sel] = true;
+                if (\str_contains($sel, '.')) {
+                    $hasRelationshipSelections = true;
+                }
+            }
+        }
+
+        foreach ($results as $index => $node) {
+            $node = $this->adapter->castingAfter($collection, $node);
+            foreach ($relationshipRenames as $rename) {
+                if (
+                    \array_key_exists($rename['key'], (array)$node)
+                    || \array_key_exists($rename['filteredKey'], (array)$node)
+                ) {
+                    $value = $node->getAttribute($rename['key']);
+                    $value ??= $node->getAttribute($rename['filteredKey']);
+                    $node->removeAttribute($rename['filteredKey']);
+                    $node->setAttribute($rename['key'], $value);
+                }
+            }
+
+            $filteredValues = $hasRelationshipSelections ? [] : null;
+
+            foreach ($workAttributes as $attr) {
+                $value = $node->getAttribute($attr['key'], null);
+                if ($value === null && $attr['filteredKey'] !== null) {
+                    $value = $node->getAttribute($attr['filteredKey']);
+                    if ($value !== null) {
+                        $node->removeAttribute($attr['filteredKey']);
+                    }
+                }
+
+                if ($value === null) {
+                    if (empty($attr['filters'])) {
+                        continue;
+                    }
+                }
+
+                if ($value instanceof Operator) {
+                    continue;
+                }
+
+                if ($attr['array']) {
+                    $value = \is_string($value) ? \json_decode($value, true) : $value;
+                    $value = ($value === null) ? [] : $value;
+                } else {
+                    $value = [$value];
+                }
+
+                foreach ($value as $vi => $v) {
+                    // Cast (skip null — original casting() skips nulls)
+                    if ($attr['needsCasting'] && $v !== null) {
+                        $v = match ($attr['type']) {
+                            self::VAR_ID => (string)$v,
+                            self::VAR_BOOLEAN => (bool)$v,
+                            self::VAR_INTEGER => (int)$v,
+                            self::VAR_FLOAT => (float)$v,
+                            default => $v,
+                        };
+                    }
+
+                    // Decode filters
+                    foreach ($attr['filters'] as $filter) {
+                        $v = $this->decodeAttribute($filter, $v, $node, $attr['key']);
+                    }
+
+                    $value[$vi] = $v;
+                }
+
+                $finalValue = $attr['array'] ? $value : $value[0];
+
+                if ($filteredValues !== null) {
+                    $filteredValues[$attr['key']] = $finalValue;
+                }
+
+                if (!$hasSelections || $hasWildcard || isset($selectionsMap[$attr['key']])) {
+                    $node->setAttribute($attr['key'], $finalValue);
+                }
+            }
+
+            if ($hasRelationshipSelections && $hasSelections && !$hasWildcard) {
+                foreach ($regularAttributes as $attribute) {
+                    $key = $attribute['$id'] ?? '';
+                    if ($key === '$permissions') {
+                        continue;
+                    }
+                    if (!isset($selectionsMap[$key]) && isset($filteredValues[$key])) {
+                        $node->setAttribute($key, $filteredValues[$key]);
+                    }
+                }
+            }
+
+            if ($hasDocumentTypes) {
+                $node = $this->createDocumentInstance($collectionId, $node->getArrayCopy());
+            }
+
+            if (!$node->isEmpty()) {
+                $node->setAttribute('$collection', $collectionId);
+            }
+
+            $results[$index] = $node;
+        }
     }
 
     /**
@@ -9570,9 +9778,36 @@ class Database
                 continue;
             }
 
-            // Resolve each value independently, then intersect parent IDs
+            $relationType = $relationship->getAttribute('options')['relationType'];
+            $relSide = $relationship->getAttribute('options')['side'];
+
+            // Subquery optimization for M2M containsAll on $id
+            if (
+                $nestedAttribute === '$id'
+                && $relationType === self::RELATION_MANY_TO_MANY
+                && $collection !== null
+                && $this->adapter->getSupportForSubqueries()
+            ) {
+                $twoWayKey = $relationship->getAttribute('options')['twoWayKey'];
+                $relatedCollectionDoc = $this->silent(fn () => $this->getCollection(
+                    $relationship->getAttribute('options')['relatedCollection']
+                ));
+                $junction = $this->getJunctionCollection($collection, $relatedCollectionDoc, $relSide);
+
+                $additionalQueries[] = Query::inSubqueryAll(
+                    '$id',
+                    $junction,
+                    $twoWayKey,
+                    $relationshipKey,
+                    $query->getValues()
+                );
+                $indicesToRemove[] = $index;
+                continue;
+            }
+
             $parentIdSets = [];
             $resolvedAttribute = '$id';
+            $usedSubqueries = false;
             foreach ($query->getValues() as $value) {
                 $relatedQuery = Query::equal($nestedAttribute, [$value]);
                 $result = $this->resolveRelationshipGroupToIds($relationship, [$relatedQuery], $collection);
@@ -9581,10 +9816,34 @@ class Database
                     return null;
                 }
 
-                $resolvedAttribute = $result['attribute'];
-                $parentIdSets[] = $result['ids'];
+                if (isset($result['subquery'])) {
+                    $additionalQueries[] = $this->createSubqueryFromResult($result);
+                    $usedSubqueries = true;
+                } else {
+                    $resolvedAttribute = $result['attribute'];
+                    $parentIdSets[] = $result['ids'];
+                }
             }
 
+            if ($usedSubqueries) {
+                // If we also collected non-subquery ID sets, intersect them and add as an equal() constraint
+                if (!empty($parentIdSets)) {
+                    $ids = \count($parentIdSets) > 1
+                        ? \array_values(\array_intersect(...$parentIdSets))
+                        : $parentIdSets[0];
+
+                    if (empty($ids)) {
+                        return null;
+                    }
+
+                    $additionalQueries[] = Query::equal($resolvedAttribute, $ids);
+                }
+
+                $indicesToRemove[] = $index;
+                continue;
+            }
+
+            // Non-subquery path: intersect ID sets
             $ids = \count($parentIdSets) > 1
                 ? \array_values(\array_intersect(...$parentIdSets))
                 : ($parentIdSets[0] ?? []);
@@ -9667,7 +9926,11 @@ class Database
                     return null;
                 }
 
-                $additionalQueries[] = Query::equal($result['attribute'], $result['ids']);
+                if (isset($result['subquery'])) {
+                    $additionalQueries[] = $this->createSubqueryFromResult($result);
+                } else {
+                    $additionalQueries[] = Query::equal($result['attribute'], $result['ids']);
+                }
 
                 foreach ($group['indices'] as $originalIndex) {
                     $indicesToRemove[] = $originalIndex;
@@ -9694,7 +9957,7 @@ class Database
      * @param Document $relationship
      * @param array<Query> $relatedQueries Queries on the related collection
      * @param Document|null $collection The parent collection document (needed for junction table lookups)
-     * @return array{attribute: string, ids: string[]}|null
+     * @return array{attribute: string, ids?: string[], subquery?: array<string, mixed>}|null
      */
     private function resolveRelationshipGroupToIds(
         Document $relationship,
@@ -9731,6 +9994,26 @@ class Database
             ));
         }
 
+        // Check if subqueries can be used — spatial queries need the full find() pipeline
+        // because renderConditionsForSubquery can't set attribute types on Query objects
+        $canUseSubquery = $this->adapter->getSupportForSubqueries();
+        if ($canUseSubquery) {
+            $spatialMethods = [
+                Query::TYPE_CROSSES, Query::TYPE_NOT_CROSSES,
+                Query::TYPE_DISTANCE_EQUAL, Query::TYPE_DISTANCE_NOT_EQUAL,
+                Query::TYPE_DISTANCE_GREATER_THAN, Query::TYPE_DISTANCE_LESS_THAN,
+                Query::TYPE_INTERSECTS, Query::TYPE_NOT_INTERSECTS,
+                Query::TYPE_OVERLAPS, Query::TYPE_NOT_OVERLAPS,
+                Query::TYPE_TOUCHES, Query::TYPE_NOT_TOUCHES,
+            ];
+            foreach ($relatedQueries as $rq) {
+                if (\in_array($rq->getMethod(), $spatialMethods)) {
+                    $canUseSubquery = false;
+                    break;
+                }
+            }
+        }
+
         $needsParentResolution = (
             ($relationType === self::RELATION_ONE_TO_MANY && $side === self::RELATION_SIDE_PARENT) ||
             ($relationType === self::RELATION_MANY_TO_ONE && $side === self::RELATION_SIDE_CHILD) ||
@@ -9738,26 +10021,70 @@ class Database
         );
 
         if ($relationType === self::RELATION_MANY_TO_MANY && $needsParentResolution && $collection !== null) {
-            // For many-to-many, query the junction table directly instead of relying
-            // on relationship population (which fails when resolveRelationships is false,
-            // e.g. when the outer find() is wrapped in skipRelationships()).
-            $matchingDocs = $this->silent(fn () => $this->skipRelationships(fn () => $this->find(
-                $relatedCollection,
-                \array_merge($relatedQueries, [
-                    Query::select(['$id']),
-                    Query::limit(PHP_INT_MAX),
-                ])
-            )));
-
-            $matchingIds = \array_map(fn ($doc) => $doc->getId(), $matchingDocs);
-
-            if (empty($matchingIds)) {
-                return null;
-            }
-
             $twoWayKey = $relationship->getAttribute('options')['twoWayKey'];
             $relatedCollectionDoc = $this->silent(fn () => $this->getCollection($relatedCollection));
             $junction = $this->getJunctionCollection($collection, $relatedCollectionDoc, $side);
+
+            // Check if all queries are $id equals (IDs already known)
+            $allIdEquals = true;
+            $directIds = [];
+            foreach ($relatedQueries as $rq) {
+                if ($rq->getMethod() === Query::TYPE_EQUAL && $rq->getAttribute() === '$id') {
+                    foreach ($rq->getValues() as $v) {
+                        $directIds[] = $v;
+                    }
+                } else {
+                    $allIdEquals = false;
+                    break;
+                }
+            }
+
+            if ($canUseSubquery) {
+                if ($allIdEquals && !empty($directIds)) {
+                    // Mode 1: Literal filter values — IDs already known
+                    return [
+                        'attribute' => '$id',
+                        'subquery' => [
+                            'table' => $junction,
+                            'column' => $twoWayKey,
+                            'filterColumn' => $relationshipKey,
+                            'filterValues' => $directIds,
+                        ],
+                    ];
+                }
+
+                // Nested subquery: pushes the entire filter into SQL
+                // WHERE _uid IN (SELECT twoWayKey FROM junction WHERE relationshipKey IN (SELECT _uid FROM related WHERE [conditions]))
+                return [
+                    'attribute' => '$id',
+                    'subquery' => [
+                        'table' => $junction,
+                        'column' => $twoWayKey,
+                        'conditions' => [
+                            Query::inSubqueryDirect($relationshipKey, $relatedCollection, '_uid', $relatedQueries)
+                        ],
+                    ],
+                ];
+            }
+
+            // Fallback for non-SQL adapters (e.g. Mongo)
+            if ($allIdEquals && !empty($directIds)) {
+                $matchingIds = $directIds;
+            } else {
+                $matchingDocs = $this->silent(fn () => $this->skipRelationships(fn () => $this->find(
+                    $relatedCollection,
+                    \array_merge($relatedQueries, [
+                        Query::select(['$id']),
+                        Query::limit(PHP_INT_MAX),
+                    ])
+                )));
+
+                $matchingIds = \array_map(fn ($doc) => $doc->getId(), $matchingDocs);
+
+                if (empty($matchingIds)) {
+                    return null;
+                }
+            }
 
             $junctionDocs = $this->silent(fn () => $this->skipRelationships(fn () => $this->find($junction, [
                 Query::equal($relationshipKey, $matchingIds),
@@ -9774,8 +10101,22 @@ class Database
 
             return empty($parentIds) ? null : ['attribute' => '$id', 'ids' => $parentIds];
         } elseif ($needsParentResolution) {
-            // For one-to-many/many-to-one parent resolution, we need relationship
-            // population to read the twoWayKey attribute from the related documents.
+            // O2M PARENT or M2O CHILD: the related collection has a FK column (twoWayKey)
+            // pointing back to this collection. Use: WHERE _uid IN (SELECT twoWayKey FROM related WHERE [conditions])
+            $twoWayKey = $relationship->getAttribute('options')['twoWayKey'];
+
+            if ($canUseSubquery) {
+                return [
+                    'attribute' => '$id',
+                    'subquery' => [
+                        'table' => $relatedCollection,
+                        'column' => $twoWayKey,
+                        'conditions' => $relatedQueries,
+                    ],
+                ];
+            }
+
+            // Fallback: execute find with relationship population
             $matchingDocs = $this->silent(fn () => $this->find(
                 $relatedCollection,
                 \array_merge($relatedQueries, [
@@ -9783,7 +10124,6 @@ class Database
                 ])
             ));
 
-            $twoWayKey = $relationship->getAttribute('options')['twoWayKey'];
             $parentIds = [];
 
             foreach ($matchingDocs as $doc) {
@@ -9810,6 +10150,19 @@ class Database
 
             return empty($parentIds) ? null : ['attribute' => '$id', 'ids' => $parentIds];
         } else {
+            if ($canUseSubquery) {
+                // Simple FK resolution: WHERE relationshipKey IN (SELECT _uid FROM relatedTable WHERE [conditions])
+                return [
+                    'attribute' => $relationshipKey,
+                    'subquery' => [
+                        'table' => $relatedCollection,
+                        'column' => '_uid',
+                        'conditions' => $relatedQueries,
+                    ],
+                ];
+            }
+
+            // Fallback for non-SQL adapters
             $matchingDocs = $this->silent(fn () => $this->skipRelationships(fn () => $this->find(
                 $relatedCollection,
                 \array_merge($relatedQueries, [
@@ -9821,6 +10174,34 @@ class Database
             $matchingIds = \array_map(fn ($doc) => $doc->getId(), $matchingDocs);
             return empty($matchingIds) ? null : ['attribute' => $relationshipKey, 'ids' => $matchingIds];
         }
+    }
+
+    /**
+     * Create a Query object from a subquery result returned by resolveRelationshipGroupToIds.
+     *
+     * @param array{attribute: string, subquery: array<string, mixed>} $result
+     * @return Query
+     */
+    private function createSubqueryFromResult(array $result): Query
+    {
+        $sub = $result['subquery'];
+
+        if (isset($sub['conditions'])) {
+            return Query::inSubqueryDirect(
+                $result['attribute'],
+                $sub['table'],
+                $sub['column'],
+                $sub['conditions']
+            );
+        }
+
+        return Query::inSubquery(
+            $result['attribute'],
+            $sub['table'],
+            $sub['column'],
+            $sub['filterColumn'],
+            $sub['filterValues']
+        );
     }
 
     /**

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -5918,7 +5918,8 @@ trait DocumentTests
             '$id' => 'doc11',
             '$permissions' => [Permission::read(Role::any()), Permission::write(Role::any()),Permission::update(Role::any())],
             'string' => 'no_dates',
-            '$createdAt' => $customDate
+            '$createdAt' => $customDate,
+            '$updatedAt' => $customDate
         ]));
 
         $newUpdatedAt = $doc11->getUpdatedAt();


### PR DESCRIPTION
## Summary

Optimizes relationship resolution and document processing with two key changes:

1. **Subquery-based relationship filtering** — M2M and relation queries now use SQL subqueries instead of N+1 round-trips
2. **Batch cast/decode** — `find()` results are cast and decoded in a single pass instead of per-document

### Benchmark highlights (500 authors × 50 articles, MariaDB)

| Area | Speedup |
|---|---|
| General `find()` queries | **2–3.4x** faster |
| M2M `$id` filters | **3.2–4.4x** faster |
| M2M attribute filters | **14–128x** faster |
| `find('authors')` + rels limit(100) | **14x** faster |

See [full benchmark results](https://github.com/utopia-php/database/pull/822#issuecomment-3955319409) in comments.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internal subquery-style relationship filters to enable declarative relationship queries.
* **Performance**
  * Batch processing for document fetches and relationship resolution to reduce latency and round-trips.
* **Chores**
  * Slimmed container build for a smaller runtime image.
  * Added a standalone many-to-many benchmark and integrated M2M benchmarks into the benchmark workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->