### PR TITLE
Fix fulltext stripping

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1593,12 +1593,20 @@ class MariaDB extends SQL
                 return empty($conditions) ? '' : ' '. $method .' (' . implode(' AND ', $conditions) . ')';
 
             case Query::TYPE_SEARCH:
-                $binds[":{$placeholder}_0"] = $this->getFulltextValue($query->getValue());
+                $fulltextValue = $this->getFulltextValue($query->getValue());
+                if ($fulltextValue === '') {
+                    return '0 = 1';
+                }
+                $binds[":{$placeholder}_0"] = $fulltextValue;
 
                 return "MATCH({$alias}.{$attribute}) AGAINST (:{$placeholder}_0 IN BOOLEAN MODE)";
 
             case Query::TYPE_NOT_SEARCH:
-                $binds[":{$placeholder}_0"] = $this->getFulltextValue($query->getValue());
+                $fulltextValue = $this->getFulltextValue($query->getValue());
+                if ($fulltextValue === '') {
+                    return '1 = 1';
+                }
+                $binds[":{$placeholder}_0"] = $fulltextValue;
 
                 return "NOT (MATCH({$alias}.{$attribute}) AGAINST (:{$placeholder}_0 IN BOOLEAN MODE))";
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1922,8 +1922,8 @@ class Postgres extends SQL
         $exact = str_ends_with($value, '"') && str_starts_with($value, '"');
 
         /** Keep only unicode letters, numbers, underscores, and whitespace. */
-        $value = preg_replace('/[^\p{L}\p{N}_\s]/u', ' ', $value);
-        $value = preg_replace('/\s+/', ' ', $value); // Remove multiple whitespaces
+        $value = preg_replace('/[^\p{L}\p{N}_\s]/u', ' ', $value) ?? '';
+        $value = preg_replace('/\s+/', ' ', $value) ?? '';
         $value = trim($value);
 
         if (empty($value)) {

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1921,8 +1921,8 @@ class Postgres extends SQL
     {
         $exact = str_ends_with($value, '"') && str_starts_with($value, '"');
 
-        /** Keep only unicode letters, numbers, and whitespace. */
-        $value = preg_replace('/[^\p{L}\p{N}\s]/u', ' ', $value);
+        /** Keep only unicode letters, numbers, underscores, and whitespace. */
+        $value = preg_replace('/[^\p{L}\p{N}_\s]/u', ' ', $value);
         $value = preg_replace('/\s+/', ' ', $value); // Remove multiple whitespaces
         $value = trim($value);
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1796,11 +1796,19 @@ class Postgres extends SQL
                 return empty($conditions) ? '' : ' ' . $method . ' (' . implode(' AND ', $conditions) . ')';
 
             case Query::TYPE_SEARCH:
-                $binds[":{$placeholder}_0"] = $this->getFulltextValue($query->getValue());
+                $fulltextValue = $this->getFulltextValue($query->getValue());
+                if ($fulltextValue === '') {
+                    return '0 = 1';
+                }
+                $binds[":{$placeholder}_0"] = $fulltextValue;
                 return "to_tsvector(regexp_replace({$attribute}, '[^\w]+',' ','g')) @@ websearch_to_tsquery(:{$placeholder}_0)";
 
             case Query::TYPE_NOT_SEARCH:
-                $binds[":{$placeholder}_0"] = $this->getFulltextValue($query->getValue());
+                $fulltextValue = $this->getFulltextValue($query->getValue());
+                if ($fulltextValue === '') {
+                    return '1 = 1';
+                }
+                $binds[":{$placeholder}_0"] = $fulltextValue;
                 return "NOT (to_tsvector(regexp_replace({$attribute}, '[^\w]+',' ','g')) @@ websearch_to_tsquery(:{$placeholder}_0))";
 
             case Query::TYPE_VECTOR_DOT:
@@ -1912,9 +1920,15 @@ class Postgres extends SQL
     protected function getFulltextValue(string $value): string
     {
         $exact = str_ends_with($value, '"') && str_starts_with($value, '"');
-        $value = str_replace(['@', '+', '-', '*', '.', "'", '"'], ' ', $value);
+
+        /** Keep only unicode letters, numbers, and whitespace. */
+        $value = preg_replace('/[^\p{L}\p{N}\s]/u', ' ', $value);
         $value = preg_replace('/\s+/', ' ', $value); // Remove multiple whitespaces
         $value = trim($value);
+
+        if (empty($value)) {
+            return '';
+        }
 
         if (!$exact) {
             $value = str_replace(' ', ' or ', $value);

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1752,8 +1752,8 @@ abstract class SQL extends Adapter
     {
         $exact = str_ends_with($value, '"') && str_starts_with($value, '"');
 
-        /** Keep only unicode letters, numbers, and whitespace. */
-        $value = preg_replace('/[^\p{L}\p{N}\s]/u', ' ', $value);
+        /** Keep only unicode letters, numbers, underscores, and whitespace. */
+        $value = preg_replace('/[^\p{L}\p{N}_\s]/u', ' ', $value);
         $value = preg_replace('/\s+/', ' ', $value); // Remove multiple whitespaces
         $value = trim($value);
 

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1753,8 +1753,8 @@ abstract class SQL extends Adapter
         $exact = str_ends_with($value, '"') && str_starts_with($value, '"');
 
         /** Keep only unicode letters, numbers, underscores, and whitespace. */
-        $value = preg_replace('/[^\p{L}\p{N}_\s]/u', ' ', $value);
-        $value = preg_replace('/\s+/', ' ', $value); // Remove multiple whitespaces
+        $value = preg_replace('/[^\p{L}\p{N}_\s]/u', ' ', $value) ?? '';
+        $value = preg_replace('/\s+/', ' ', $value) ?? '';
         $value = trim($value);
 
         if (empty($value)) {

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1752,9 +1752,8 @@ abstract class SQL extends Adapter
     {
         $exact = str_ends_with($value, '"') && str_starts_with($value, '"');
 
-        /** Replace reserved chars with space. */
-        $specialChars = '@,+,-,*,),(,<,>,~,"';
-        $value = str_replace(explode(',', $specialChars), ' ', $value);
+        /** Keep only unicode letters, numbers, and whitespace. */
+        $value = preg_replace('/[^\p{L}\p{N}\s]/u', ' ', $value);
         $value = preg_replace('/\s+/', ' ', $value); // Remove multiple whitespaces
         $value = trim($value);
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -2179,6 +2179,95 @@ trait DocumentTests
         $this->assertEquals(1, count($documents));
     }
 
+    /**
+     * Regression: accented characters and non-operator special chars
+     * previously caused SQLSTATE[42000] syntax error in FTS BOOLEAN MODE.
+     *
+     * @see https://appwrite.sentry.io/issues/5628237003
+     */
+    public function testFindFulltextAccentedAndSpecialChars(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        if (!$database->getAdapter()->getSupportForFulltextIndex()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $collection = 'full_text_unicode';
+        $database->createCollection($collection, permissions: [
+            Permission::create(Role::any()),
+            Permission::update(Role::users())
+        ]);
+
+        $this->assertTrue($database->createAttribute($collection, 'nombre', Database::VAR_STRING, 128, true));
+        $this->assertTrue($database->createIndex($collection, 'nombre-ft', Database::INDEX_FULLTEXT, ['nombre']));
+
+        $database->createDocument($collection, new Document([
+            '$permissions' => [Permission::read(Role::any())],
+            'nombre' => 'Luis García'
+        ]));
+
+        $database->createDocument($collection, new Document([
+            '$permissions' => [Permission::read(Role::any())],
+            'nombre' => 'Álvaro Yair Cuéllar'
+        ]));
+
+        $database->createDocument($collection, new Document([
+            '$permissions' => [Permission::read(Role::any())],
+            'nombre' => 'Fernando naïve über'
+        ]));
+
+        /**
+         * Accented characters must not cause FTS parser errors
+         */
+        $documents = $database->find($collection, [
+            Query::search('nombre', 'García'),
+        ]);
+        $this->assertGreaterThanOrEqual(1, count($documents));
+
+        $documents = $database->find($collection, [
+            Query::search('nombre', 'Álvaro'),
+        ]);
+        $this->assertGreaterThanOrEqual(1, count($documents));
+
+        $documents = $database->find($collection, [
+            Query::search('nombre', 'Cuéllar'),
+        ]);
+        $this->assertGreaterThanOrEqual(1, count($documents));
+
+        /**
+         * Non-operator special chars (! . #) were not stripped by old code,
+         * producing values like "!!!...###*" that crash MySQL's FTS parser.
+         */
+        $documents = $database->find($collection, [
+            Query::search('nombre', '!!!...###'),
+        ]);
+        $this->assertEquals(0, count($documents));
+
+        $documents = $database->find($collection, [
+            Query::search('nombre', '$$$%%%^^^'),
+        ]);
+        $this->assertEquals(0, count($documents));
+
+        /**
+         * FTS operator-only input also must not error
+         */
+        $documents = $database->find($collection, [
+            Query::search('nombre', '+-*@<>~'),
+        ]);
+        $this->assertEquals(0, count($documents));
+
+        /**
+         * Mixed special chars + accented word should still find results
+         */
+        $documents = $database->find($collection, [
+            Query::search('nombre', '@García!'),
+        ]);
+        $this->assertGreaterThanOrEqual(1, count($documents));
+    }
+
     public function testFindMultipleConditions(): void
     {
         /** @var Database $database */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents empty full-text searches from running and returning unintended results.
  * Improves handling of accented and special characters in full-text searches.
  * Ensures document permission updates are applied atomically.
  * Improves duplicate-key error reporting and edge-case handling for numeric and spatial queries.
  * Adds more reliable schema index and large-number support across database adapters.

* **Tests**
  * Added regression coverage for accented characters and special-character inputs in full-text search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->