### PR TITLE
Add ignore param to createDocuments for silent duplicate handling

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -729,12 +729,13 @@ abstract class Adapter
      *
      * @param Document $collection
      * @param array<Document> $documents
+     * @param bool $ignore If true, silently ignore duplicate documents instead of throwing
      *
      * @return array<Document>
      *
      * @throws DatabaseException
      */
-    abstract public function createDocuments(Document $collection, array $documents): array;
+    abstract public function createDocuments(Document $collection, array $documents, bool $ignore = false): array;
 
     /**
      * Update Document

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1439,11 +1439,16 @@ class Mongo extends Adapter
      * @throws DuplicateException
      * @throws DatabaseException
      */
-    public function createDocuments(Document $collection, array $documents): array
+    public function createDocuments(Document $collection, array $documents, bool $ignore = false): array
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection->getId());
 
         $options = $this->getTransactionOptions();
+
+        if ($ignore) {
+            $options['ordered'] = false;
+        }
+
         $records = [];
         $hasSequence = null;
         $documents = \array_map(fn ($doc) => clone $doc, $documents);
@@ -1469,7 +1474,13 @@ class Mongo extends Adapter
         try {
             $documents = $this->client->insertMany($name, $records, $options);
         } catch (MongoException $e) {
-            throw $this->processException($e);
+            $processed = $this->processException($e);
+
+            if ($ignore && $processed instanceof DuplicateException) {
+                return $documents;
+            }
+
+            throw $processed;
         }
 
         foreach ($documents as $index => $document) {

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -1464,10 +1464,12 @@ class Mongo extends Adapter
     {
         $name = $this->getNamespace() . '_' . $this->filter($collection->getId());
 
-        $options = $this->getTransactionOptions();
-
         if ($ignore) {
-            $options['ordered'] = false;
+            // Run outside transaction — MongoDB aborts transactions on any write error,
+            // so ordered:false + session would roll back even successfully inserted docs.
+            $options = ['ordered' => false];
+        } else {
+            $options = $this->getTransactionOptions();
         }
 
         $records = [];
@@ -1498,7 +1500,10 @@ class Mongo extends Adapter
             $processed = $this->processException($e);
 
             if ($ignore && $processed instanceof DuplicateException) {
-                return $documents;
+                // Race condition: a doc was inserted between pre-filter and insertMany.
+                // With ordered:false outside transaction, non-duplicate inserts persist.
+                // Return empty — we cannot determine which docs succeeded without querying.
+                return [];
             }
 
             throw $processed;

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -263,7 +263,7 @@ class Pool extends Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
-    public function createDocuments(Document $collection, array $documents): array
+    public function createDocuments(Document $collection, array $documents, bool $ignore = false): array
     {
         return $this->delegate(__FUNCTION__, \func_get_args());
     }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1376,7 +1376,7 @@ class Postgres extends SQL
             return '';
         }
 
-        $conflictTarget = $this->sharedTables ? '("_uid", _tenant)' : '("_uid")';
+        $conflictTarget = $this->sharedTables ? '("_uid", "_tenant")' : '("_uid")';
 
         return "ON CONFLICT {$conflictTarget} DO NOTHING";
     }
@@ -1388,8 +1388,8 @@ class Postgres extends SQL
         }
 
         $conflictTarget = $this->sharedTables
-            ? '(_type, _permission, _document, _tenant)'
-            : '(_type, _permission, _document)';
+            ? '("_type", "_permission", "_document", "_tenant")'
+            : '("_type", "_permission", "_document")';
 
         return "ON CONFLICT {$conflictTarget} DO NOTHING";
     }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1361,6 +1361,35 @@ class Postgres extends SQL
         return $document;
     }
 
+    protected function getInsertKeyword(bool $ignore): string
+    {
+        return 'INSERT INTO';
+    }
+
+    protected function getInsertSuffix(bool $ignore, string $table): string
+    {
+        if (!$ignore) {
+            return '';
+        }
+
+        $conflictTarget = $this->sharedTables ? '("_uid", _tenant)' : '("_uid")';
+
+        return "ON CONFLICT {$conflictTarget} DO NOTHING";
+    }
+
+    protected function getInsertPermissionsSuffix(bool $ignore): string
+    {
+        if (!$ignore) {
+            return '';
+        }
+
+        $conflictTarget = $this->sharedTables
+            ? '(_type, _permission, _document, _tenant)'
+            : '(_type, _permission, _document)';
+
+        return "ON CONFLICT {$conflictTarget} DO NOTHING";
+    }
+
     /**
      * @param string $tableName
      * @param string $columns

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -2451,7 +2451,7 @@ abstract class SQL extends Adapter
      * @throws DuplicateException
      * @throws \Throwable
      */
-    public function createDocuments(Document $collection, array $documents): array
+    public function createDocuments(Document $collection, array $documents, bool $ignore = false): array
     {
         if (empty($documents)) {
             return $documents;
@@ -2553,8 +2553,9 @@ abstract class SQL extends Adapter
             $batchKeys = \implode(', ', $batchKeys);
 
             $stmt = $this->getPDO()->prepare("
-                INSERT INTO {$this->getSQLTable($name)} {$columns}
+                {$this->getInsertKeyword($ignore)} {$this->getSQLTable($name)} {$columns}
                 VALUES {$batchKeys}
+                {$this->getInsertSuffix($ignore, $name)}
             ");
 
             foreach ($bindValues as $key => $value) {
@@ -2568,8 +2569,9 @@ abstract class SQL extends Adapter
                 $permissions = \implode(', ', $permissions);
 
                 $sqlPermissions = "
-                    INSERT INTO {$this->getSQLTable($name . '_perms')} (_type, _permission, _document {$tenantColumn})
-                    VALUES {$permissions};
+                    {$this->getInsertKeyword($ignore)} {$this->getSQLTable($name . '_perms')} (_type, _permission, _document {$tenantColumn})
+                    VALUES {$permissions}
+                    {$this->getInsertPermissionsSuffix($ignore)}
                 ";
 
                 $stmtPermissions = $this->getPDO()->prepare($sqlPermissions);
@@ -2586,6 +2588,33 @@ abstract class SQL extends Adapter
         }
 
         return $documents;
+    }
+
+    /**
+     * Returns the INSERT keyword, optionally with IGNORE for duplicate handling.
+     * Override in adapter subclasses for DB-specific syntax.
+     */
+    protected function getInsertKeyword(bool $ignore): string
+    {
+        return $ignore ? 'INSERT IGNORE INTO' : 'INSERT INTO';
+    }
+
+    /**
+     * Returns a suffix appended after VALUES clause for duplicate handling.
+     * Override in adapter subclasses (e.g., Postgres uses ON CONFLICT DO NOTHING).
+     */
+    protected function getInsertSuffix(bool $ignore, string $table): string
+    {
+        return '';
+    }
+
+    /**
+     * Returns a suffix for the permissions INSERT statement when ignoring duplicates.
+     * Override in adapter subclasses for DB-specific syntax.
+     */
+    protected function getInsertPermissionsSuffix(bool $ignore): string
+    {
+        return '';
     }
 
     /**

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -34,6 +34,11 @@ use Utopia\Database\Operator;
  */
 class SQLite extends MariaDB
 {
+    protected function getInsertKeyword(bool $ignore): string
+    {
+        return $ignore ? 'INSERT OR IGNORE INTO' : 'INSERT INTO';
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5655,6 +5655,24 @@ class Database
         $time = DateTime::now();
         $modified = 0;
 
+        // Deduplicate intra-batch documents by ID when ignore mode is on.
+        // Keeps the first occurrence, mirrors upsertDocuments' seenIds check.
+        if ($ignore) {
+            $seenIds = [];
+            $deduplicated = [];
+            foreach ($documents as $document) {
+                $docId = $document->getId();
+                if ($docId !== '' && isset($seenIds[$docId])) {
+                    continue;
+                }
+                if ($docId !== '') {
+                    $seenIds[$docId] = true;
+                }
+                $deduplicated[] = $document;
+            }
+            $documents = $deduplicated;
+        }
+
         // When ignore mode is on and relationships are being resolved,
         // pre-fetch existing document IDs so we skip relationship writes for duplicates
         $preExistingIds = [];

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5562,6 +5562,7 @@ class Database
      * @param int $batchSize
      * @param (callable(Document): void)|null $onNext
      * @param (callable(Throwable): void)|null $onError
+     * @param bool $ignore If true, silently ignore duplicate documents instead of throwing
      * @return int
      * @throws AuthorizationException
      * @throws StructureException
@@ -5574,6 +5575,7 @@ class Database
         int $batchSize = self::INSERT_BATCH_SIZE,
         ?callable $onNext = null,
         ?callable $onError = null,
+        bool $ignore = false,
     ): int {
         if (!$this->adapter->getSharedTables() && $this->adapter->getTenantPerDocument()) {
             throw new DatabaseException('Shared tables must be enabled if tenant per document is enabled.');
@@ -5641,8 +5643,8 @@ class Database
         }
 
         foreach (\array_chunk($documents, $batchSize) as $chunk) {
-            $batch = $this->withTransaction(function () use ($collection, $chunk) {
-                return $this->adapter->createDocuments($collection, $chunk);
+            $batch = $this->withTransaction(function () use ($collection, $chunk, $ignore) {
+                return $this->adapter->createDocuments($collection, $chunk, $ignore);
             });
 
             $batch = $this->adapter->getSequences($collection->getId(), $batch);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5659,7 +5659,7 @@ class Database
         // pre-fetch existing document IDs so we skip relationship writes for duplicates
         $preExistingIds = [];
         $tenantPerDocument = $this->adapter->getSharedTables() && $this->adapter->getTenantPerDocument();
-        if ($ignore && $this->resolveRelationships) {
+        if ($ignore) {
             if ($tenantPerDocument) {
                 $idsByTenant = [];
                 foreach ($documents as $doc) {
@@ -5667,7 +5667,7 @@ class Database
                 }
                 foreach ($idsByTenant as $tenant => $tenantIds) {
                     $tenantIds = \array_values(\array_unique($tenantIds));
-                    foreach (\array_chunk($tenantIds, $this->maxQueryValues) as $idChunk) {
+                    foreach (\array_chunk($tenantIds, \max(1, $this->maxQueryValues)) as $idChunk) {
                         $existing = $this->authorization->skip(fn () => $this->withTenant($tenant, fn () => $this->silent(fn () => $this->find(
                             $collection->getId(),
                             [
@@ -5686,7 +5686,7 @@ class Database
                     \array_map(fn (Document $doc) => $doc->getId(), $documents)
                 )));
 
-                foreach (\array_chunk($inputIds, $this->maxQueryValues) as $idChunk) {
+                foreach (\array_chunk($inputIds, \max(1, $this->maxQueryValues)) as $idChunk) {
                     $existing = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
                         $collection->getId(),
                         [
@@ -5755,6 +5755,18 @@ class Database
         }
 
         foreach (\array_chunk($documents, $batchSize) as $chunk) {
+            if ($ignore && !empty($preExistingIds)) {
+                $chunk = \array_values(\array_filter($chunk, function (Document $doc) use ($preExistingIds, $tenantPerDocument) {
+                    $key = $tenantPerDocument
+                        ? $doc->getTenant() . ':' . $doc->getId()
+                        : $doc->getId();
+                    return !isset($preExistingIds[$key]);
+                }));
+                if (empty($chunk)) {
+                    continue;
+                }
+            }
+
             $batch = $this->withTransaction(function () use ($collection, $chunk, $ignore) {
                 return $this->adapter->createDocuments($collection, $chunk, $ignore);
             });
@@ -7190,7 +7202,7 @@ class Database
                 }
                 foreach ($idsByTenant as $tenant => $tenantIds) {
                     $tenantIds = \array_values(\array_unique($tenantIds));
-                    foreach (\array_chunk($tenantIds, $this->maxQueryValues) as $idChunk) {
+                    foreach (\array_chunk($tenantIds, \max(1, $this->maxQueryValues)) as $idChunk) {
                         $fetched = $this->authorization->skip(fn () => $this->withTenant($tenant, fn () => $this->silent(fn () => $this->find(
                             $collection->getId(),
                             [Query::equal('$id', $idChunk), Query::limit(\count($idChunk))],
@@ -7201,7 +7213,7 @@ class Database
                     }
                 }
             } else {
-                foreach (\array_chunk($uniqueIds, $this->maxQueryValues) as $idChunk) {
+                foreach (\array_chunk($uniqueIds, \max(1, $this->maxQueryValues)) as $idChunk) {
                     $fetched = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
                         $collection->getId(),
                         [Query::equal('$id', $idChunk), Query::limit(\count($idChunk))],

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5655,6 +5655,29 @@ class Database
         $time = DateTime::now();
         $modified = 0;
 
+        // When ignore mode is on and relationships are being resolved,
+        // pre-fetch existing document IDs so we skip relationship writes for duplicates
+        $preExistingIds = [];
+        if ($ignore && $this->resolveRelationships) {
+            $inputIds = \array_values(\array_unique(\array_filter(
+                \array_map(fn (Document $doc) => $doc->getId(), $documents)
+            )));
+
+            foreach (\array_chunk($inputIds, $this->maxQueryValues) as $idChunk) {
+                $existing = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
+                    $collection->getId(),
+                    [
+                        Query::equal('$id', $idChunk),
+                        Query::select(['$id']),
+                        Query::limit(\count($idChunk)),
+                    ]
+                )));
+                foreach ($existing as $doc) {
+                    $preExistingIds[$doc->getId()] = true;
+                }
+            }
+        }
+
         foreach ($documents as $document) {
             $createdAt = $document->getCreatedAt();
             $updatedAt = $document->getUpdatedAt();
@@ -5694,7 +5717,7 @@ class Database
                 }
             }
 
-            if ($this->resolveRelationships) {
+            if ($this->resolveRelationships && !isset($preExistingIds[$document->getId()])) {
                 $document = $this->silent(fn () => $this->createDocumentRelationships($collection, $document));
             }
 
@@ -7135,21 +7158,25 @@ class Database
                 }
                 foreach ($idsByTenant as $tenant => $tenantIds) {
                     $tenantIds = \array_values(\array_unique($tenantIds));
-                    $fetched = $this->authorization->skip(fn () => $this->withTenant($tenant, fn () => $this->silent(fn () => $this->find(
-                        $collection->getId(),
-                        [Query::equal('$id', $tenantIds), Query::limit(\count($tenantIds))],
-                    ))));
-                    foreach ($fetched as $doc) {
-                        $existingDocs[$doc->getId()] = $doc;
+                    foreach (\array_chunk($tenantIds, $this->maxQueryValues) as $idChunk) {
+                        $fetched = $this->authorization->skip(fn () => $this->withTenant($tenant, fn () => $this->silent(fn () => $this->find(
+                            $collection->getId(),
+                            [Query::equal('$id', $idChunk), Query::limit(\count($idChunk))],
+                        ))));
+                        foreach ($fetched as $doc) {
+                            $existingDocs[$doc->getId()] = $doc;
+                        }
                     }
                 }
             } else {
-                $fetched = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
-                    $collection->getId(),
-                    [Query::equal('$id', $uniqueIds), Query::limit(\count($uniqueIds))],
-                )));
-                foreach ($fetched as $doc) {
-                    $existingDocs[$doc->getId()] = $doc;
+                foreach (\array_chunk($uniqueIds, $this->maxQueryValues) as $idChunk) {
+                    $fetched = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
+                        $collection->getId(),
+                        [Query::equal('$id', $idChunk), Query::limit(\count($idChunk))],
+                    )));
+                    foreach ($fetched as $doc) {
+                        $existingDocs[$doc->getId()] = $doc;
+                    }
                 }
             }
         }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5658,22 +5658,46 @@ class Database
         // When ignore mode is on and relationships are being resolved,
         // pre-fetch existing document IDs so we skip relationship writes for duplicates
         $preExistingIds = [];
+        $tenantPerDocument = $this->adapter->getSharedTables() && $this->adapter->getTenantPerDocument();
         if ($ignore && $this->resolveRelationships) {
-            $inputIds = \array_values(\array_unique(\array_filter(
-                \array_map(fn (Document $doc) => $doc->getId(), $documents)
-            )));
-
-            foreach (\array_chunk($inputIds, $this->maxQueryValues) as $idChunk) {
-                $existing = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
-                    $collection->getId(),
-                    [
-                        Query::equal('$id', $idChunk),
-                        Query::select(['$id']),
-                        Query::limit(\count($idChunk)),
-                    ]
+            if ($tenantPerDocument) {
+                $idsByTenant = [];
+                foreach ($documents as $doc) {
+                    $idsByTenant[$doc->getTenant()][] = $doc->getId();
+                }
+                foreach ($idsByTenant as $tenant => $tenantIds) {
+                    $tenantIds = \array_values(\array_unique($tenantIds));
+                    foreach (\array_chunk($tenantIds, $this->maxQueryValues) as $idChunk) {
+                        $existing = $this->authorization->skip(fn () => $this->withTenant($tenant, fn () => $this->silent(fn () => $this->find(
+                            $collection->getId(),
+                            [
+                                Query::equal('$id', $idChunk),
+                                Query::select(['$id']),
+                                Query::limit(\count($idChunk)),
+                            ]
+                        ))));
+                        foreach ($existing as $doc) {
+                            $preExistingIds[$tenant . ':' . $doc->getId()] = true;
+                        }
+                    }
+                }
+            } else {
+                $inputIds = \array_values(\array_unique(\array_filter(
+                    \array_map(fn (Document $doc) => $doc->getId(), $documents)
                 )));
-                foreach ($existing as $doc) {
-                    $preExistingIds[$doc->getId()] = true;
+
+                foreach (\array_chunk($inputIds, $this->maxQueryValues) as $idChunk) {
+                    $existing = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
+                        $collection->getId(),
+                        [
+                            Query::equal('$id', $idChunk),
+                            Query::select(['$id']),
+                            Query::limit(\count($idChunk)),
+                        ]
+                    )));
+                    foreach ($existing as $doc) {
+                        $preExistingIds[$doc->getId()] = true;
+                    }
                 }
             }
         }
@@ -5717,8 +5741,14 @@ class Database
                 }
             }
 
-            if ($this->resolveRelationships && !isset($preExistingIds[$document->getId()])) {
-                $document = $this->silent(fn () => $this->createDocumentRelationships($collection, $document));
+            if ($this->resolveRelationships) {
+                $preExistKey = $tenantPerDocument
+                    ? $document->getTenant() . ':' . $document->getId()
+                    : $document->getId();
+
+                if (!isset($preExistingIds[$preExistKey])) {
+                    $document = $this->silent(fn () => $this->createDocumentRelationships($collection, $document));
+                }
             }
 
             $document = $this->adapter->castingBefore($collection, $document);
@@ -7145,12 +7175,14 @@ class Database
         // Batch-fetch existing documents in one query instead of N individual getDocument() calls
         $ids = \array_filter(\array_map(fn ($doc) => $doc->getId(), $documents));
         $existingDocs = [];
+        $upsertTenantPerDocument = $this->getSharedTables() && $this->getTenantPerDocument();
 
         if (!empty($ids)) {
             $uniqueIds = \array_values(\array_unique($ids));
 
-            if ($this->getSharedTables() && $this->getTenantPerDocument()) {
+            if ($upsertTenantPerDocument) {
                 // Group IDs by tenant and fetch each group separately
+                // Use composite key tenant:id to avoid cross-tenant collisions
                 $idsByTenant = [];
                 foreach ($documents as $doc) {
                     $tenant = $doc->getTenant();
@@ -7164,7 +7196,7 @@ class Database
                             [Query::equal('$id', $idChunk), Query::limit(\count($idChunk))],
                         ))));
                         foreach ($fetched as $doc) {
-                            $existingDocs[$doc->getId()] = $doc;
+                            $existingDocs[$tenant . ':' . $doc->getId()] = $doc;
                         }
                     }
                 }
@@ -7182,7 +7214,10 @@ class Database
         }
 
         foreach ($documents as $key => $document) {
-            $old = $existingDocs[$document->getId()] ?? new Document();
+            $lookupKey = $upsertTenantPerDocument
+                ? $document->getTenant() . ':' . $document->getId()
+                : $document->getId();
+            $old = $existingDocs[$lookupKey] ?? new Document();
 
             // Extract operators early to avoid comparison issues
             $documentArray = $document->getArrayCopy();

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -7118,18 +7118,44 @@ class Database
         $created = 0;
         $updated = 0;
         $seenIds = [];
-        foreach ($documents as $key => $document) {
+
+        // Batch-fetch existing documents in one query instead of N individual getDocument() calls
+        $ids = \array_filter(\array_map(fn ($doc) => $doc->getId(), $documents));
+        $existingDocs = [];
+
+        if (!empty($ids)) {
+            $uniqueIds = \array_values(\array_unique($ids));
+
             if ($this->getSharedTables() && $this->getTenantPerDocument()) {
-                $old = $this->authorization->skip(fn () => $this->withTenant($document->getTenant(), fn () => $this->silent(fn () => $this->getDocument(
-                    $collection->getId(),
-                    $document->getId(),
-                ))));
+                // Group IDs by tenant and fetch each group separately
+                $idsByTenant = [];
+                foreach ($documents as $doc) {
+                    $tenant = $doc->getTenant();
+                    $idsByTenant[$tenant][] = $doc->getId();
+                }
+                foreach ($idsByTenant as $tenant => $tenantIds) {
+                    $tenantIds = \array_values(\array_unique($tenantIds));
+                    $fetched = $this->authorization->skip(fn () => $this->withTenant($tenant, fn () => $this->silent(fn () => $this->find(
+                        $collection->getId(),
+                        [Query::equal('$id', $tenantIds), Query::limit(\count($tenantIds))],
+                    ))));
+                    foreach ($fetched as $doc) {
+                        $existingDocs[$doc->getId()] = $doc;
+                    }
+                }
             } else {
-                $old = $this->authorization->skip(fn () => $this->silent(fn () => $this->getDocument(
+                $fetched = $this->authorization->skip(fn () => $this->silent(fn () => $this->find(
                     $collection->getId(),
-                    $document->getId(),
+                    [Query::equal('$id', $uniqueIds), Query::limit(\count($uniqueIds))],
                 )));
+                foreach ($fetched as $doc) {
+                    $existingDocs[$doc->getId()] = $doc;
+                }
             }
+        }
+
+        foreach ($documents as $key => $document) {
+            $old = $existingDocs[$document->getId()] ?? new Document();
 
             // Extract operators early to avoid comparison issues
             $documentArray = $document->getArrayCopy();

--- a/src/Database/Mirror.php
+++ b/src/Database/Mirror.php
@@ -600,6 +600,7 @@ class Mirror extends Database
         int $batchSize = self::INSERT_BATCH_SIZE,
         ?callable $onNext = null,
         ?callable $onError = null,
+        bool $ignore = false,
     ): int {
         $modified = $this->source->createDocuments(
             $collection,
@@ -607,6 +608,7 @@ class Mirror extends Database
             $batchSize,
             $onNext,
             $onError,
+            $ignore,
         );
 
         if (
@@ -645,6 +647,7 @@ class Mirror extends Database
                     $collection,
                     $clones,
                     $batchSize,
+                    ignore: $ignore,
                 )
             );
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -7722,4 +7722,122 @@ trait DocumentTests
     //        }
     //        $database->deleteCollection($collectionName);
     //    }
+
+    public function testCreateDocumentsIgnoreDuplicates(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $database->createCollection(__FUNCTION__);
+        $database->createAttribute(__FUNCTION__, 'name', Database::VAR_STRING, 128, true);
+
+        // Insert initial documents
+        $database->createDocuments(__FUNCTION__, [
+            new Document([
+                '$id' => 'doc1',
+                'name' => 'Original A',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+            new Document([
+                '$id' => 'doc2',
+                'name' => 'Original B',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+        ]);
+
+        // Without ignore, duplicates should throw
+        try {
+            $database->createDocuments(__FUNCTION__, [
+                new Document([
+                    '$id' => 'doc1',
+                    'name' => 'Duplicate A',
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::create(Role::any()),
+                    ],
+                ]),
+            ]);
+            $this->fail('Expected DuplicateException');
+        } catch (DuplicateException $e) {
+            $this->assertNotEmpty($e->getMessage());
+        }
+
+        // With ignore, duplicates should be silently skipped
+        $count = $database->createDocuments(__FUNCTION__, [
+            new Document([
+                '$id' => 'doc1',
+                'name' => 'Duplicate A',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+            new Document([
+                '$id' => 'doc3',
+                'name' => 'New C',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+        ], ignore: true);
+
+        // doc3 should exist, doc1 should retain original value
+        $doc1 = $database->getDocument(__FUNCTION__, 'doc1');
+        $this->assertSame('Original A', $doc1->getAttribute('name'));
+
+        $doc3 = $database->getDocument(__FUNCTION__, 'doc3');
+        $this->assertSame('New C', $doc3->getAttribute('name'));
+
+        // Total should be 3 (doc1, doc2, doc3)
+        $all = $database->find(__FUNCTION__);
+        $this->assertCount(3, $all);
+    }
+
+    public function testCreateDocumentsIgnoreAllDuplicates(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $database->createCollection(__FUNCTION__);
+        $database->createAttribute(__FUNCTION__, 'name', Database::VAR_STRING, 128, true);
+
+        // Insert initial document
+        $database->createDocuments(__FUNCTION__, [
+            new Document([
+                '$id' => 'existing',
+                'name' => 'Original',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+        ]);
+
+        // With ignore, inserting only duplicates should succeed with no new rows
+        $count = $database->createDocuments(__FUNCTION__, [
+            new Document([
+                '$id' => 'existing',
+                'name' => 'Duplicate',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+        ], ignore: true);
+
+        // Original document should be unchanged
+        $doc = $database->getDocument(__FUNCTION__, 'existing');
+        $this->assertSame('Original', $doc->getAttribute('name'));
+
+        // Still only 1 document
+        $all = $database->find(__FUNCTION__);
+        $this->assertCount(1, $all);
+    }
 }

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -7788,6 +7788,9 @@ trait DocumentTests
             ]),
         ], ignore: true);
 
+        // Only doc3 was new, doc1 was skipped as duplicate
+        $this->assertSame(1, $count);
+
         // doc3 should exist, doc1 should retain original value
         $doc1 = $database->getDocument(__FUNCTION__, 'doc1');
         $this->assertSame('Original A', $doc1->getAttribute('name'));
@@ -7831,6 +7834,9 @@ trait DocumentTests
                 ],
             ]),
         ], ignore: true);
+
+        // All duplicates skipped, nothing inserted
+        $this->assertSame(0, $count);
 
         // Original document should be unchanged
         $doc = $database->getDocument(__FUNCTION__, 'existing');

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -7769,6 +7769,7 @@ trait DocumentTests
         }
 
         // With ignore, duplicates should be silently skipped
+        $emittedIds = [];
         $count = $database->createDocuments(__FUNCTION__, [
             new Document([
                 '$id' => 'doc1',
@@ -7786,10 +7787,14 @@ trait DocumentTests
                     Permission::create(Role::any()),
                 ],
             ]),
-        ], ignore: true);
+        ], onNext: function (Document $doc) use (&$emittedIds) {
+            $emittedIds[] = $doc->getId();
+        }, ignore: true);
 
         // Only doc3 was new, doc1 was skipped as duplicate
         $this->assertSame(1, $count);
+        $this->assertCount(1, $emittedIds);
+        $this->assertSame('doc3', $emittedIds[0]);
 
         // doc3 should exist, doc1 should retain original value
         $doc1 = $database->getDocument(__FUNCTION__, 'doc1');
@@ -7801,6 +7806,69 @@ trait DocumentTests
         // Total should be 3 (doc1, doc2, doc3)
         $all = $database->find(__FUNCTION__);
         $this->assertCount(3, $all);
+    }
+
+    public function testCreateDocumentsIgnoreIntraBatchDuplicates(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+        $col = 'createDocsIgnoreIntraBatch';
+
+        $database->createCollection($col);
+        $database->createAttribute($col, 'name', Database::VAR_STRING, 128, true);
+
+        // Two docs with same ID in one batch — first wins, second is deduplicated
+        $emittedIds = [];
+        $count = $database->createDocuments($col, [
+            new Document([
+                '$id' => 'dup',
+                'name' => 'First',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+            new Document([
+                '$id' => 'dup',
+                'name' => 'Second',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                    Permission::update(Role::user('extra')),
+                ],
+            ]),
+            new Document([
+                '$id' => 'unique1',
+                'name' => 'Unique',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::create(Role::any()),
+                ],
+            ]),
+        ], onNext: function (Document $doc) use (&$emittedIds) {
+            $emittedIds[] = $doc->getId();
+        }, ignore: true);
+
+        $this->assertSame(2, $count);
+        $this->assertCount(2, $emittedIds);
+
+        // First occurrence wins
+        $doc = $database->getDocument($col, 'dup');
+        $this->assertSame('First', $doc->getAttribute('name'));
+
+        // Second doc's extra permission should NOT exist (no ACL drift)
+        $perms = $doc->getPermissions();
+        foreach ($perms as $perm) {
+            $this->assertStringNotContainsString('extra', $perm);
+        }
+
+        // unique1 should exist
+        $unique = $database->getDocument($col, 'unique1');
+        $this->assertSame('Unique', $unique->getAttribute('name'));
+
+        // Total: 2 documents
+        $all = $database->find($col);
+        $this->assertCount(2, $all);
     }
 
     public function testCreateDocumentsIgnoreAllDuplicates(): void
@@ -7824,6 +7892,7 @@ trait DocumentTests
         ]);
 
         // With ignore, inserting only duplicates should succeed with no new rows
+        $emittedIds = [];
         $count = $database->createDocuments(__FUNCTION__, [
             new Document([
                 '$id' => 'existing',
@@ -7833,10 +7902,13 @@ trait DocumentTests
                     Permission::create(Role::any()),
                 ],
             ]),
-        ], ignore: true);
+        ], onNext: function (Document $doc) use (&$emittedIds) {
+            $emittedIds[] = $doc->getId();
+        }, ignore: true);
 
         // All duplicates skipped, nothing inserted
         $this->assertSame(0, $count);
+        $this->assertSame([], $emittedIds);
 
         // Original document should be unchanged
         $doc = $database->getDocument(__FUNCTION__, 'existing');


### PR DESCRIPTION
## Summary
- Adds `bool $ignore = false` parameter to `createDocuments` across all adapters
- When `ignore` is true, duplicate documents are silently skipped instead of throwing
- MariaDB/MySQL: `INSERT IGNORE INTO`
- SQLite: `INSERT OR IGNORE INTO`
- Postgres: `ON CONFLICT DO NOTHING`
- MongoDB: `ordered: false` with duplicate error suppression
- Also applies ignore to the permissions INSERT statement
- Threads `ignore` param from `Database.php` → `Adapter` → SQL/Mongo implementations

## Test plan
- [ ] Run existing `createDocuments` tests to verify no regression
- [ ] Test `createDocuments` with `ignore: true` inserting documents with duplicate IDs — should not throw
- [ ] Verify on MariaDB, Postgres, SQLite adapters
- [ ] Verify permissions table also uses ignore when flag is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk document creation gains an optional "ignore" mode that skips duplicate documents instead of failing, available across adapters and mirroring.

* **Performance**
  * Upsert operations now pre-batch existence checks, reducing per-item lookups and improving large-batch throughput.

* **Behavior**
  * Create/insert and mirror flows propagate the new ignore flag so duplicate-insert attempts are handled gracefully.

* **Tests**
  * Added end-to-end tests validating duplicate-ignore scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->