### PR TITLE
feat: add StructureException handling for invalid datetime values in …

### DIFF
--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -13,6 +13,7 @@ use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
+use Utopia\Database\Exception\Structure as StructureException;
 use Utopia\Database\Exception\Timeout as TimeoutException;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Exception\Type as TypeException;
@@ -1414,7 +1415,11 @@ class Mongo extends Adapter
                 switch ($type) {
                     case Database::VAR_DATETIME:
                         if (!($node instanceof UTCDateTime)) {
-                            $node = new UTCDateTime(new \DateTime($node));
+                            try {
+                                $node = new UTCDateTime(new \DateTime($node));
+                            } catch (\Throwable $e) {
+                                throw new StructureException('Invalid datetime value for attribute "' . $key . '": ' . $e->getMessage());
+                            }
                         }
                         break;
                     case Database::VAR_OBJECT:

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -5801,6 +5801,63 @@ trait DocumentTests
         $database->deleteCollection($collection);
     }
 
+    public function testInvalidCreatedAndUpdatedAtThrowStructureException(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+        $collection = 'invalid_date_attributes';
+
+        $database->createCollection($collection);
+        $this->assertEquals(true, $database->createAttribute($collection, 'string', Database::VAR_STRING, 128, false));
+
+        $invalidDates = [
+            'not-a-date',
+            '2026-13-01T00:00:00.000+00:00',
+        ];
+
+        $database->setPreserveDates(true);
+
+        try {
+            foreach ($invalidDates as $index => $invalidDate) {
+                foreach (['$createdAt', '$updatedAt'] as $attribute) {
+                    try {
+                        if ($attribute === '$createdAt') {
+                            $database->createDocument($collection, new Document([
+                                '$id' => $attribute . '-' . $index,
+                                '$permissions' => [
+                                    Permission::read(Role::any()),
+                                    Permission::write(Role::any()),
+                                    Permission::update(Role::any()),
+                                ],
+                                'string' => 'invalid-date',
+                                $attribute => $invalidDate,
+                            ]));
+                        } else {
+                            $document = $database->createDocument($collection, new Document([
+                                '$id' => 'doc-' . $index,
+                                '$permissions' => [
+                                    Permission::read(Role::any()),
+                                    Permission::write(Role::any()),
+                                    Permission::update(Role::any()),
+                                ],
+                                'string' => 'valid-date',
+                            ]));
+                            $document->setAttribute($attribute, $invalidDate);
+                            $database->updateDocument($collection, $document->getId(), $document);
+                        }
+
+                        $this->fail('Expected StructureException for invalid ' . $attribute);
+                    } catch (Throwable $e) {
+                        $this->assertInstanceOf(StructureException::class, $e);
+                    }
+                }
+            }
+        } finally {
+            $database->setPreserveDates(false);
+            $database->deleteCollection($collection);
+        }
+    }
+
     public function testSingleDocumentDateOperations(): void
     {
         /** @var Database $database */

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -5805,52 +5805,53 @@ trait DocumentTests
     {
         /** @var Database $database */
         $database = $this->getDatabase();
+
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
         $collection = 'invalid_date_attributes';
 
         $database->createCollection($collection);
         $this->assertEquals(true, $database->createAttribute($collection, 'string', Database::VAR_STRING, 128, false));
 
-        $invalidDates = [
-            'not-a-date',
-            '2026-13-01T00:00:00.000+00:00',
-        ];
-
         $database->setPreserveDates(true);
 
         try {
-            foreach ($invalidDates as $index => $invalidDate) {
-                foreach (['$createdAt', '$updatedAt'] as $attribute) {
-                    try {
-                        if ($attribute === '$createdAt') {
-                            $database->createDocument($collection, new Document([
-                                '$id' => $attribute . '-' . $index,
-                                '$permissions' => [
-                                    Permission::read(Role::any()),
-                                    Permission::write(Role::any()),
-                                    Permission::update(Role::any()),
-                                ],
-                                'string' => 'invalid-date',
-                                $attribute => $invalidDate,
-                            ]));
-                        } else {
-                            $document = $database->createDocument($collection, new Document([
-                                '$id' => 'doc-' . $index,
-                                '$permissions' => [
-                                    Permission::read(Role::any()),
-                                    Permission::write(Role::any()),
-                                    Permission::update(Role::any()),
-                                ],
-                                'string' => 'valid-date',
-                            ]));
-                            $document->setAttribute($attribute, $invalidDate);
-                            $database->updateDocument($collection, $document->getId(), $document);
-                        }
+            // Outside allowed year range (Structure uses DatetimeValidator min/max, e.g. 0000–9999).
+            $invalidDate = '10000-01-01T00:00:00.000+00:00';
 
-                        $this->fail('Expected StructureException for invalid ' . $attribute);
-                    } catch (Throwable $e) {
-                        $this->assertInstanceOf(StructureException::class, $e);
-                    }
-                }
+            try {
+                $database->createDocument($collection, new Document([
+                    '$id' => 'doc1',
+                    '$permissions' => [
+                        Permission::read(Role::any()),
+                        Permission::update(Role::any()),
+                    ],
+                    '$createdAt' => $invalidDate,
+                ]));
+                $this->fail('Expected StructureException for invalid $createdAt');
+            } catch (Throwable $e) {
+                $this->assertInstanceOf(StructureException::class, $e);
+            }
+
+            $database->createDocument($collection, new Document([
+                '$id' => 'doc2',
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                ],
+                'string' => 'x',
+            ]));
+
+            try {
+                $database->updateDocument($collection, 'doc2', new Document([
+                    '$updatedAt' => $invalidDate,
+                ]));
+                $this->fail('Expected StructureException for invalid $updatedAt');
+            } catch (Throwable $e) {
+                $this->assertInstanceOf(StructureException::class, $e);
             }
         } finally {
             $database->setPreserveDates(false);


### PR DESCRIPTION
…Mongo adapter and corresponding tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for datetime validation: invalid non-UTC datetime inputs now raise clear structure validation errors that identify the affected attribute and reason.

* **Tests**
  * Added end-to-end tests covering invalid datetime values for created/updated timestamps to ensure structured errors are thrown and preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->