### PR TITLE
fix: wrap cache purge operations in try-catch for graceful degradation

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8214,12 +8214,16 @@ class Database
     {
         [$collectionKey] = $this->getCacheKeys($collectionId);
 
-        $documentKeys = $this->cache->list($collectionKey);
-        foreach ($documentKeys as $documentKey) {
-            $this->cache->purge($documentKey);
-        }
+        try {
+            $documentKeys = $this->cache->list($collectionKey);
+            foreach ($documentKeys as $documentKey) {
+                $this->cache->purge($documentKey);
+            }
 
-        $this->cache->purge($collectionKey);
+            $this->cache->purge($collectionKey);
+        } catch (Exception $e) {
+            Console::warning('Failed to purge collection from cache: ' . $e->getMessage());
+        }
 
         return true;
     }
@@ -8241,8 +8245,12 @@ class Database
 
         [$collectionKey, $documentKey] = $this->getCacheKeys($collectionId, $id);
 
-        $this->cache->purge($collectionKey, $documentKey);
-        $this->cache->purge($documentKey);
+        try {
+            $this->cache->purge($collectionKey, $documentKey);
+            $this->cache->purge($documentKey);
+        } catch (Exception $e) {
+            Console::warning('Failed to purge document from cache: ' . $e->getMessage());
+        }
 
         return true;
     }


### PR DESCRIPTION
## Summary
- Wrap `purgeCachedCollection()` and `purgeCachedDocumentInternal()` in try-catch blocks
- Log warning messages instead of throwing exceptions when cache purge fails
- Match existing pattern used for cache load and save operations

## Context
During a production incident, cache failures on purge operations propagated as exceptions, causing HTTP request failures. This change ensures cache infrastructure issues don't cascade to application failures.

## Test plan
- [ ] Existing unit tests pass
- [ ] Cache purge failures now log warnings instead of throwing
- [ ] HTTP requests complete successfully even when cache is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cache invalidation stability with improved error handling to prevent operation failures from impacting system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->