### PR TITLE
feat: add Query::fingerprint() for shape-only query hashing

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -420,6 +420,41 @@ class Query
     }
 
     /**
+     * Compute a shape-only fingerprint of an array of queries.
+     *
+     * The fingerprint captures the structure of the queries — method and
+     * attribute — without values. Two query sets with the same shape but
+     * different parameter values produce the same fingerprint, which is
+     * useful for pattern-based counting and slow-query grouping.
+     *
+     * Accepts either raw query strings or parsed Query objects.
+     *
+     * @param array<string|Query> $queries
+     * @return string md5 hash of the canonical shape
+     * @throws QueryException
+     */
+    public static function fingerprint(array $queries): string
+    {
+        $shapes = [];
+
+        foreach ($queries as $query) {
+            if (\is_string($query)) {
+                $query = self::parse($query);
+            }
+
+            if (!$query instanceof self) {
+                continue;
+            }
+
+            $shapes[] = $query->getMethod() . ':' . $query->getAttribute();
+        }
+
+        \sort($shapes);
+
+        return \md5(\implode('|', $shapes));
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(): array

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -427,9 +427,9 @@ class Query
      * different parameter values produce the same fingerprint, which is
      * useful for pattern-based counting and slow-query grouping.
      *
-     * Logical queries (`and`, `or`, `elemMatch`) are recursively fingerprinted
-     * so their inner structure contributes to the hash — two `and(...)`
-     * queries with different child shapes produce different fingerprints.
+     * Logical queries (`and`, `or`, `elemMatch`) contribute their inner
+     * structure to the hash via `Query::shape()` — two `and(...)` queries
+     * with different child shapes produce different fingerprints.
      *
      * Accepts either raw query strings or parsed Query objects.
      *
@@ -450,7 +450,7 @@ class Query
                 throw new QueryException('Invalid query element for fingerprint: expected string or Query instance');
             }
 
-            $shapes[] = self::queryShape($query);
+            $shapes[] = $query->shape();
         }
 
         \sort($shapes);
@@ -459,28 +459,60 @@ class Query
     }
 
     /**
-     * Canonical shape string for a single Query — recursive for logical types.
+     * Canonical shape string for this Query — values excluded.
      *
-     * @param Query $query
+     * Non-logical queries produce `method:attribute`. Logical queries
+     * (`and`, `or`, `elemMatch`) produce `method:attribute(child1|child2|…)`
+     * with children sorted so child order does not affect the shape.
+     *
+     * Implemented iteratively: walks the tree into a preorder list via a
+     * stack, then processes the reversed list so each node's children are
+     * always resolved before the node itself.
+     *
      * @return string
      */
-    private static function queryShape(self $query): string
+    public function shape(): string
     {
-        $method = $query->getMethod();
+        // 1. Preorder flatten the tree.
+        $nodes = [];
+        $stack = [$this];
+        while ($stack) {
+            /** @var self $node */
+            $node = \array_pop($stack);
+            $nodes[] = $node;
 
-        if (\in_array($method, self::LOGICAL_TYPES, true)) {
-            $childShapes = [];
-            foreach ($query->getValues() as $child) {
+            if (!\in_array($node->method, self::LOGICAL_TYPES, true)) {
+                continue;
+            }
+            foreach ($node->values as $child) {
                 if ($child instanceof self) {
-                    $childShapes[] = self::queryShape($child);
+                    $stack[] = $child;
+                }
+            }
+        }
+
+        // 2. Process reversed so children are always shaped before parents.
+        $shapes = [];
+        foreach (\array_reverse($nodes) as $node) {
+            $id = \spl_object_id($node);
+
+            if (!\in_array($node->method, self::LOGICAL_TYPES, true)) {
+                $shapes[$id] = $node->method . ':' . $node->attribute;
+                continue;
+            }
+
+            $childShapes = [];
+            foreach ($node->values as $child) {
+                if ($child instanceof self) {
+                    $childShapes[] = $shapes[\spl_object_id($child)];
                 }
             }
             \sort($childShapes);
             // Attribute is empty for and/or; meaningful for elemMatch (the field being matched).
-            return $method . ':' . $query->getAttribute() . '(' . \implode('|', $childShapes) . ')';
+            $shapes[$id] = $node->method . ':' . $node->attribute . '(' . \implode('|', $childShapes) . ')';
         }
 
-        return $method . ':' . $query->getAttribute();
+        return $shapes[\spl_object_id($this)];
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -427,11 +427,15 @@ class Query
      * different parameter values produce the same fingerprint, which is
      * useful for pattern-based counting and slow-query grouping.
      *
+     * Logical queries (`and`, `or`, `elemMatch`) are recursively fingerprinted
+     * so their inner structure contributes to the hash — two `and(...)`
+     * queries with different child shapes produce different fingerprints.
+     *
      * Accepts either raw query strings or parsed Query objects.
      *
-     * @param array<string|Query> $queries
+     * @param array<mixed> $queries raw query strings or Query instances
      * @return string md5 hash of the canonical shape
-     * @throws QueryException
+     * @throws QueryException if an element is neither a string nor a Query
      */
     public static function fingerprint(array $queries): string
     {
@@ -443,15 +447,39 @@ class Query
             }
 
             if (!$query instanceof self) {
-                continue;
+                throw new QueryException('Invalid query element for fingerprint: expected string or Query instance');
             }
 
-            $shapes[] = $query->getMethod() . ':' . $query->getAttribute();
+            $shapes[] = self::queryShape($query);
         }
 
         \sort($shapes);
 
         return \md5(\implode('|', $shapes));
+    }
+
+    /**
+     * Canonical shape string for a single Query — recursive for logical types.
+     *
+     * @param Query $query
+     * @return string
+     */
+    private static function queryShape(self $query): string
+    {
+        $method = $query->getMethod();
+
+        if (\in_array($method, self::LOGICAL_TYPES, true)) {
+            $childShapes = [];
+            foreach ($query->getValues() as $child) {
+                if ($child instanceof self) {
+                    $childShapes[] = self::queryShape($child);
+                }
+            }
+            \sort($childShapes);
+            return $method . '(' . \implode('|', $childShapes) . ')';
+        }
+
+        return $method . ':' . $query->getAttribute();
     }
 
     /**

--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -476,7 +476,8 @@ class Query
                 }
             }
             \sort($childShapes);
-            return $method . '(' . \implode('|', $childShapes) . ')';
+            // Attribute is empty for and/or; meaningful for elemMatch (the field being matched).
+            return $method . ':' . $query->getAttribute() . '(' . \implode('|', $childShapes) . ')';
         }
 
         return $method . ':' . $query->getAttribute();

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -544,4 +544,35 @@ class QueryTest extends TestCase
         $this->expectException(QueryException::class);
         Query::fingerprint([42]);
     }
+
+    public function testShape(): void
+    {
+        // Leaf queries
+        $this->assertSame('equal:name', Query::equal('name', ['Alice'])->shape());
+        $this->assertSame('greaterThan:age', Query::greaterThan('age', 18)->shape());
+
+        // Logical with empty attribute
+        $and = Query::and([Query::equal('name', ['Alice']), Query::greaterThan('age', 18)]);
+        $this->assertSame('and:(equal:name|greaterThan:age)', $and->shape());
+
+        // elemMatch preserves the attribute (the field being matched)
+        $elem = new Query(Query::TYPE_ELEM_MATCH, 'tags', [Query::equal('name', ['php'])]);
+        $this->assertSame('elemMatch:tags(equal:name)', $elem->shape());
+
+        // Deeply nested — iterative traversal must match recursive result
+        $deep = Query::and([
+            Query::or([
+                Query::equal('a', ['x']),
+                Query::and([
+                    Query::equal('b', ['y']),
+                    Query::lessThan('c', 5),
+                ]),
+            ]),
+            Query::greaterThan('d', 10),
+        ]);
+        $this->assertSame(
+            'and:(greaterThan:d|or:(and:(equal:b|lessThan:c)|equal:a))',
+            $deep->shape(),
+        );
+    }
 }

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -503,4 +503,36 @@ class QueryTest extends TestCase
         // Empty array returns deterministic hash
         $this->assertSame(\md5(''), Query::fingerprint([]));
     }
+
+    public function testFingerprintNestedLogicalQueries(): void
+    {
+        // AND queries with different inner shapes produce different fingerprints
+        $andEqName = Query::and([Query::equal('name', ['Alice'])]);
+        $andEqEmail = Query::and([Query::equal('email', ['a@b.c'])]);
+        $this->assertNotSame(Query::fingerprint([$andEqName]), Query::fingerprint([$andEqEmail]));
+
+        // AND queries with same inner shape produce the same fingerprint (values differ)
+        $andEqNameBob = Query::and([Query::equal('name', ['Bob'])]);
+        $this->assertSame(Query::fingerprint([$andEqName]), Query::fingerprint([$andEqNameBob]));
+
+        // Order of children inside a logical query does not matter
+        $andA = Query::and([Query::equal('name', ['Alice']), Query::greaterThan('age', 18)]);
+        $andB = Query::and([Query::greaterThan('age', 42), Query::equal('name', ['Bob'])]);
+        $this->assertSame(Query::fingerprint([$andA]), Query::fingerprint([$andB]));
+
+        // AND of two filters differs from OR of the same two filters
+        $orA = Query::or([Query::equal('name', ['Alice']), Query::greaterThan('age', 18)]);
+        $this->assertNotSame(Query::fingerprint([$andA]), Query::fingerprint([$orA]));
+
+        // AND with one child differs from AND with two children
+        $andOne = Query::and([Query::equal('name', ['Alice'])]);
+        $andTwo = Query::and([Query::equal('name', ['Alice']), Query::greaterThan('age', 18)]);
+        $this->assertNotSame(Query::fingerprint([$andOne]), Query::fingerprint([$andTwo]));
+    }
+
+    public function testFingerprintRejectsInvalidElements(): void
+    {
+        $this->expectException(QueryException::class);
+        Query::fingerprint([42]);
+    }
 }

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -528,6 +528,15 @@ class QueryTest extends TestCase
         $andOne = Query::and([Query::equal('name', ['Alice'])]);
         $andTwo = Query::and([Query::equal('name', ['Alice']), Query::greaterThan('age', 18)]);
         $this->assertNotSame(Query::fingerprint([$andOne]), Query::fingerprint([$andTwo]));
+
+        // elemMatch attribute matters: same inner shape on different fields must NOT collide
+        $elemTags = new Query(Query::TYPE_ELEM_MATCH, 'tags', [Query::equal('name', ['php'])]);
+        $elemCategories = new Query(Query::TYPE_ELEM_MATCH, 'categories', [Query::equal('name', ['php'])]);
+        $this->assertNotSame(Query::fingerprint([$elemTags]), Query::fingerprint([$elemCategories]));
+
+        // elemMatch values-only change (same field, same child shape) still collides — as expected
+        $elemTagsOther = new Query(Query::TYPE_ELEM_MATCH, 'tags', [Query::equal('name', ['js'])]);
+        $this->assertSame(Query::fingerprint([$elemTags]), Query::fingerprint([$elemTagsOther]));
     }
 
     public function testFingerprintRejectsInvalidElements(): void

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -468,4 +468,39 @@ class QueryTest extends TestCase
         $this->assertContains(Query::TYPE_NOT_BETWEEN, Query::TYPES);
         $this->assertContains(Query::TYPE_ORDER_RANDOM, Query::TYPES);
     }
+
+    public function testFingerprint(): void
+    {
+        $equalAlice = '{"method":"equal","attribute":"name","values":["Alice"]}';
+        $equalBob = '{"method":"equal","attribute":"name","values":["Bob"]}';
+        $equalEmail = '{"method":"equal","attribute":"email","values":["a@b.c"]}';
+        $notEqualAlice = '{"method":"notEqual","attribute":"name","values":["Alice"]}';
+        $gtAge18 = '{"method":"greaterThan","attribute":"age","values":[18]}';
+        $gtAge42 = '{"method":"greaterThan","attribute":"age","values":[42]}';
+
+        // Same shape, different values produce the same fingerprint
+        $a = Query::fingerprint([$equalAlice, $gtAge18]);
+        $b = Query::fingerprint([$equalBob, $gtAge42]);
+        $this->assertSame($a, $b);
+
+        // Different attribute produces different fingerprint
+        $c = Query::fingerprint([$equalEmail, $gtAge18]);
+        $this->assertNotSame($a, $c);
+
+        // Different method produces different fingerprint
+        $d = Query::fingerprint([$notEqualAlice, $gtAge18]);
+        $this->assertNotSame($a, $d);
+
+        // Order-independent
+        $e = Query::fingerprint([$gtAge18, $equalAlice]);
+        $this->assertSame($a, $e);
+
+        // Accepts parsed Query objects
+        $parsed = [Query::equal('name', ['Alice']), Query::greaterThan('age', 18)];
+        $f = Query::fingerprint($parsed);
+        $this->assertSame($a, $f);
+
+        // Empty array returns deterministic hash
+        $this->assertSame(\md5(''), Query::fingerprint([]));
+    }
 }


### PR DESCRIPTION
## Summary
Adds `Query::fingerprint(array $queries): string` — a static helper that computes a deterministic hash of query structure (method + attribute) with values excluded.

## Why
Useful for grouping queries by pattern — for example, slow-query analytics where two queries with the same shape but different parameter values should count as the same pattern. Two queries like `equal("name", "Alice")` and `equal("name", "Bob")` produce the same fingerprint.

## Behavior
- Accepts raw query strings or already-parsed `Query` objects
- Order-independent (sorts shapes before hashing)
- Returns md5 hash of canonical `method:attribute|method:attribute|...` string
- Empty array returns a deterministic hash (`md5('')`)

## Test plan
Added `testFingerprint()` in `tests/unit/QueryTest.php` covering:
- Same shape different values → same hash
- Different attribute → different hash
- Different method → different hash
- Order-independence
- Accepts parsed `Query` objects
- Empty array behavior

All 5 tests pass locally (257 assertions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added query fingerprinting to generate consistent identifiers for queries with the same structure, independent of literal values and array order; accepts serialized or structured queries and returns a deterministic hash (empty input yields a stable result).
* **Tests**
  * Added unit tests verifying shape-only equality, order-independence, logical grouping behavior, input formats, and invalid-input error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->