### PR TITLE
(chore): pin claude-pr-owner to v0.2.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@e6baaab0ae24628a4d6e8b695b49a77f37e797f7 # v0.1.0
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@5ba5982d9d9ccb53bc8f33088124ef8bdb05cf13 # v0.2.0
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:


### PR DESCRIPTION
## Summary
- Bumps the Claude PR orchestrator pin to [v0.2.0](https://github.com/abnegate/claude-pr-owner/releases/tag/v0.2.0).

v0.2.0 fixes two bugs that made Claude silently no-op on every PR:

1. **Unexpanded prompt variables** — the reusable workflow passed a prompt containing literal `$TASK`, `$PR_NUMBER`, `$REPO`, `$HEAD_BRANCH`, `$HEAD_SHA`, `$REVIEWER`, `$REVIEW_ID`, `$FAILED_RUN_ID` to \`claude-code-action\`. Those never expanded, so Claude saw raw shell placeholders and bailed. Now built in a prior shell step. User-controlled bodies (comments/issues) are substituted via a Python one-liner so backticks / \`\${…}\` / quotes in malicious bodies stay literal.
2. **classify-complexity auth** — the native \`claude\` CLI installed by \`install.sh\` does not read \`CLAUDE_CODE_OAUTH_TOKEN\` from env, so classification always exited with \"Not logged in · Please run /login\" and silently routed to opus. Now writes \`~/.claude/.credentials.json\` before invoking the CLI.

See https://github.com/utopia-php/database/actions/runs/24834250763/job/72690259306?pr=823 for the pre-fix failure trace.

## Test plan
- [ ] Open/synchronize a PR and confirm the \`claude / Run improvement\` job actually produces a commit or an inline review (rather than exiting with \"task instructions contain unexpanded shell variables\").
- [ ] Confirm \`classify-complexity\` logs a real classification (\`simple\` or \`complex\`), not the fallback route.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow automation tools to a newer version for improved development process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->