### PR TITLE
(chore): pin claude-pr-owner to v0.3.1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@c8a67b67d15c2ca57163c57f322352129c83544b # v0.3.0
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@b8299b2a5f868e81dbb799a355b92a7b93b5d3dc # v0.3.1
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@5ba5982d9d9ccb53bc8f33088124ef8bdb05cf13 # v0.2.0
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@c8a67b67d15c2ca57163c57f322352129c83544b # v0.3.0
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

Bumps the Claude PR orchestrator pin to [v0.3.0](https://github.com/abnegate/claude-pr-owner/releases/tag/v0.3.0), which fixes two issues that survived the v0.2.0 bump (#864):

1. **Classify-complexity still authenticated against the wrong endpoint.** v0.2.0 tried to make the native \`claude\` CLI pick up \`CLAUDE_CODE_OAUTH_TOKEN\` by writing \`~/.claude/.credentials.json\`; the native binary installed by \`install.sh\` still exited with \"Not logged in · Please run /login\" (see run [24836809699](https://github.com/utopia-php/database/actions/runs/24836809699/job/72699421401), classification \`'notloggedin·pleaser'\`). v0.3.0 delegates classification to \`anthropics/claude-code-base-action\`, which uses the \`@anthropic-ai/claude-agent-sdk\` that handles the OAuth token correctly.

2. **Improvement looped on its own commits.** Each \`improvement\` run that pushed a fix fired \`pull_request.synchronize\`, which re-ran improvement, committed again, and so on. v0.3.0's plan step now short-circuits \`improvement\` (pull_request) and \`healing\` (workflow_run) when the HEAD commit is authored by \`claude-bot@users.noreply.github.com\`. \`bots\` and \`comments\` are unaffected since they need external triggers.

## Test plan
- [ ] Push to a PR → \`classify-complexity\` logs a real classification (\`simple\`/\`complex\`), not empty/garbage.
- [ ] Let improvement commit a fix → the subsequent synchronize run shows \"HEAD commit ... authored by claude[bot]; skipping improvement to avoid self-trigger loop.\" and does not fan out.
- [ ] An external review from a bot or \`@claude\` comment still fires \`bots\`/\`comments\` as before.