### PR TITLE
(chore): pin claude-pr-owner to v0.4.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@b8299b2a5f868e81dbb799a355b92a7b93b5d3dc # v0.3.1
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@d6ea746d7b7da003f6d10a67143af1a7bd88515a # v0.4.0
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

Bumps the Claude PR orchestrator pin to [v0.4.0](https://github.com/abnegate/claude-pr-owner/releases/tag/v0.4.0).

v0.4.0 removes the \`classify-complexity\` composite action and its three per-task classification steps. Every run now uses \`claude-opus-4-7\` with a \`claude-sonnet-4-6\` fallback — no Haiku call, no model selection branching. Also dropped the secondary \`abnegate/claude-pr-owner\` checkout (only needed to load the deleted composite) and the \`Diff stats\` step (only consumed by the classify prompt).

## Test plan
- [ ] Open a PR → \`claude / improvement\` runs directly against opus, no classify step in the job DAG.
- [ ] \`claude / consolidate\` still completes successfully.