### PR TITLE
(chore): pin claude-pr-owner to v0.4.1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@d6ea746d7b7da003f6d10a67143af1a7bd88515a # v0.4.0
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@6e883b07b6c3c8df9acca65d08909a470cb4fd4c # v0.4.1
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:


### PR DESCRIPTION
## Summary
Bumps the Claude PR orchestrator pin to [v0.4.1](https://github.com/abnegate/claude-pr-owner/releases/tag/v0.4.1), which drops \`--max-turns 50\` from \`claude_args\`. Under v0.4.0 both \`improvement\` on PR #823 and \`healing\` for its Tests failure ran the full 50-turn budget (e.g. run [24839000951](https://github.com/utopia-php/database/actions/runs/24839000951) — healing, 51 turns, \$2.17, \`terminal_reason: max_turns\`) and aborted before posting a comment or committing, so from the PR's perspective no Claude activity was visible even though healing had fired correctly.

## Test plan
- [ ] Let \`improvement\`/\`healing\` run against a large PR and confirm they reach \`end_turn\` instead of \`max_turns\`, and that the resulting review comment / \"CI — ...\" commit shows up on the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow tooling to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->