### PR TITLE
(chore): pin claude-pr-owner to v0.6.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@e2ccc15e75fb17295f8c8d03eacce48b08c6294d # v0.4.2
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@5fa75f2433542cc05a9c0f2777150628f2e14b9e # v0.5.0
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,9 +25,14 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@5fa75f2433542cc05a9c0f2777150628f2e14b9e # v0.5.0
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@7138fd26ee7317ac1f05001eafeb41d371ba58a6 # v0.6.0
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # PAT with `contents: write` on this repo. Without this, commits pushed
+      # by the consolidator (authenticated with GITHUB_TOKEN) do not trigger
+      # workflow_run/synchronize events, so Tests/CodeQL/Linter stay dormant
+      # on Claude's fixes.
+      push_token: ${{ secrets.CLAUDE_PUSH_TOKEN }}
     with:
       improvement: true
       healing: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
-    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@6e883b07b6c3c8df9acca65d08909a470cb4fd4c # v0.4.1
+    uses: abnegate/claude-pr-owner/.github/workflows/orchestrator.yml@e2ccc15e75fb17295f8c8d03eacce48b08c6294d # v0.4.2
     secrets:
       oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:


### PR DESCRIPTION
## Summary
Bumps the Claude PR orchestrator pin to [v0.6.0](https://github.com/abnegate/claude-pr-owner/releases/tag/v0.6.0) and wires a \`push_token\` secret.

Background:
- v0.5.0 (previous commits in this branch) swapped \`improvement\` from \`/code-review:code-review\` to \`/skills:improve\` so every push gets a fresh review.
- But: CI on Claude's own commits was not running, because the consolidator pushes with the built-in \`GITHUB_TOKEN\` and GitHub deliberately suppresses \`workflow_run\`/\`synchronize\` events for commits pushed that way — an anti-recursion safeguard.

v0.6.0 adds a caller-supplied \`push_token\` secret. When present, the consolidator uses it for the checkout + push, so the push is treated like a normal user push and Tests/CodeQL/Linter/… re-run on Claude's fixes. When absent, behaviour is unchanged and the consolidator emits a warning.

## Action required before merging
Add a repo secret \`CLAUDE_PUSH_TOKEN\` — a fine-grained PAT (or GitHub App token) scoped to this repo with \`contents: write\`. Without the secret, v0.6.0 still runs, but CI will keep staying dormant on Claude's pushes and the consolidator will log a warning.

## Test plan
- [ ] With \`CLAUDE_PUSH_TOKEN\` set: let Claude push a fix and confirm Tests/CodeQL/Linter are triggered on that commit.
- [ ] Without the secret: confirm the consolidator logs a warning and pushes still succeed (just without CI re-trigger).