### PR TITLE
fix(memory): exclude null rows from negation operators

### DIFF
--- a/src/Database/Adapter/Memory.php
+++ b/src/Database/Adapter/Memory.php
@@ -561,6 +561,7 @@ class Memory extends Adapter
             foreach ($attributes as $i => $attribute) {
                 if ($this->filter($attribute) === $id) {
                     $touched = true;
+
                     continue;
                 }
                 $filtered[] = $attribute;
@@ -2629,6 +2630,10 @@ class Memory extends Adapter
                 return false;
 
             case Query::TYPE_NOT_EQUAL:
+                // SQL: NULL != x evaluates to NULL (i.e. excluded), not true.
+                if ($value === null) {
+                    return false;
+                }
                 foreach ($queryValues as $candidate) {
                     if ($this->looseEquals($value, $candidate)) {
                         return false;
@@ -2659,18 +2664,31 @@ class Memory extends Adapter
                 return $value !== null && $value >= $queryValues[0] && $value <= $queryValues[1];
 
             case Query::TYPE_NOT_BETWEEN:
-                return $value === null || $value < $queryValues[0] || $value > $queryValues[1];
+                // SQL: NULL NOT BETWEEN x AND y evaluates to NULL (excluded).
+                if ($value === null) {
+                    return false;
+                }
+
+                return $value < $queryValues[0] || $value > $queryValues[1];
 
             case Query::TYPE_STARTS_WITH:
                 return \is_string($value) && \is_string($queryValues[0]) && \str_starts_with($value, $queryValues[0]);
 
             case Query::TYPE_NOT_STARTS_WITH:
+                if ($value === null) {
+                    return false;
+                }
+
                 return ! \is_string($value) || ! \is_string($queryValues[0]) || ! \str_starts_with($value, $queryValues[0]);
 
             case Query::TYPE_ENDS_WITH:
                 return \is_string($value) && \is_string($queryValues[0]) && \str_ends_with($value, $queryValues[0]);
 
             case Query::TYPE_NOT_ENDS_WITH:
+                if ($value === null) {
+                    return false;
+                }
+
                 return ! \is_string($value) || ! \is_string($queryValues[0]) || ! \str_ends_with($value, $queryValues[0]);
 
             case Query::TYPE_CONTAINS:
@@ -2701,6 +2719,12 @@ class Memory extends Adapter
                 return false;
 
             case Query::TYPE_NOT_CONTAINS:
+                // SQL: NULL NOT LIKE '%x%' / JSON_CONTAINS(NULL, ...) evaluates
+                // to NULL — null-valued rows are excluded, not matched.
+                if ($value === null) {
+                    return false;
+                }
+
                 return ! $this->matches($row, new Query(Query::TYPE_CONTAINS, $query->getAttribute(), $queryValues));
 
             case Query::TYPE_CONTAINS_ANY:
@@ -2762,6 +2786,10 @@ class Memory extends Adapter
                 return $this->matchesFulltext($value, $needle);
 
             case Query::TYPE_NOT_SEARCH:
+                // SQL: NULL NOT MATCH evaluates to NULL — null rows excluded.
+                if ($value === null) {
+                    return false;
+                }
                 if (! \is_string($value)) {
                     return true;
                 }
@@ -2915,8 +2943,10 @@ class Memory extends Adapter
                 return false;
 
             case Query::TYPE_NOT_EQUAL:
+                // Postgres: NOT (NULL @> x) evaluates to NULL — null/invalid
+                // JSON rows are excluded, mirroring SQL three-valued logic.
                 if ($haystack === null) {
-                    return true;
+                    return false;
                 }
                 foreach ($values as $candidate) {
                     if ($this->jsonContains($haystack, $candidate)) {
@@ -2952,8 +2982,9 @@ class Memory extends Adapter
                 return true;
 
             case Query::TYPE_NOT_CONTAINS:
+                // Postgres three-valued logic: NULL field excluded from negation.
                 if ($haystack === null) {
-                    return true;
+                    return false;
                 }
                 foreach ($values as $candidate) {
                     if ($this->jsonContains($haystack, $this->wrapScalarObjectValue($candidate))) {
@@ -3099,7 +3130,7 @@ class Memory extends Adapter
      * column) against a stored row. JSON-encoded blobs are decoded on demand
      * so dotted paths can descend into them.
      *
-     * @param array<string, mixed> $row
+     * @param  array<string, mixed>  $row
      */
     protected function resolveAttributeValue(array $row, string $attribute): mixed
     {
@@ -3339,17 +3370,20 @@ class Memory extends Adapter
                     if (! $entry['asc']) {
                         $output[] = $row;
                     }
+
                     continue 2;
                 }
                 if ($ref === null) {
                     if ($entry['asc']) {
                         $output[] = $row;
                     }
+
                     continue 2;
                 }
                 if ($entry['asc'] ? ($current > $ref) : ($current < $ref)) {
                     $output[] = $row;
                 }
+
                 continue 2;
             }
         }

--- a/tests/e2e/Adapter/MemoryTest.php
+++ b/tests/e2e/Adapter/MemoryTest.php
@@ -868,4 +868,90 @@ class MemoryTest extends Base
             'code' => 3,
         ]));
     }
+
+    /**
+     * Regression: SQL three-valued logic — `WHERE col != x` evaluates to NULL
+     * for null-valued rows, so they are EXCLUDED from the result set. Memory
+     * adapter previously included null rows on every negation operator,
+     * diverging from MariaDB / MySQL / Postgres / SQLite.
+     */
+    public function testNegationOperatorsExcludeNullRows(): void
+    {
+        $database = $this->freshDatabase();
+
+        $database->createCollection('nullable', [
+            new Document([
+                '$id' => 'name',
+                'type' => Database::VAR_STRING,
+                'size' => 64,
+                'required' => false,
+            ]),
+            new Document([
+                '$id' => 'score',
+                'type' => Database::VAR_INTEGER,
+                'size' => 0,
+                'required' => false,
+            ]),
+            new Document([
+                '$id' => 'bio',
+                'type' => Database::VAR_STRING,
+                'size' => 1024,
+                'required' => false,
+            ]),
+        ], [
+            new Document([
+                '$id' => 'bio_ft',
+                'type' => Database::INDEX_FULLTEXT,
+                'attributes' => ['bio'],
+            ]),
+        ], [
+            Permission::create(Role::any()),
+            Permission::read(Role::any()),
+        ]);
+
+        $database->createDocument('nullable', new Document([
+            '$id' => 'with_value',
+            '$permissions' => [Permission::read(Role::any())],
+            'name' => 'alice',
+            'score' => 5,
+            'bio' => 'hello world',
+        ]));
+
+        $database->createDocument('nullable', new Document([
+            '$id' => 'with_null',
+            '$permissions' => [Permission::read(Role::any())],
+            'name' => null,
+            'score' => null,
+            'bio' => null,
+        ]));
+
+        $assertOnlyValueRow = function (string $operator, array $results) {
+            $ids = \array_map(fn (Document $d) => $d->getId(), $results);
+            $this->assertSame(['with_value'], $ids, $operator . ' should exclude null-valued rows');
+        };
+
+        $assertOnlyValueRow('notEqual', $database->find('nullable', [
+            Query::notEqual('name', 'bob'),
+        ]));
+
+        $assertOnlyValueRow('notBetween', $database->find('nullable', [
+            Query::notBetween('score', 100, 200),
+        ]));
+
+        $assertOnlyValueRow('notStartsWith', $database->find('nullable', [
+            Query::notStartsWith('name', 'zz'),
+        ]));
+
+        $assertOnlyValueRow('notEndsWith', $database->find('nullable', [
+            Query::notEndsWith('name', 'zz'),
+        ]));
+
+        $assertOnlyValueRow('notContains', $database->find('nullable', [
+            Query::notContains('bio', ['nope']),
+        ]));
+
+        $assertOnlyValueRow('notSearch', $database->find('nullable', [
+            Query::notSearch('bio', 'unrelated'),
+        ]));
+    }
 }


### PR DESCRIPTION
## Summary

Greptile P1 follow-up to #860. The Memory adapter included null-valued rows in negation operator results, diverging from every SQL adapter:

- `notEqual`, `notBetween`, `notStartsWith`, `notEndsWith` (scalar)
- `notContains`, `notSearch` (scalar)
- `notEqual`, `notContains` (object/JSONB context)

In MariaDB / MySQL / Postgres / SQLite, `WHERE col != x` evaluates to **NULL** for null rows under three-valued logic, so they are excluded. The Memory adapter was returning `true` (or relying on `! matches(...)` flipping `false` to `true`), causing null rows to leak into negation results.

Each branch now short-circuits on `$value === null` (or `$haystack === null` in the object path) and returns `false`, matching SQL semantics.

## Test plan
- [x] `testNegationOperatorsExcludeNullRows` — verifies all six scalar negation operators exclude a row with null-valued attributes
- [ ] CI pipeline (lint, phpstan, full test suite across MariaDB/MySQL/Postgres/SQLite/Mongo/Memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query matching behavior for negated operators (`notEqual`, `notBetween`, `notStartsWith`, `notEndsWith`, `notContains`, `notSearch`) to properly handle null values—these operators now return false when the queried value is null.

* **Tests**
  * Added regression test coverage for negation operators with null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->