### PR TITLE
chore: allow utopia-php/cache 2.* alongside 1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-redis": "*",
         "utopia-php/validators": "0.2.*",
         "utopia-php/console": "0.1.*",
-        "utopia-php/cache": "1.*",
+        "utopia-php/cache": "1.* || 2.*",
         "utopia-php/pools": "1.*",
         "utopia-php/mongo": "1.*"
     },


### PR DESCRIPTION
## What

Widen the `utopia-php/cache` constraint from `1.*` to `1.* || 2.*`.

## Why

`utopia-php/cache` 2.0.0 was released ([release notes](https://github.com/utopia-php/cache/releases/tag/2.0.0)). It bumps the PHP floor to `>=8.2`, adds a `CircuitBreaker` adapter and a `Feature\Telemetry` propagation contract — all additive. The `Cache` class type-hint used here (`src/Database/Database.php`) is unchanged, so allowing 2.x is safe.

Allowing both `1.*` and `2.*` lets downstream consumers (e.g. appwrite/appwrite) pick up cache 2.0 without forcing existing users off 1.x.

## Test plan

- [ ] CI passes against both cache 1.x and 2.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency compatibility to support additional library versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utopia-php/database/pull/875)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->