### PR TITLE
perf(adapter): rewrite permissions condition as EXISTS instead of IN subquery

### DIFF
--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1914,6 +1914,9 @@ abstract class SQL extends Adapter
     /**
      * Get SQL condition for permissions
      *
+     * Uses correlated EXISTS so the planner can short-circuit at the first matching
+     * _perms row per outer document, instead of materializing IN (subquery).
+     *
      * @param string $collection
      * @param array<string> $roles
      * @param string $alias
@@ -1931,15 +1934,24 @@ abstract class SQL extends Adapter
             throw new DatabaseException('Unknown permission type: ' . $type);
         }
 
+        if (empty($roles)) {
+            return '1 = 0';
+        }
+
         $roles = \array_map(fn ($role) => $this->getPDO()->quote($role), $roles);
         $roles = \implode(', ', $roles);
 
-        return "{$this->quote($alias)}.{$this->quote('_uid')} IN (
-            SELECT _document
-            FROM {$this->getSQLTable($collection . '_perms')}
-            WHERE _permission IN ({$roles})
-              AND _type = '{$type}'
-              {$this->getTenantQuery($collection)}
+        $outerAlias = $this->quote($alias);
+        $permsTable = $this->getSQLTable($collection . '_perms');
+        $tenantClause = $this->getTenantQuery($collection, 'perms');
+
+        return "EXISTS (
+            SELECT 1
+            FROM {$permsTable} AS perms
+            WHERE perms._document = {$outerAlias}._uid
+              AND perms._permission IN ({$roles})
+              AND perms._type = '{$type}'
+              {$tenantClause}
         )";
     }
 

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -1943,14 +1943,17 @@ abstract class SQL extends Adapter
 
         $outerAlias = $this->quote($alias);
         $permsTable = $this->getSQLTable($collection . '_perms');
-        $tenantClause = $this->getTenantQuery($collection, 'perms');
+        // Leading-underscore sentinel to avoid collisions with caller-provided aliases
+        $innerAlias = '_perms_inner';
+        $innerAliasQuoted = $this->quote($innerAlias);
+        $tenantClause = $this->getTenantQuery($collection, $innerAlias);
 
         return "EXISTS (
             SELECT 1
-            FROM {$permsTable} AS perms
-            WHERE perms._document = {$outerAlias}._uid
-              AND perms._permission IN ({$roles})
-              AND perms._type = '{$type}'
+            FROM {$permsTable} AS {$innerAliasQuoted}
+            WHERE {$innerAliasQuoted}._document = {$outerAlias}._uid
+              AND {$innerAliasQuoted}._permission IN ({$roles})
+              AND {$innerAliasQuoted}._type = '{$type}'
               {$tenantClause}
         )";
     }


### PR DESCRIPTION
## Summary

Rewrites `getSQLPermissionsCondition` from `IN (SELECT ... FROM <coll>_perms)` to a correlated `EXISTS` clause. This is appended to every authenticated `find`/`count`/`sum`, so the per-query cost reduction compounds across the entire platform.

The previous `IN (subquery)` pattern forces the planner to either materialize the inner permission set or unnest into a semi-join — strategies that scan a non-trivial chunk of `_perms` per outer query. Correlated `EXISTS` lets the planner short-circuit at the first matching `_perms` row per outer document, using the existing `_document` index for single-row lookups.

Also adds an early `1 = 0` return for empty `$roles`, so anonymous users no longer produce the invalid `_permission IN ()` SQL fragment.

## Why

Production telemetry on Appwrite Cloud (fra region, project DBs) shows ~600 rows scanned per `SELECT` on authenticated reads, sustained over a 7-day window. For a typical `LIMIT 25` query that's ~24× over-scanning, attributable to the permissions subquery materializing more than necessary.

`EXISTS` directly targets this: short-circuit at first match means roughly 1–5 `_perms` rows scanned per outer document instead of the full filtered subset. Predicted impact on the rows-read-per-SELECT ratio: drop from ~600 → ~50–150 (5–10×), translating to ~15–30% MySQL CPU reduction on read-heavy workloads.

## Scope

- `SQL.php` only — `MariaDB.php`, `Postgres.php`, `MySQL.php` inherit the method unchanged
- Method signature unchanged → no caller updates needed in `find`, `count`, `sum`
- `getTenantQuery` already accepts an alias, so tenant scoping carries through to the `perms` correlation alias

## Test plan

- [ ] Existing test suite passes (`composer test`)
- [ ] Manual verification that `find()` with `documentSecurity: true` returns identical row sets before/after
- [ ] Manual verification that empty-roles (anonymous) read paths still behave correctly
- [ ] Staging deploy: confirm `sum(rate(mysql_global_status_innodb_row_ops_total{operation="read"})) / sum(rate(mysql_global_status_commands_total{command="select"}))` drops from baseline (~600) to <200
- [ ] Production canary (one region) before full rollout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an edge case in permission filtering that could result in invalid queries when no roles are assigned.

* **Refactor**
  * Optimized permission validation logic for improved query efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utopia-php/database/pull/877)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->