### PR TITLE
test

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -398,6 +398,18 @@ class Database
      */
     protected ?array $silentListeners = [];
 
+    /**
+     * In-process cache of collection metadata, keyed by
+     * "database:namespace:tenant:collectionId". Stores the raw array form so
+     * callers always get a fresh Document and cannot corrupt the cache.
+     * Invalidated via the EVENT_DOCUMENT_PURGE listener registered in the
+     * constructor, and fully cleared on context changes (setNamespace,
+     * setDatabase, setSharedTables, setTenant, delete).
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    protected array $collectionCache = [];
+
     protected ?\DateTime $timestamp = null;
 
     protected bool $resolveRelationships = true;
@@ -701,6 +713,21 @@ class Database
                 return is_array($decoded) ? $decoded : $value;
             }
         );
+
+        // Keep the in-process collection cache in sync with the existing
+        // EVENT_DOCUMENT_PURGE plumbing. Every metadata mutation already
+        // fires this event with $collection=METADATA; cross-region purges
+        // (cloud) also flow through here, so this listener stays correct
+        // without changes to consumers.
+        $this->on(
+            self::EVENT_DOCUMENT_PURGE,
+            'collection-cache-invalidator',
+            function (string $event, Document $payload): void {
+                if ($payload->getCollection() === self::METADATA) {
+                    $this->invalidateCollectionCache($payload->getId());
+                }
+            }
+        );
     }
 
     /**
@@ -930,6 +957,7 @@ class Database
     public function setNamespace(string $namespace): static
     {
         $this->adapter->setNamespace($namespace);
+        $this->clearCollectionCache();
 
         return $this;
     }
@@ -969,6 +997,7 @@ class Database
     public function setDatabase(string $name): static
     {
         $this->adapter->setDatabase($name);
+        $this->clearCollectionCache();
 
         return $this;
     }
@@ -1253,6 +1282,7 @@ class Database
     public function setSharedTables(bool $sharedTables): static
     {
         $this->adapter->setSharedTables($sharedTables);
+        $this->clearCollectionCache();
 
         return $this;
     }
@@ -1268,6 +1298,7 @@ class Database
     public function setTenant(int|string|null $tenant): static
     {
         $this->adapter->setTenant($tenant);
+        $this->clearCollectionCache();
 
         return $this;
     }
@@ -1664,6 +1695,7 @@ class Database
         }
 
         $this->cache->flush();
+        $this->clearCollectionCache();
 
         return $deleted;
     }
@@ -1923,6 +1955,11 @@ class Database
     /**
      * Get Collection
      *
+     * Reads collection metadata. Cached in-process per (database, namespace,
+     * tenant, id) tuple to avoid redundant Redis lookups on hot paths like
+     * find()/cascade — a single request often touches the same collection
+     * 20-50× via relationship resolution and internal helpers.
+     *
      * @param string $id
      *
      * @return Document
@@ -1930,7 +1967,20 @@ class Database
      */
     public function getCollection(string $id): Document
     {
-        $collection = $this->silent(fn () => $this->getDocument(self::METADATA, $id));
+        $cacheKey = $this->collectionCacheKey($id);
+
+        if (isset($this->collectionCache[$cacheKey])) {
+            // Rebuild a fresh Document on every hit so callers can mutate the
+            // returned collection (setAttribute on attributes/indexes, etc.)
+            // without poisoning the cache.
+            $collection = new Document($this->collectionCache[$cacheKey]);
+        } else {
+            $collection = $this->silent(fn () => $this->getDocument(self::METADATA, $id));
+
+            if (!$collection->isEmpty()) {
+                $this->collectionCache[$cacheKey] = $this->arrayifyDocuments($collection->getArrayCopy());
+            }
+        }
 
         if (
             $id !== self::METADATA
@@ -1948,6 +1998,65 @@ class Database
         }
 
         return $collection;
+    }
+
+    /**
+     * Build the per-instance cache key for a collection id.
+     *
+     * @param string $id
+     * @return string
+     */
+    private function collectionCacheKey(string $id): string
+    {
+        return $this->adapter->getDatabase()
+            . ':' . $this->adapter->getNamespace()
+            . ':' . ($this->adapter->getTenant() ?? '')
+            . ':' . $id;
+    }
+
+    /**
+     * Drop a single collection from the in-process cache.
+     * Invoked by the EVENT_DOCUMENT_PURGE listener registered in __construct.
+     *
+     * @param string $id
+     * @return void
+     */
+    private function invalidateCollectionCache(string $id): void
+    {
+        unset($this->collectionCache[$this->collectionCacheKey($id)]);
+    }
+
+    /**
+     * Wipe the in-process cache entirely. Called from context-changing
+     * setters (namespace/database/sharedTables/tenant) since those alter the
+     * cache key shape, and from delete() since the underlying data is gone.
+     *
+     * @return void
+     */
+    private function clearCollectionCache(): void
+    {
+        $this->collectionCache = [];
+    }
+
+    /**
+     * Recursively convert nested Document instances to plain arrays so the
+     * cache stores fully isolated data. A caller mutating the returned
+     * Document (or any nested attribute/index Document) cannot reach back
+     * into the cache.
+     *
+     * @param array<string, mixed> $arr
+     * @return array<string, mixed>
+     */
+    private function arrayifyDocuments(array $arr): array
+    {
+        foreach ($arr as $k => $v) {
+            if ($v instanceof Document) {
+                $arr[$k] = $this->arrayifyDocuments($v->getArrayCopy());
+            } elseif (\is_array($v)) {
+                $arr[$k] = $this->arrayifyDocuments($v);
+            }
+        }
+        return $arr;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a per-instance in-process cache for collection metadata in `Database::getCollection()`. Today, every authenticated read path calls `getCollection()` many times — directly and through internal helpers like `convertQuery`, validators, and relationship resolution — and each call goes through `getDocument(METADATA, $id)` which incurs a Redis round trip even when the metadata is unchanged.

For a relationship-heavy request that touches one collection 50 times via cascade resolution, that's currently 50 redundant Redis reads. With this change it becomes 1 read, with the remaining 49 served from in-process memory.

## How invalidation works

We don't add new invalidation call sites. The library already fires `EVENT_DOCUMENT_PURGE` with `$collection=METADATA` after every metadata mutation (createAttribute, deleteAttribute, createIndex, deleteRelationship, updateCollection, etc.). A new listener registered in the constructor catches those events and drops the corresponding cache entry.

For Appwrite Cloud, this also stays correct across regions for free: `cloud/app/controllers/general.php` already listens on the same event and propagates purges via `RegionManager`. The receiving region's `purgeCachedDocument(METADATA, $id)` call re-fires the event on its own Database instance, which invalidates the in-process cache there too.

Full cache wipes are added to the four context-changing setters (`setNamespace`, `setDatabase`, `setSharedTables`, `setTenant`) and `delete()`, since those alter the cache key shape or invalidate the underlying data wholesale.

## Memory safety

The cache stores the array form of each collection, not the `Document` instance. The recursive `arrayifyDocuments` helper unwraps nested attribute/index `Document` references too. On every cache hit, a fresh `Document` is rebuilt from the stored array — so callers can mutate the returned collection (e.g. `setAttribute('attributes', $new, SET_TYPE_APPEND)` as `createAttribute` does) without any risk of poisoning the cache.

## Cache key shape

`{database}:{namespace}:{tenant}:{collectionId}` — multi-tenant safe. `withTenant()` doesn't need a clear because the tenant is part of the key.

## Predicted impact

- 15-25% p99 latency reduction on relationship-heavy reads (listMemberships, listDocuments with selects, cascade fetches)
- 20-40% Dragonfly/Redis cache command rate reduction
- No MySQL impact (this is a cache-layer fix, not a query-layer one)
- Per-pod memory: ~5MB at steady state for a typical project (typically dozens of collections)

## Test plan

- [ ] Existing PHPUnit suite passes
- [ ] Manual: call `getCollection('foo')` → mutate the result → call again, verify second call returns the original (isolation test)
- [ ] Manual: call `getCollection('foo')` → `createAttribute('foo', ...)` → call `getCollection('foo')`, verify new attribute appears (invalidation test)
- [ ] Manual: under `withTenant($t1)` populate cache, switch to `withTenant($t2)`, verify isolation
- [ ] Staging: confirm Dragonfly command rate drops on canary region post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Database operations involving relationships now execute more efficiently through optimized metadata handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utopia-php/database/pull/878)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->