### PR TITLE
Add SQL trigger in getDocument

### DIFF
--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -394,6 +394,8 @@ abstract class SQL extends Adapter
             $sql .= " {$forUpdate}";
         }
 
+        $sql = $this->trigger(Database::EVENT_DOCUMENT_READ, $sql);
+
         $stmt = $this->getPDO()->prepare($sql);
 
         $stmt->bindValue(':_uid', $id);

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -732,10 +732,10 @@ class Database
      *
      * @param string $event
      * @param string $name
-     * @param callable $callback
+     * @param ?callable $callback
      * @return $this
      */
-    public function before(string $event, string $name, callable $callback): static
+    public function before(string $event, string $name, ?callable $callback): static
     {
         $this->adapter->before($event, $name, $callback);
 

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1674,9 +1674,13 @@ trait CollectionTests
             return "SELECT 1";
         });
 
-        $result = $database->getDocument('docs', 'doc1');
+        try {
+            $result = $database->getDocument('docs', 'doc1');
 
-        $this->assertTrue($result->isEmpty());
+            $this->assertTrue($result->isEmpty());
+        } finally {
+            $database->getAdapter()->before(Database::EVENT_DOCUMENT_READ, 'test', null);
+        }
     }
 
     public function testSetGlobalCollection(): void

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1685,7 +1685,8 @@ trait CollectionTests
         $result = $database->getDocument('docs', 'doc1');
 
         $this->assertTrue($result->isEmpty());
-        if (!$database->getAdapter() instanceof SQL) {
+
+        if ($database->getAdapter() instanceof SQL) {
             $this->assertStringContainsString('/* scope: api.users */', $capturedSql);
         }
 

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -3,6 +3,7 @@
 namespace Tests\E2E\Adapter\Scopes;
 
 use Exception;
+use Utopia\Database\Adapter\SQL;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
@@ -1670,13 +1671,29 @@ trait CollectionTests
             'name' => 'value1',
         ]));
 
-        $database->before(Database::EVENT_DOCUMENT_READ, 'test', function (string $query) {
-            return "SELECT 1";
+        $originalMetadata = $database->getMetadata();
+
+        $database->setMetadata('scope', 'api.users');
+
+        $capturedSql = '';
+        $database->before(Database::EVENT_DOCUMENT_READ, 'test', function (string $sql) use (&$capturedSql) {
+            $sql .= ' AND 1=0';
+            $capturedSql = $sql;
+            return $sql;
         });
 
         $result = $database->getDocument('docs', 'doc1');
 
         $this->assertTrue($result->isEmpty());
+        if (!$database->getAdapter() instanceof SQL) {
+            $this->assertStringContainsString('/* scope: api.users */', $capturedSql);
+        }
+
+        $database->before(Database::EVENT_DOCUMENT_READ, 'test', null);
+        $database->resetMetadata();
+        foreach ($originalMetadata as $key => $value) {
+            $database->setMetadata($key, $value);
+        }
     }
 
     public function testSetGlobalCollection(): void

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1671,7 +1671,7 @@ trait CollectionTests
         ]));
 
         $database->before(Database::EVENT_DOCUMENT_READ, 'test', function (string $query) {
-            return "SELECT 1";
+            return "SELECT * FROM ({$query}) AS sub_q WHERE 1 = 0";
         });
 
         try {

--- a/tests/e2e/Adapter/Scopes/CollectionTests.php
+++ b/tests/e2e/Adapter/Scopes/CollectionTests.php
@@ -1671,8 +1671,6 @@ trait CollectionTests
             'name' => 'value1',
         ]));
 
-        $originalMetadata = $database->getMetadata();
-
         $database->setMetadata('scope', 'api.users');
 
         $capturedSql = '';
@@ -1692,9 +1690,6 @@ trait CollectionTests
 
         $database->before(Database::EVENT_DOCUMENT_READ, 'test', null);
         $database->resetMetadata();
-        foreach ($originalMetadata as $key => $value) {
-            $database->setMetadata($key, $value);
-        }
     }
 
     public function testSetGlobalCollection(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document read operations can be intercepted and modified via event hooks, allowing dynamic adjustment of read queries.

* **Bug Fixes**
  * Event hook removal is now supported, preventing stale handlers from affecting subsequent operations.

* **Tests**
  * Tests improved to set and clean up event hooks and verify scoped document reads behave as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utopia-php/database/pull/880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->