### PR TITLE
Fix undefined array key 0 in Query/Filter isEmpty

### DIFF
--- a/src/Database/Validator/Query/Filter.php
+++ b/src/Database/Validator/Query/Filter.php
@@ -316,7 +316,8 @@ class Filter extends Base
             return true;
         }
 
-        if (is_array($values[0]) && count($values[0]) === 0) {
+        $firstKey = \array_key_first($values);
+        if (\is_array($values[$firstKey]) && \count($values[$firstKey]) === 0) {
             return true;
         }
 

--- a/tests/unit/Validator/Query/FilterTest.php
+++ b/tests/unit/Validator/Query/FilterTest.php
@@ -122,6 +122,16 @@ class FilterTest extends TestCase
         $this->assertEquals('Equal queries require at least one value.', $this->validator->getDescription());
     }
 
+    public function testIsEmptyHandlesNonZeroIndexedValues(): void
+    {
+        // Sparse / associative arrays must not trigger "Undefined array key 0".
+        $sparse = new Query(Query::TYPE_EQUAL, 'string', [1 => 'super']);
+        $this->assertTrue($this->validator->isValid($sparse));
+
+        $assoc = new Query(Query::TYPE_CONTAINS, 'string_array', ['foo' => 'super']);
+        $this->assertTrue($this->validator->isValid($assoc));
+    }
+
     public function testMaxValuesCount(): void
     {
         $max = $this->validator->getMaxValuesCount();


### PR DESCRIPTION
## Summary
`Filter::isEmpty()` accesses `$values[0]` after only checking `count($values) === 0`. When the values array is non-empty but not zero-indexed (sparse arrays, associative arrays), PHP emits `Warning: Undefined array key 0`. Replaced the direct index access with `array_key_first()` so the first element is read regardless of key layout. Behaviour for zero-indexed arrays is unchanged.

## Test plan
- [x] Added unit test in `tests/unit/Validator/Query/FilterTest.php` covering sparse and associative value arrays.
- [x] `composer lint` clean.
- [x] `composer check` (PHPStan level 7) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query filter validation to correctly handle arrays with non-zero starting indices and associative array keys. The validator now properly detects empty value arrays regardless of their indexing structure, improving reliability of query filtering across different data formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utopia-php/database/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->