### PR TITLE
feat: add UniqueException for non-_uid unique violations

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -10,6 +10,7 @@ use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Exception\Character as CharacterException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Exception\Operator as OperatorException;
 use Utopia\Database\Exception\Query as QueryException;
@@ -1995,7 +1996,7 @@ class MariaDB extends SQL
                 return new DuplicateException('Duplicate permissions for document', $e->getCode(), $e);
             }
             if (!\str_contains($message, '_uid')) {
-                return new DuplicateException('Document with the requested unique attributes already exists', $e->getCode(), $e);
+                return new UniqueException('Unique index violation', $e->getCode(), $e);
             }
             return new DuplicateException('Document already exists', $e->getCode(), $e);
         }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -11,6 +11,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Exception\Operator as OperatorException;
 use Utopia\Database\Exception\Timeout as TimeoutException;
@@ -2224,9 +2225,13 @@ class Postgres extends SQL
 
         // Duplicate row
         if ($e->getCode() === '23505' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 7) {
-            $message = $e->getMessage();
-            if (!\str_contains($message, '_uid')) {
-                return new DuplicateException('Document with the requested unique attributes already exists', $e->getCode(), $e);
+            if (preg_match('/Key \(([^)]+)\)=\(.+\) already exists/', $e->getMessage(), $matches)) {
+                $columns = array_map('trim', explode(',', $matches[1]));
+                sort($columns);
+                $target = $this->sharedTables ? ['_tenant', '_uid'] : ['_uid'];
+                if ($columns !== $target) {
+                    return new UniqueException('Unique index violation', $e->getCode(), $e);
+                }
             }
             return new DuplicateException('Document already exists', $e->getCode(), $e);
         }

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -11,6 +11,7 @@ use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
 use Utopia\Database\Exception\Limit as LimitException;
+use Utopia\Database\Exception\Unique as UniqueException;
 use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Exception\Operator as OperatorException;
 use Utopia\Database\Exception\Timeout as TimeoutException;
@@ -1994,7 +1995,7 @@ class SQLite extends MariaDB
                 stripos($message, 'duplicate') !== false
             ) {
                 if (!\str_contains($message, '_uid')) {
-                    return new DuplicateException('Document with the requested unique attributes already exists', $e->getCode(), $e);
+                    return new UniqueException('Unique index violation', $e->getCode(), $e);
                 }
                 return new DuplicateException('Document already exists', $e->getCode(), $e);
             }

--- a/src/Database/Exception/Unique.php
+++ b/src/Database/Exception/Unique.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Utopia\Database\Exception;
+
+use Utopia\Database\Exception;
+
+class Unique extends Exception
+{
+}


### PR DESCRIPTION
## Changes

- Add \Unique.php\ exception class extending \Utopia\Database\Exception\
- Override \processException\ in MariaDB, Postgres, and SQLite adapters
- Non-\_uid\ unique constraint violations now throw \UniqueException\
- \_uid\ duplicate key violations still throw \DuplicateException\ (unchanged)

This allows the Appwrite layer to distinguish between document ID conflicts (\_uid\) and other unique constraint violations (custom unique indexes on user attributes, collection attributes, etc.).

Closes #10657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unique constraint violations across database adapters with more specific error messages. Users will now receive clearer feedback when attempting to create records with duplicate unique attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->