### PR TITLE
Purge document cache again after transaction commit

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6365,6 +6365,9 @@ class Database
             return $document;
         }
 
+        // Purge again after commit so readers cannot re-cache the pre-commit version
+        $this->purgeCachedDocumentInternal($collection->getId(), $id);
+
         if (!$this->inBatchRelationshipPopulation && $this->resolveRelationships) {
             $documents = $this->silent(fn () => $this->populateDocumentsRelationships([$document], $collection, $this->relationshipFetchDepth));
             $document = $documents[0];
@@ -7751,6 +7754,8 @@ class Database
         });
 
         if ($deleted) {
+            // Purge again after commit so readers cannot re-cache the pre-commit version
+            $this->purgeCachedDocumentInternal($collection->getId(), $id);
             $this->trigger(self::EVENT_DOCUMENT_DELETE, $document);
         }
 


### PR DESCRIPTION
## What does this PR do?

`updateDocument` and `deleteDocument` purge the document cache **inside** the transaction, before the write is visible. A reader landing between the purge and the commit reads the old row and re-caches it — and with no purge following, the stale version is served for up to 24 hours (`Database::TTL`).

```mermaid
sequenceDiagram
    participant R as Reader (getDocument)
    participant C as Cache
    participant DB as Database
    participant W as Writer (updateDocument)

    W->>DB: write version N+1 (in txn, not yet visible)
    W->>C: purge(doc)
    R->>DB: read document → version N (txn not committed)
    R->>C: save(doc, version N) ⚠️
    W->>DB: commit
    Note over C: stale version N cached, no purge follows
```

The fix is one purge per write path, after the transaction commits, so any entry cached during the purge→commit window is evicted.

It also helps with a related race we hit as a recurring Appwrite CI flake ([example failure](https://github.com/appwrite/appwrite/actions/runs/27250699152/job/80474386490)): a reader whose `cache->save()` lands *after* the writer's purge. The post-commit purge adds a later eviction point that narrows that window, though a slow enough save can still land after it — fully closing it needs reader-side cooperation (e.g. a purge tombstone) and is left for a follow-up.

**Cost:** one extra cache purge per single-document write. Reads are untouched.

## Test plan

- `php -l` + Pint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved cache handling to prevent serving stale data when documents are deleted or purged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
