### PR TITLE
Bypass cache for locking document reads

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4855,6 +4855,11 @@ class Database
         if ($cached) {
             $document = $this->createDocumentInstance($collection->getId(), $cached);
 
+            // JSON serialization in cache backends collapses floats with zero
+            // fractions to ints. Re-cast so cached and freshly-loaded documents
+            // compare equal under strict equality (e.g. in updateDocument).
+            $document = $this->casting($collection, $document);
+
             if ($collection->getId() !== self::METADATA) {
 
                 if (!$this->authorization->isValid(new Input(self::PERMISSION_READ, [

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -4840,11 +4840,16 @@ class Database
             $selections
         );
 
-        try {
-            $cached = $this->cache->load($documentKey, self::TTL, $hashKey);
-        } catch (Exception $e) {
-            Console::warning('Warning: Failed to get document from cache: ' . $e->getMessage());
-            $cached = null;
+        // A locking read must observe the current row, not a cached copy:
+        // updateDocument merges the changes into this read and writes the result
+        // back, so serving it from a stale cache would persist the staleness.
+        $cached = null;
+        if (!$forUpdate) {
+            try {
+                $cached = $this->cache->load($documentKey, self::TTL, $hashKey);
+            } catch (Exception $e) {
+                Console::warning('Warning: Failed to get document from cache: ' . $e->getMessage());
+            }
         }
 
         if ($cached) {
@@ -4916,8 +4921,10 @@ class Database
             fn ($attribute) => $attribute['type'] === Database::VAR_RELATIONSHIP
         );
 
-        // Don't save to cache if it's part of a relationship
-        if (empty($relationships)) {
+        // Don't save to cache if it's part of a relationship, or if this is a
+        // locking read: a forUpdate read happens inside an open transaction, and
+        // caching the pre-commit row would poison the cache for other readers.
+        if (!$forUpdate && empty($relationships)) {
             try {
                 $this->cache->save($documentKey, $document->getArrayCopy(), $hashKey);
                 $this->cache->save($collectionKey, 'empty', $documentKey);

--- a/tests/unit/ForUpdateCacheTest.php
+++ b/tests/unit/ForUpdateCacheTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\Memory as CacheMemory;
+use Utopia\Cache\Cache;
+use Utopia\Database\Adapter\Memory as DatabaseMemory;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+
+class ForUpdateCacheTest extends TestCase
+{
+    private DatabaseMemory $adapter;
+
+    private Database $database;
+
+    protected function setUp(): void
+    {
+        $this->adapter = new DatabaseMemory();
+        $this->database = new Database($this->adapter, new Cache(new CacheMemory()));
+        $this->database
+            ->setDatabase('utopiaTests')
+            ->setNamespace('for_update_' . \uniqid());
+
+        $this->database->create();
+        $this->database->createCollection('projects');
+        $this->database->createAttribute('projects', 'name', Database::VAR_STRING, 255, false);
+        $this->database->createAttribute('projects', 'description', Database::VAR_STRING, 255, false);
+        $this->database->createDocument('projects', new Document([
+            '$id' => 'project',
+            '$permissions' => [
+                Permission::read(Role::any()),
+                Permission::update(Role::any()),
+            ],
+            'name' => 'stale',
+            'description' => 'stale',
+        ]));
+    }
+
+    /**
+     * Write to the row through the adapter, bypassing Database and therefore
+     * the cache purge — the cache now holds a stale copy, exactly as if a
+     * concurrent reader had re-cached the old row after a writer's purge.
+     */
+    private function staleCache(string $attribute, string $value): void
+    {
+        $collection = $this->database->getCollection('projects');
+        $document = $this->adapter->getDocument($collection, 'project');
+        $document->setAttribute($attribute, $value);
+        $this->adapter->updateDocument($collection, 'project', $document, true);
+    }
+
+    public function testForUpdateReadBypassesStaleCache(): void
+    {
+        $cached = $this->database->getDocument('projects', 'project');
+        $this->assertSame('stale', $cached->getAttribute('name'));
+
+        $this->staleCache('name', 'fresh');
+
+        $cached = $this->database->getDocument('projects', 'project');
+        $this->assertSame('stale', $cached->getAttribute('name'));
+
+        $fresh = $this->database->getDocument('projects', 'project', forUpdate: true);
+        $this->assertSame('fresh', $fresh->getAttribute('name'));
+    }
+
+    public function testForUpdateReadDoesNotPopulateCache(): void
+    {
+        $this->database->getDocument('projects', 'project');
+        $this->staleCache('name', 'fresh');
+
+        $this->database->getDocument('projects', 'project', forUpdate: true);
+
+        // The locking read happens inside an open transaction; caching what it
+        // saw would publish a pre-commit row. The cached copy must be untouched.
+        $cached = $this->database->getDocument('projects', 'project');
+        $this->assertSame('stale', $cached->getAttribute('name'));
+    }
+
+    public function testUpdateDocumentDoesNotResurrectStaleCachedAttributes(): void
+    {
+        $this->database->getDocument('projects', 'project');
+        $this->staleCache('name', 'fresh');
+
+        // updateDocument merges the changes into its locking read of the current
+        // row. Served from the stale cache, that merge would durably revert
+        // name to 'stale' — the lost-update behind flaky project config tests.
+        $this->database->updateDocument('projects', 'project', new Document([
+            'description' => 'updated',
+        ]));
+
+        $collection = $this->database->getCollection('projects');
+        $row = $this->adapter->getDocument($collection, 'project');
+        $this->assertSame('fresh', $row->getAttribute('name'));
+        $this->assertSame('updated', $row->getAttribute('description'));
+
+        $document = $this->database->getDocument('projects', 'project');
+        $this->assertSame('fresh', $document->getAttribute('name'));
+        $this->assertSame('updated', $document->getAttribute('description'));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

`getDocument(..., forUpdate: true)` served the document from the cache when an entry existed. A locking read is meant to observe the current row under lock — `updateDocument` merges its changes into that read and writes the merged result back, so a stale cache entry durably reverted attributes updated since the entry was cached:

1. Writer A updates `serviceUsers = false`, purges the cache.
2. A concurrent reader re-caches the old row (the reader-side race noted in #887).
3. Writer B updates an unrelated attribute. Its `forUpdate` read is served from the poisoned cache, the merge resurrects `serviceUsers = true`, and the adapter writes it back — the staleness is now durable in the database, surviving every later purge.

This is the mechanism behind the recurring `ProjectsConsoleClientTest::testGetProject` CI flake in Appwrite (project `services` / `auths` / `smtp` map fields reverting after a 200 PATCH; failing ~50–70% of runs in appwrite-labs/cloud since the race window widened).

The fix: a `forUpdate` read always reads through to the adapter, and skips the cache save — it runs inside an open transaction, so caching what it saw would publish a pre-commit row to other readers (the same poisoning #887 closed for the write path's own purge).

Replaces the core of #885 without the unrelated scope that stalled it.

## Test plan

- `tests/unit/ForUpdateCacheTest.php` — three regression tests, all failing before the fix:
  - a `forUpdate` read bypasses a stale cache entry,
  - a `forUpdate` read does not (re)populate the cache,
  - `updateDocument` does not resurrect stale cached attributes into the database (the durable lost-update).
- Full unit suite green (354 tests). MySQL adapter e2e `Cache|ForUpdate` and `testUpdateDocument|testCreateDocument` slices green locally (incl. `testCacheFallback`).
- Pint + PHPStan level 7 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened caching so locking (for-update) reads bypass stale cache and don't return pre-commit values.
  * Avoided populating cache with transient/pre-commit state and prevented cache-related lost updates during concurrent document changes.

* **Tests**
  * Added unit tests to verify cache coherency around locking reads, cache non-population during transactions, and correct merge behavior on updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->