### PR TITLE
Retry transient transaction failures in the Mongo adapter

### DIFF
--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -12,7 +12,12 @@ use Utopia\Database\Database;
 use Utopia\Database\DateTime;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
+use Utopia\Database\Exception\Authorization as AuthorizationException;
+use Utopia\Database\Exception\Conflict as ConflictException;
 use Utopia\Database\Exception\Duplicate as DuplicateException;
+use Utopia\Database\Exception\Limit as LimitException;
+use Utopia\Database\Exception\Relationship as RelationshipException;
+use Utopia\Database\Exception\Restricted as RestrictedException;
 use Utopia\Database\Exception\Structure as StructureException;
 use Utopia\Database\Exception\Timeout as TimeoutException;
 use Utopia\Database\Exception\Transaction as TransactionException;
@@ -132,33 +137,56 @@ class Mongo extends Adapter
             return $callback();
         }
 
-        try {
-            $this->startTransaction();
-            $result = $callback();
-            $this->commitTransaction();
-            return $result;
-        } catch (\Throwable $action) {
-            try {
-                $this->rollbackTransaction();
-            } catch (\Throwable) {
-                // Throw the original exception, not the rollback one
-                // Since if it's a duplicate key error, the rollback will fail,
-                // and we want to throw the original exception.
-            } finally {
-                // Ensure state is cleaned up even if rollback fails
-                if ($this->session) {
-                    try {
-                        $this->client->endSessions([$this->session]);
-                    } catch (\Throwable $endSessionError) {
-                        // Ignore errors when ending session during error cleanup
-                    }
-                }
-                $this->inTransaction = 0;
-                $this->session = null;
-            }
+        $sleep = 50_000; // 50 milliseconds
+        $retries = 2;
 
-            throw $action;
+        for ($attempts = 0; $attempts <= $retries; $attempts++) {
+            try {
+                $this->startTransaction();
+                $result = $callback();
+                $this->commitTransaction();
+                return $result;
+            } catch (\Throwable $action) {
+                try {
+                    $this->rollbackTransaction();
+                } catch (\Throwable) {
+                    // Throw the original exception, not the rollback one
+                    // Since if it's a duplicate key error, the rollback will fail,
+                    // and we want to throw the original exception.
+                } finally {
+                    // Ensure state is cleaned up even if rollback fails
+                    if ($this->session) {
+                        try {
+                            $this->client->endSessions([$this->session]);
+                        } catch (\Throwable $endSessionError) {
+                            // Ignore errors when ending session during error cleanup
+                        }
+                    }
+                    $this->inTransaction = 0;
+                    $this->session = null;
+                }
+
+                if (
+                    $action instanceof DuplicateException ||
+                    $action instanceof RestrictedException ||
+                    $action instanceof AuthorizationException ||
+                    $action instanceof RelationshipException ||
+                    $action instanceof ConflictException ||
+                    $action instanceof LimitException
+                ) {
+                    throw $action;
+                }
+
+                if ($attempts < $retries) {
+                    \usleep($sleep * ($attempts + 1));
+                    continue;
+                }
+
+                throw $action;
+            }
         }
+
+        throw new TransactionException('Failed to execute transaction');
     }
 
     public function startTransaction(): bool


### PR DESCRIPTION
## What does this PR do?

Gives `Mongo::withTransaction` the same retry-with-backoff behavior every other adapter already inherits from `Adapter::withTransaction`: up to 2 retries with 50ms/100ms backoff on transient failures.

Mongo is the only adapter that overrides `withTransaction` without reproducing the base retry loop, so transient MongoDB errors — most notably `E112 WriteConflict`, which MongoDB documents as retryable ("Please retry your operation or multi-document transaction") — surface immediately as 500s instead of being retried.

Non-transient typed exceptions (`Duplicate`, `Restricted`, `Authorization`, `Relationship`, `Conflict`, `Limit`) still throw immediately without retrying, matching the base adapter's exclusion list. The existing rollback/session-cleanup semantics are preserved as-is and now run before each retry, so every attempt starts with a fresh session.

## Test Plan

- `composer lint` passes.
- Verified the retry path against the production failure below: the conflicting write is a one-shot update, so the first retry succeeds.

## Related PRs and Issues

Root cause of the flaky `testInvalidSSRSource` Sites E2E failures on appwrite/appwrite MongoDB CI jobs (e.g. https://github.com/appwrite/appwrite/actions/runs/27395946536/job/80963312794). The builds worker updates the site document's `latestDeployment*` attributes at the same time the test's cleanup issues `DELETE /v1/sites/:siteId`; the delete transaction hits `E112 WriteConflict` and bubbles up as `500 general_unknown`. SQL adapters don't flake because InnoDB row locks make the delete wait, and because their inherited `withTransaction` retries.

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/utopia-php/database/blob/main/CONTRIBUTING.md)?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database transaction reliability with automatic retry capability for transient failures
  * Improved error handling and recovery for specific database exception scenarios
  * Strengthened transaction state cleanup and resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->