### PR TITLE
Bug update document uid with delete

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -986,14 +986,6 @@ class MariaDB extends SQL
             $columns = '';
 
             if (!$skipPermissions) {
-                /**
-                 * Permission rows in the _perms table are keyed by the document's
-                 * UID (the _document column). Replace the permissions with a full
-                 * rewrite: delete every existing row for the (old) UID, then
-                 * re-insert the document's current permission set under the (new)
-                 * UID. This keeps the logic simple and correctly re-keys the
-                 * permission rows when the UID changes.
-                 */
                 $newUid = $document->offsetExists('$id') ? $document->getId() : $id;
 
                 $sql = "
@@ -1011,10 +1003,6 @@ class MariaDB extends SQL
                     $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
                 }
 
-                /**
-                 * Insert the document's full current permission set under the
-                 * (new) UID.
-                 */
                 $values = [];
                 foreach (Database::PERMISSIONS as $type) {
                     foreach ($document->getPermissionsByType($type) as $i => $_) {

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -988,164 +988,47 @@ class MariaDB extends SQL
             if (!$skipPermissions) {
                 /**
                  * Permission rows in the _perms table are keyed by the document's
-                 * UID (the _document column). When the UID changes, the existing
-                 * rows must be re-pointed to the new UID before the diff below is
-                 * applied, otherwise the old rows are orphaned and unchanged
-                 * permissions are lost for the new UID.
+                 * UID (the _document column). Replace the permissions with a full
+                 * rewrite: delete every existing row for the (old) UID, then
+                 * re-insert the document's current permission set under the (new)
+                 * UID. This keeps the logic simple and correctly re-keys the
+                 * permission rows when the UID changes.
                  */
                 $newUid = $document->offsetExists('$id') ? $document->getId() : $id;
-                $uidChanged = $newUid !== $id;
 
                 $sql = "
-			    SELECT _type, _permission
-			    FROM {$this->getSQLTable($name . '_perms')}
+			    DELETE FROM {$this->getSQLTable($name . '_perms')}
 			    WHERE _document = :_uid
 			    {$this->getTenantQuery($collection)}
 			";
 
-                $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
+                $sql = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $sql);
 
-                /**
-                 * Get current permissions from the database
-                 */
-                $sqlPermissions = $this->getPDO()->prepare($sql);
-
-                $sqlPermissions->bindValue(':_uid', $id);
+                $stmtRemovePermissions = $this->getPDO()->prepare($sql);
+                $stmtRemovePermissions->bindValue(':_uid', $id);
 
                 if ($this->sharedTables) {
-                    $sqlPermissions->bindValue(':_tenant', $this->tenant);
+                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
                 }
 
-                $sqlPermissions->execute();
-                $permissions = $sqlPermissions->fetchAll();
-                $sqlPermissions->closeCursor();
-
-                $initial = [];
+                /**
+                 * Insert the document's full current permission set under the
+                 * (new) UID.
+                 */
+                $values = [];
                 foreach (Database::PERMISSIONS as $type) {
-                    $initial[$type] = [];
-                }
-
-                $permissions = array_reduce($permissions, function (array $carry, array $item) {
-                    $carry[$item['_type']][] = $item['_permission'];
-
-                    return $carry;
-                }, $initial);
-
-                /**
-                 * Get removed Permissions
-                 */
-                $removals = [];
-                foreach (Database::PERMISSIONS as $type) {
-                    $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
-                    if (!empty($diff)) {
-                        $removals[$type] = $diff;
+                    foreach ($document->getPermissionsByType($type) as $i => $_) {
+                        $tenantPlaceholder = $this->sharedTables ? ', :_tenant' : '';
+                        $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i}{$tenantPlaceholder})";
                     }
                 }
 
-                /**
-                 * Get added Permissions
-                 */
-                $additions = [];
-                foreach (Database::PERMISSIONS as $type) {
-                    $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
-                    if (!empty($diff)) {
-                        $additions[$type] = $diff;
-                    }
-                }
-
-                /**
-                 * Query to re-point existing permissions to the new UID
-                 */
-                if ($uidChanged) {
-                    $sql = "
-				    UPDATE {$this->getSQLTable($name . '_perms')}
-                    SET _document = :_newUid
-                    WHERE _document = :_uid
-                    {$this->getTenantQuery($collection)}
-                ";
-
-                    $stmtRepointPermissions = $this->getPDO()->prepare($sql);
-                    $stmtRepointPermissions->bindValue(':_uid', $id);
-                    $stmtRepointPermissions->bindValue(':_newUid', $newUid);
-
-                    if ($this->sharedTables) {
-                        $stmtRepointPermissions->bindValue(':_tenant', $this->tenant);
-                    }
-                }
-
-                /**
-                 * Query to remove permissions
-                 */
-                $removeQuery = '';
-                if (!empty($removals)) {
-                    $removeQuery = ' AND (';
-                    foreach ($removals as $type => $permissions) {
-                        $removeQuery .= "(
-                    _type = '{$type}'
-                    AND _permission IN (" . implode(', ', \array_map(fn (string $i) => ":_remove_{$type}_{$i}", \array_keys($permissions))) . ")
-                )";
-                        if ($type !== \array_key_last($removals)) {
-                            $removeQuery .= ' OR ';
-                        }
-                    }
-                }
-                if (!empty($removeQuery)) {
-                    $removeQuery .= ')';
-                    $sql = "
-				    DELETE
-                    FROM {$this->getSQLTable($name . '_perms')}
-                    WHERE _document = :_uid
-                    {$this->getTenantQuery($collection)}
-                ";
-
-                    $removeQuery = $sql . $removeQuery;
-
-                    $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
-
-                    $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                    $stmtRemovePermissions->bindValue(':_uid', $newUid);
-
-                    if ($this->sharedTables) {
-                        $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
-                    }
-
-                    foreach ($removals as $type => $permissions) {
-                        foreach ($permissions as $i => $permission) {
-                            $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
-                        }
-                    }
-                }
-
-                /**
-                 * Query to add permissions
-                 */
-                if (!empty($additions)) {
-                    $values = [];
-                    foreach ($additions as $type => $permissions) {
-                        foreach ($permissions as $i => $_) {
-                            $value = "( :_uid, '{$type}', :_add_{$type}_{$i}";
-
-                            if ($this->sharedTables) {
-                                $value .= ", :_tenant)";
-                            } else {
-                                $value .= ")";
-                            }
-
-                            $values[] = $value;
-                        }
-                    }
+                if (!empty($values)) {
+                    $tenantColumn = $this->sharedTables ? ', _tenant' : '';
 
                     $sql = "
-				    INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission
-				";
-
-                    if ($this->sharedTables) {
-                        $sql .= ', _tenant)';
-                    } else {
-                        $sql .= ')';
-                    }
-
-                    $sql .= " VALUES " . \implode(', ', $values);
+				    INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission{$tenantColumn})
+				    VALUES " . \implode(', ', $values);
 
                     $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
@@ -1157,8 +1040,8 @@ class MariaDB extends SQL
                         $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
                     }
 
-                    foreach ($additions as $type => $permissions) {
-                        foreach ($permissions as $i => $permission) {
+                    foreach (Database::PERMISSIONS as $type) {
+                        foreach ($document->getPermissionsByType($type) as $i => $permission) {
                             $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
                         }
                     }
@@ -1240,9 +1123,6 @@ class MariaDB extends SQL
 
             $stmt->execute();
 
-            if (isset($stmtRepointPermissions)) {
-                $stmtRepointPermissions->execute();
-            }
             if (isset($stmtRemovePermissions)) {
                 $stmtRemovePermissions->execute();
             }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -992,7 +992,7 @@ class MariaDB extends SQL
 			    DELETE FROM {$this->getSQLTable($name . '_perms')}
 			    WHERE _document = :_uid
 			    {$this->getTenantQuery($collection)}
-			";
+			    ";
 
                 $sql = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $sql);
 
@@ -1003,10 +1003,12 @@ class MariaDB extends SQL
                 }
 
                 $values = [];
+                $binds = [];
                 foreach (Database::PERMISSIONS as $type) {
-                    foreach ($document->getPermissionsByType($type) as $i => $_) {
+                    foreach ($document->getPermissionsByType($type) as $i => $permission) {
                         $tenantPlaceholder = $this->sharedTables ? ', :_tenant' : '';
-                        $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i}{$tenantPlaceholder})";
+                        $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i} {$tenantPlaceholder})";
+                        $binds[":_add_{$type}_{$i}"] = $permission;
                     }
                 }
 
@@ -1020,17 +1022,13 @@ class MariaDB extends SQL
                     $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
                     $stmtAddPermissions = $this->getPDO()->prepare($sql);
-
                     $stmtAddPermissions->bindValue(":_uid", $newUid);
-
                     if ($this->sharedTables) {
                         $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
                     }
 
-                    foreach (Database::PERMISSIONS as $type) {
-                        foreach ($document->getPermissionsByType($type) as $i => $permission) {
-                            $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
-                        }
+                    foreach ($binds as $key => $permission) {
+                        $stmtAddPermissions->bindValue($key, $permission);
                     }
                 }
             }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1016,7 +1016,7 @@ class MariaDB extends SQL
                     $tenantColumn = $this->sharedTables ? ', _tenant' : '';
 
                     $sql = "
-				    INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission{$tenantColumn})
+				    INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission {$tenantColumn})
 				    VALUES " . \implode(', ', $values);
 
                     $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -980,11 +980,22 @@ class MariaDB extends SQL
             $attributes['_createdAt'] = $document->getCreatedAt();
             $attributes['_updatedAt'] = $document->getUpdatedAt();
             $attributes['_permissions'] = json_encode($document->getPermissions());
+            $attributes['_uid'] = $document->getId();
 
             $name = $this->filter($collection);
             $columns = '';
 
             if (!$skipPermissions) {
+                /**
+                 * Permission rows in the _perms table are keyed by the document's
+                 * UID (the _document column). When the UID changes, the existing
+                 * rows must be re-pointed to the new UID before the diff below is
+                 * applied, otherwise the old rows are orphaned and unchanged
+                 * permissions are lost for the new UID.
+                 */
+                $newUid = $document->offsetExists('$id') ? $document->getId() : $id;
+                $uidChanged = $newUid !== $id;
+
                 $sql = "
 			    SELECT _type, _permission
 			    FROM {$this->getSQLTable($name . '_perms')}
@@ -998,7 +1009,8 @@ class MariaDB extends SQL
                  * Get current permissions from the database
                  */
                 $sqlPermissions = $this->getPDO()->prepare($sql);
-                $sqlPermissions->bindValue(':_uid', $document->getId());
+
+                $sqlPermissions->bindValue(':_uid', $id);
 
                 if ($this->sharedTables) {
                     $sqlPermissions->bindValue(':_tenant', $this->tenant);
@@ -1042,6 +1054,26 @@ class MariaDB extends SQL
                 }
 
                 /**
+                 * Query to re-point existing permissions to the new UID
+                 */
+                if ($uidChanged) {
+                    $sql = "
+				    UPDATE {$this->getSQLTable($name . '_perms')}
+                    SET _document = :_newUid
+                    WHERE _document = :_uid
+                    {$this->getTenantQuery($collection)}
+                ";
+
+                    $stmtRepointPermissions = $this->getPDO()->prepare($sql);
+                    $stmtRepointPermissions->bindValue(':_uid', $id);
+                    $stmtRepointPermissions->bindValue(':_newUid', $newUid);
+
+                    if ($this->sharedTables) {
+                        $stmtRepointPermissions->bindValue(':_tenant', $this->tenant);
+                    }
+                }
+
+                /**
                  * Query to remove permissions
                  */
                 $removeQuery = '';
@@ -1071,7 +1103,7 @@ class MariaDB extends SQL
                     $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
 
                     $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                    $stmtRemovePermissions->bindValue(':_uid', $document->getId());
+                    $stmtRemovePermissions->bindValue(':_uid', $newUid);
 
                     if ($this->sharedTables) {
                         $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
@@ -1119,7 +1151,7 @@ class MariaDB extends SQL
 
                     $stmtAddPermissions = $this->getPDO()->prepare($sql);
 
-                    $stmtAddPermissions->bindValue(":_uid", $document->getId());
+                    $stmtAddPermissions->bindValue(":_uid", $newUid);
 
                     if ($this->sharedTables) {
                         $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
@@ -1168,7 +1200,7 @@ class MariaDB extends SQL
 
             $sql = "
                 UPDATE {$this->getSQLTable($name)}
-                SET {$columns} _uid = :_newUid
+                SET " . \rtrim($columns, ',') . "
                 WHERE _id=:_sequence
                 {$this->getTenantQuery($collection)}
 			";
@@ -1178,7 +1210,6 @@ class MariaDB extends SQL
             $stmt = $this->getPDO()->prepare($sql);
 
             $stmt->bindValue(':_sequence', $document->getSequence());
-            $stmt->bindValue(':_newUid', $document->getId());
 
             if ($this->sharedTables) {
                 $stmt->bindValue(':_tenant', $this->tenant);
@@ -1209,6 +1240,9 @@ class MariaDB extends SQL
 
             $stmt->execute();
 
+            if (isset($stmtRepointPermissions)) {
+                $stmtRepointPermissions->execute();
+            }
             if (isset($stmtRemovePermissions)) {
                 $stmtRemovePermissions->execute();
             }

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -998,7 +998,6 @@ class MariaDB extends SQL
 
                 $stmtRemovePermissions = $this->getPDO()->prepare($sql);
                 $stmtRemovePermissions->bindValue(':_uid', $id);
-
                 if ($this->sharedTables) {
                     $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
                 }

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1139,140 +1139,55 @@ class Postgres extends SQL
         $attributes['_createdAt'] = $document->getCreatedAt();
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = json_encode($document->getPermissions());
+        $attributes['_uid'] = $document->getId();
 
         $name = $this->filter($collection);
         $columns = '';
 
         if (!$skipPermissions) {
+            $newUid = $document->offsetExists('$id') ? $document->getId() : $id;
+
             $sql = "
-			SELECT _type, _permission
-			FROM {$this->getSQLTable($name . '_perms')}
+			DELETE FROM {$this->getSQLTable($name . '_perms')}
 			WHERE _document = :_uid
 			{$this->getTenantQuery($collection)}
 		";
 
-            $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
+            $sql = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $sql);
 
-            /**
-             * Get current permissions from the database
-             */
-            $permissionsStmt = $this->getPDO()->prepare($sql);
-            $permissionsStmt->bindValue(':_uid', $document->getId());
-
+            $stmtRemovePermissions = $this->getPDO()->prepare($sql);
+            $stmtRemovePermissions->bindValue(':_uid', $id);
             if ($this->sharedTables) {
-                $permissionsStmt->bindValue(':_tenant', $this->tenant);
+                $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
             }
 
-            $this->execute($permissionsStmt);
-            $permissions = $permissionsStmt->fetchAll();
-            $permissionsStmt->closeCursor();
-
-            $initial = [];
+            $values = [];
+            $binds = [];
             foreach (Database::PERMISSIONS as $type) {
-                $initial[$type] = [];
-            }
-
-            $permissions = array_reduce($permissions, function (array $carry, array $item) {
-                $carry[$item['_type']][] = $item['_permission'];
-
-                return $carry;
-            }, $initial);
-
-            /**
-             * Get removed Permissions
-             */
-            $removals = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
-                if (!empty($diff)) {
-                    $removals[$type] = $diff;
+                foreach ($document->getPermissionsByType($type) as $i => $permission) {
+                    $sqlTenant = $this->sharedTables ? ', :_tenant' : '';
+                    $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i} {$sqlTenant})";
+                    $binds[":_add_{$type}_{$i}"] = $permission;
                 }
             }
 
-            /**
-             * Get added Permissions
-             */
-            $additions = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
-                if (!empty($diff)) {
-                    $additions[$type] = $diff;
-                }
-            }
-
-            /**
-             * Query to remove permissions
-             */
-            $removeQuery = '';
-            if (!empty($removals)) {
-                $removeQuery = ' AND (';
-                foreach ($removals as $type => $permissions) {
-                    $removeQuery .= "(
-                    _type = '{$type}'
-                    AND _permission IN (" . implode(', ', \array_map(fn (string $i) => ":_remove_{$type}_{$i}", \array_keys($permissions))) . ")
-                )";
-                    if ($type !== \array_key_last($removals)) {
-                        $removeQuery .= ' OR ';
-                    }
-                }
-            }
-            if (!empty($removeQuery)) {
-                $removeQuery .= ')';
-
-                $sql = "
-				DELETE
-                FROM {$this->getSQLTable($name . '_perms')}
-                WHERE _document = :_uid
-                {$this->getTenantQuery($collection)}
-			";
-
-                $removeQuery = $sql . $removeQuery;
-
-                $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
-                $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                $stmtRemovePermissions->bindValue(':_uid', $document->getId());
-
-                if ($this->sharedTables) {
-                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
-                }
-
-                foreach ($removals as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
-                    }
-                }
-            }
-
-            /**
-             * Query to add permissions
-             */
-            if (!empty($additions)) {
-                $values = [];
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $_) {
-                        $sqlTenant = $this->sharedTables ? ', :_tenant' : '';
-                        $values[] = "( :_uid, '{$type}', :_add_{$type}_{$i} {$sqlTenant})";
-                    }
-                }
-
+            if (!empty($values)) {
                 $sqlTenant = $this->sharedTables ? ', _tenant' : '';
 
                 $sql = "
 				INSERT INTO {$this->getSQLTable($name . '_perms')} (_document, _type, _permission {$sqlTenant})
-				VALUES" . \implode(', ', $values);
+				VALUES " . \implode(', ', $values);
 
                 $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
                 $stmtAddPermissions = $this->getPDO()->prepare($sql);
-                $stmtAddPermissions->bindValue(":_uid", $document->getId());
+                $stmtAddPermissions->bindValue(":_uid", $newUid);
                 if ($this->sharedTables) {
                     $stmtAddPermissions->bindValue(':_tenant', $this->tenant);
                 }
 
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
-                    }
+                foreach ($binds as $key => $permission) {
+                    $stmtAddPermissions->bindValue($key, $permission);
                 }
             }
         }
@@ -1312,7 +1227,7 @@ class Postgres extends SQL
 
         $sql = "
 			UPDATE {$this->getSQLTable($name)}
-			SET {$columns} _uid = :_newUid 
+			SET " . \rtrim($columns, ',') . "
 			WHERE _id=:_sequence
 			{$this->getTenantQuery($collection)}
 		";
@@ -1322,7 +1237,6 @@ class Postgres extends SQL
         $stmt = $this->getPDO()->prepare($sql);
 
         $stmt->bindValue(':_sequence', $document->getSequence());
-        $stmt->bindValue(':_newUid', $document->getId());
 
         if ($this->sharedTables) {
             $stmt->bindValue(':_tenant', $this->tenant);

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -1275,6 +1275,7 @@ class SQLite extends MariaDB
         $attributes['_createdAt'] = $document->getCreatedAt();
         $attributes['_updatedAt'] = $document->getUpdatedAt();
         $attributes['_permissions'] = json_encode($document->getPermissions());
+        $attributes['_uid'] = $document->getId();
 
         if ($this->sharedTables) {
             $attributes['_tenant'] = $this->tenant;
@@ -1284,116 +1285,33 @@ class SQLite extends MariaDB
         $columns = '';
 
         if (!$skipPermissions) {
+            $newUid = $document->offsetExists('$id') ? $document->getId() : $id;
+
             $sql = "
-			SELECT _type, _permission
-			FROM `{$this->getNamespace()}_{$name}_perms`
+			DELETE FROM `{$this->getNamespace()}_{$name}_perms`
 			WHERE _document = :_uid
 			{$this->getTenantQuery($collection)}
 		";
 
-            $sql = $this->trigger(Database::EVENT_PERMISSIONS_READ, $sql);
+            $sql = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $sql);
 
-            /**
-             * Get current permissions from the database
-             */
-            $permissionsStmt = $this->getPDO()->prepare($sql);
-            $permissionsStmt->bindValue(':_uid', $document->getId());
-
+            $stmtRemovePermissions = $this->getPDO()->prepare($sql);
+            $stmtRemovePermissions->bindValue(':_uid', $id);
             if ($this->sharedTables) {
-                $permissionsStmt->bindValue(':_tenant', $this->tenant);
+                $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
             }
 
-            $permissionsStmt->execute();
-            $permissions = $permissionsStmt->fetchAll();
-            $permissionsStmt->closeCursor();
-
-            $initial = [];
+            $values = [];
+            $binds = [];
             foreach (Database::PERMISSIONS as $type) {
-                $initial[$type] = [];
-            }
-
-            $permissions = array_reduce($permissions, function (array $carry, array $item) {
-                $carry[$item['_type']][] = $item['_permission'];
-
-                return $carry;
-            }, $initial);
-
-            /**
-             * Get removed Permissions
-             */
-            $removals = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($permissions[$type], $document->getPermissionsByType($type));
-                if (!empty($diff)) {
-                    $removals[$type] = $diff;
+                foreach ($document->getPermissionsByType($type) as $i => $permission) {
+                    $tenantQuery = $this->sharedTables ? ', :_tenant' : '';
+                    $values[] = "(:_uid, '{$type}', :_add_{$type}_{$i} {$tenantQuery})";
+                    $binds[":_add_{$type}_{$i}"] = $permission;
                 }
             }
 
-            /**
-             * Get added Permissions
-             */
-            $additions = [];
-            foreach (Database::PERMISSIONS as $type) {
-                $diff = \array_diff($document->getPermissionsByType($type), $permissions[$type]);
-                if (!empty($diff)) {
-                    $additions[$type] = $diff;
-                }
-            }
-
-            /**
-             * Query to remove permissions
-             */
-            $removeQuery = '';
-            if (!empty($removals)) {
-                $removeQuery = ' AND (';
-                foreach ($removals as $type => $permissions) {
-                    $removeQuery .= "(
-                    _type = '{$type}'
-                    AND _permission IN (" . implode(', ', \array_map(fn (string $i) => ":_remove_{$type}_{$i}", \array_keys($permissions))) . ")
-                )";
-                    if ($type !== \array_key_last($removals)) {
-                        $removeQuery .= ' OR ';
-                    }
-                }
-            }
-            if (!empty($removeQuery)) {
-                $removeQuery .= ')';
-                $sql = "
-				DELETE
-                FROM `{$this->getNamespace()}_{$name}_perms`
-                WHERE _document = :_uid
-                {$this->getTenantQuery($collection)}
-			";
-
-                $removeQuery = $sql . $removeQuery;
-                $removeQuery = $this->trigger(Database::EVENT_PERMISSIONS_DELETE, $removeQuery);
-
-                $stmtRemovePermissions = $this->getPDO()->prepare($removeQuery);
-                $stmtRemovePermissions->bindValue(':_uid', $document->getId());
-
-                if ($this->sharedTables) {
-                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
-                }
-
-                foreach ($removals as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtRemovePermissions->bindValue(":_remove_{$type}_{$i}", $permission);
-                    }
-                }
-            }
-
-            /**
-             * Query to add permissions
-             */
-            if (!empty($additions)) {
-                $values = [];
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $_) {
-                        $tenantQuery = $this->sharedTables ? ', :_tenant' : '';
-                        $values[] = "(:_uid, '{$type}', :_add_{$type}_{$i} {$tenantQuery})";
-                    }
-                }
-
+            if (!empty($values)) {
                 $tenantQuery = $this->sharedTables ? ', _tenant' : '';
 
                 $sql = "
@@ -1403,16 +1321,13 @@ class SQLite extends MariaDB
                 $sql = $this->trigger(Database::EVENT_PERMISSIONS_CREATE, $sql);
 
                 $stmtAddPermissions = $this->getPDO()->prepare($sql);
-
-                $stmtAddPermissions->bindValue(":_uid", $document->getId());
+                $stmtAddPermissions->bindValue(":_uid", $newUid);
                 if ($this->sharedTables) {
                     $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
                 }
 
-                foreach ($additions as $type => $permissions) {
-                    foreach ($permissions as $i => $permission) {
-                        $stmtAddPermissions->bindValue(":_add_{$type}_{$i}", $permission);
-                    }
+                foreach ($binds as $key => $permission) {
+                    $stmtAddPermissions->bindValue($key, $permission);
                 }
             }
         }
@@ -1456,7 +1371,7 @@ class SQLite extends MariaDB
 
         $sql = "
 			UPDATE `{$this->getNamespace()}_{$name}`
-			SET {$columns}, _uid = :_newUid
+			SET {$columns}
 			WHERE _uid = :_existingUid
 			{$this->getTenantQuery($collection)}
 		";
@@ -1466,7 +1381,6 @@ class SQLite extends MariaDB
         $stmt = $this->getPDO()->prepare($sql);
 
         $stmt->bindValue(':_existingUid', $id);
-        $stmt->bindValue(':_newUid', $document->getId());
 
         if ($this->sharedTables) {
             $stmt->bindValue(':_tenant', $this->tenant);

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -2844,7 +2844,15 @@ class SQLite extends MariaDB
      * Schema-index entries for FTS5 fulltext tables on `$collection`.
      * Maps each back to a metadata index id when possible.
      *
-     * @return array<array{$id: string, indexName: string, indexType: string, nonUnique: int, columns: array<string>, lengths: array<null>}>
+     * Each entry has keys:
+     * - `$id`: string
+     * - `indexName`: string
+     * - `indexType`: string
+     * - `nonUnique`: int
+     * - `columns`: array<string>
+     * - `lengths`: array<null>
+     *
+     * @return array<array<string, mixed>>
      */
     protected function getFulltextSchemaIndexes(string $collection): array
     {

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -2844,14 +2844,7 @@ class SQLite extends MariaDB
      * Schema-index entries for FTS5 fulltext tables on `$collection`.
      * Maps each back to a metadata index id when possible.
      *
-     * @return array<array{
-     *     '$id': string,
-     *     indexName: string,
-     *     indexType: string,
-     *     nonUnique: int,
-     *     columns: array<string>,
-     *     lengths: array<null>,
-     * }>
+     * @return array<array{$id: string, indexName: string, indexType: string, nonUnique: int, columns: array<string>, lengths: array<null>}>
      */
     protected function getFulltextSchemaIndexes(string $collection): array
     {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6180,6 +6180,7 @@ class Database
 
             $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
             $document['$collection'] = $old->getAttribute('$collection'); // Make sure user doesn't switch collection ID
+            $document['$sequence'] = $old->getSequence(); // Sequence is immutable
             $document['$createdAt'] = ($createdAt === null || !$this->preserveDates) ? $old->getCreatedAt() : $createdAt;
 
             if ($this->adapter->getSharedTables()) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6170,6 +6170,12 @@ class Database
 
                 $skipPermissionsUpdate = ($originalPermissions === $currentPermissions);
             }
+
+            // UID change
+            if ($document->offsetExists('$id') && $document->getId() !== $id) {
+                $skipPermissionsUpdate = false;
+            }
+
             $createdAt = $document->getCreatedAt();
 
             $document = \array_merge($old->getArrayCopy(), $document->getArrayCopy());
@@ -6182,14 +6188,6 @@ class Database
                 $old->setAttribute('$tenant', $tenant); // Normalize for strict comparison
             }
             $document = new Document($document);
-
-            // A UID change re-keys the permission rows (_perms._document) to the
-            // new UID, so the permission block must run even when the permission
-            // set itself is unchanged. Otherwise the old rows are orphaned and the
-            // new UID is left with no permissions.
-            if ($document->getId() !== $id) {
-                $skipPermissionsUpdate = false;
-            }
 
             $attributes = $collection->getAttribute('attributes', []);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6183,6 +6183,14 @@ class Database
             }
             $document = new Document($document);
 
+            // A UID change re-keys the permission rows (_perms._document) to the
+            // new UID, so the permission block must run even when the permission
+            // set itself is unchanged. Otherwise the old rows are orphaned and the
+            // new UID is left with no permissions.
+            if ($document->getId() !== $id) {
+                $skipPermissionsUpdate = false;
+            }
+
             $attributes = $collection->getAttribute('attributes', []);
 
             $relationships = \array_filter($attributes, function ($attribute) {

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -1645,6 +1645,7 @@ trait DocumentTests
                     '$id' => 'final_id',
                     '$permissions' => [
                         Permission::read(Role::user('bob')),
+                        Permission::read(Role::user('bob')), // Duplication check
                         Permission::update(Role::user('bob')),
                         Permission::delete(Role::user('bob')),
                     ],

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -1572,6 +1572,110 @@ trait DocumentTests
         $database->deleteCollection('defaults');
     }
 
+    /**
+     * When a document's UID changes on update, its permission rows in the
+     * collection's _perms table must follow the new UID. Otherwise the old
+     * rows are orphaned and the renamed document is left with no permissions,
+     * even when the permission set itself was not changed.
+     */
+    public function testUpdateDocumentChangeIdMigratesPermissions(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $auth = $database->getAuthorization();
+
+        $collection = 'update_change_id_perms';
+
+        // documentSecurity with no collection-level permissions: reads are
+        // governed purely by the document's rows in the _perms table.
+        $database->createCollection($collection, permissions: [], documentSecurity: true);
+        $this->assertEquals(true, $database->createAttribute($collection, 'name', Database::VAR_STRING, 128, false));
+
+        // Create a document whose read permission is scoped to a single role,
+        // so that find() must consult the _perms table to return it.
+        $document = $auth->skip(fn () => $database->createDocument($collection, new Document([
+            '$id' => 'old_id',
+            'name' => 'test',
+            '$permissions' => [
+                Permission::read(Role::user('alice')),
+                Permission::update(Role::user('alice')),
+                Permission::delete(Role::user('alice')),
+            ],
+        ])));
+        $this->assertEquals('old_id', $document->getId());
+
+        // Sanity: as alice the document is visible via the _perms table.
+        $auth->addRole(Role::user('alice')->toString());
+        $this->assertCount(1, $database->find($collection));
+
+        // Rename the document WITHOUT changing its permission set.
+        $renamed = $auth->skip(fn () => $database->updateDocument($collection, 'old_id', new Document(\array_merge(
+            $document->getArrayCopy(),
+            ['$id' => 'new_id'],
+        ))));
+        $this->assertEquals('new_id', $renamed->getId());
+
+        // The old UID must no longer resolve to a document.
+        $this->assertTrue($auth->skip(fn () => $database->getDocument($collection, 'old_id'))->isEmpty());
+
+        // The new UID must exist and keep its permissions on the main row.
+        $newDoc = $auth->skip(fn () => $database->getDocument($collection, 'new_id'));
+        $this->assertFalse($newDoc->isEmpty());
+        $this->assertContains(Permission::read(Role::user('alice')), $newDoc->getPermissions());
+
+        // The crucial check: the permission rows must have migrated to the new
+        // UID in the _perms table. As alice, find() (which joins _perms) must
+        // still return exactly the renamed document. With orphaned rows under
+        // the old UID this returns 0.
+        $found = $database->find($collection);
+        $this->assertCount(1, $found);
+        $this->assertEquals('new_id', $found[0]->getId());
+
+        /**
+         * Second scenario: change the UID AND the permission set in the same
+         * update. Drop alice's access and grant bob instead. The removed rows
+         * must be gone, the added rows must land under the new UID, and nothing
+         * may be left orphaned under the old UID.
+         */
+        $rekeyed = $auth->skip(fn () => $database->updateDocument($collection, 'new_id', new Document(\array_merge(
+            $newDoc->getArrayCopy(),
+            [
+                '$id' => 'final_id',
+                '$permissions' => [
+                    Permission::read(Role::user('bob')),
+                    Permission::update(Role::user('bob')),
+                    Permission::delete(Role::user('bob')),
+                ],
+            ],
+        ))));
+        $this->assertEquals('final_id', $rekeyed->getId());
+
+        // The old UID must no longer resolve to a document.
+        $this->assertTrue($auth->skip(fn () => $database->getDocument($collection, 'new_id'))->isEmpty());
+
+        // The main row must reflect the new permission set.
+        $finalDoc = $auth->skip(fn () => $database->getDocument($collection, 'final_id'));
+        $this->assertFalse($finalDoc->isEmpty());
+        $this->assertContains(Permission::read(Role::user('bob')), $finalDoc->getPermissions());
+        $this->assertNotContains(Permission::read(Role::user('alice')), $finalDoc->getPermissions());
+
+        // alice's permission rows were removed: as alice nothing is returned.
+        $this->assertCount(0, $database->find($collection));
+
+        // bob's permission rows landed under the new UID: as bob the renamed
+        // document is returned via the _perms join.
+        $auth->addRole(Role::user('bob')->toString());
+        $foundAsBob = $database->find($collection);
+        $this->assertCount(1, $foundAsBob);
+        $this->assertEquals('final_id', $foundAsBob[0]->getId());
+
+        $auth->removeRole(Role::user('alice')->toString());
+        $auth->removeRole(Role::user('bob')->toString());
+
+        $auth->skip(fn () => $database->deleteCollection($collection));
+    }
+
     public function testIncreaseDecrease(): Document
     {
         /** @var Database $database */

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -1587,93 +1587,95 @@ trait DocumentTests
 
         $collection = 'update_change_id_perms';
 
-        // documentSecurity with no collection-level permissions: reads are
-        // governed purely by the document's rows in the _perms table.
-        $database->createCollection($collection, permissions: [], documentSecurity: true);
-        $this->assertEquals(true, $database->createAttribute($collection, 'name', Database::VAR_STRING, 128, false));
+        try {
+            // documentSecurity with no collection-level permissions: reads are
+            // governed purely by the document's rows in the _perms table.
+            $database->createCollection($collection, permissions: [], documentSecurity: true);
+            $this->assertEquals(true, $database->createAttribute($collection, 'name', Database::VAR_STRING, 128, false));
 
-        // Create a document whose read permission is scoped to a single role,
-        // so that find() must consult the _perms table to return it.
-        $document = $auth->skip(fn () => $database->createDocument($collection, new Document([
-            '$id' => 'old_id',
-            'name' => 'test',
-            '$permissions' => [
-                Permission::read(Role::user('alice')),
-                Permission::update(Role::user('alice')),
-                Permission::delete(Role::user('alice')),
-            ],
-        ])));
-        $this->assertEquals('old_id', $document->getId());
-
-        // Sanity: as alice the document is visible via the _perms table.
-        $auth->addRole(Role::user('alice')->toString());
-        $this->assertCount(1, $database->find($collection));
-
-        // Rename the document WITHOUT changing its permission set.
-        $renamed = $auth->skip(fn () => $database->updateDocument($collection, 'old_id', new Document(\array_merge(
-            $document->getArrayCopy(),
-            ['$id' => 'new_id'],
-        ))));
-        $this->assertEquals('new_id', $renamed->getId());
-
-        // The old UID must no longer resolve to a document.
-        $this->assertTrue($auth->skip(fn () => $database->getDocument($collection, 'old_id'))->isEmpty());
-
-        // The new UID must exist and keep its permissions on the main row.
-        $newDoc = $auth->skip(fn () => $database->getDocument($collection, 'new_id'));
-        $this->assertFalse($newDoc->isEmpty());
-        $this->assertContains(Permission::read(Role::user('alice')), $newDoc->getPermissions());
-
-        // The crucial check: the permission rows must have migrated to the new
-        // UID in the _perms table. As alice, find() (which joins _perms) must
-        // still return exactly the renamed document. With orphaned rows under
-        // the old UID this returns 0.
-        $found = $database->find($collection);
-        $this->assertCount(1, $found);
-        $this->assertEquals('new_id', $found[0]->getId());
-
-        /**
-         * Second scenario: change the UID AND the permission set in the same
-         * update. Drop alice's access and grant bob instead. The removed rows
-         * must be gone, the added rows must land under the new UID, and nothing
-         * may be left orphaned under the old UID.
-         */
-        $rekeyed = $auth->skip(fn () => $database->updateDocument($collection, 'new_id', new Document(\array_merge(
-            $newDoc->getArrayCopy(),
-            [
-                '$id' => 'final_id',
+            // Create a document whose read permission is scoped to a single role,
+            // so that find() must consult the _perms table to return it.
+            $document = $auth->skip(fn () => $database->createDocument($collection, new Document([
+                '$id' => 'old_id',
+                'name' => 'test',
                 '$permissions' => [
-                    Permission::read(Role::user('bob')),
-                    Permission::update(Role::user('bob')),
-                    Permission::delete(Role::user('bob')),
+                    Permission::read(Role::user('alice')),
+                    Permission::update(Role::user('alice')),
+                    Permission::delete(Role::user('alice')),
                 ],
-            ],
-        ))));
-        $this->assertEquals('final_id', $rekeyed->getId());
+            ])));
+            $this->assertEquals('old_id', $document->getId());
 
-        // The old UID must no longer resolve to a document.
-        $this->assertTrue($auth->skip(fn () => $database->getDocument($collection, 'new_id'))->isEmpty());
+            // Sanity: as alice the document is visible via the _perms table.
+            $auth->addRole(Role::user('alice')->toString());
+            $this->assertCount(1, $database->find($collection));
 
-        // The main row must reflect the new permission set.
-        $finalDoc = $auth->skip(fn () => $database->getDocument($collection, 'final_id'));
-        $this->assertFalse($finalDoc->isEmpty());
-        $this->assertContains(Permission::read(Role::user('bob')), $finalDoc->getPermissions());
-        $this->assertNotContains(Permission::read(Role::user('alice')), $finalDoc->getPermissions());
+            // Rename the document WITHOUT changing its permission set.
+            $renamed = $auth->skip(fn () => $database->updateDocument($collection, 'old_id', new Document(\array_merge(
+                $document->getArrayCopy(),
+                ['$id' => 'new_id'],
+            ))));
+            $this->assertEquals('new_id', $renamed->getId());
 
-        // alice's permission rows were removed: as alice nothing is returned.
-        $this->assertCount(0, $database->find($collection));
+            // The old UID must no longer resolve to a document.
+            $this->assertTrue($auth->skip(fn () => $database->getDocument($collection, 'old_id'))->isEmpty());
 
-        // bob's permission rows landed under the new UID: as bob the renamed
-        // document is returned via the _perms join.
-        $auth->addRole(Role::user('bob')->toString());
-        $foundAsBob = $database->find($collection);
-        $this->assertCount(1, $foundAsBob);
-        $this->assertEquals('final_id', $foundAsBob[0]->getId());
+            // The new UID must exist and keep its permissions on the main row.
+            $newDoc = $auth->skip(fn () => $database->getDocument($collection, 'new_id'));
+            $this->assertFalse($newDoc->isEmpty());
+            $this->assertContains(Permission::read(Role::user('alice')), $newDoc->getPermissions());
 
-        $auth->removeRole(Role::user('alice')->toString());
-        $auth->removeRole(Role::user('bob')->toString());
+            // The crucial check: the permission rows must have migrated to the new
+            // UID in the _perms table. As alice, find() (which joins _perms) must
+            // still return exactly the renamed document. With orphaned rows under
+            // the old UID this returns 0.
+            $found = $database->find($collection);
+            $this->assertCount(1, $found);
+            $this->assertEquals('new_id', $found[0]->getId());
 
-        $auth->skip(fn () => $database->deleteCollection($collection));
+            /**
+             * Second scenario: change the UID AND the permission set in the same
+             * update. Drop alice's access and grant bob instead. The removed rows
+             * must be gone, the added rows must land under the new UID, and nothing
+             * may be left orphaned under the old UID.
+             */
+            $rekeyed = $auth->skip(fn () => $database->updateDocument($collection, 'new_id', new Document(\array_merge(
+                $newDoc->getArrayCopy(),
+                [
+                    '$id' => 'final_id',
+                    '$permissions' => [
+                        Permission::read(Role::user('bob')),
+                        Permission::update(Role::user('bob')),
+                        Permission::delete(Role::user('bob')),
+                    ],
+                ],
+            ))));
+            $this->assertEquals('final_id', $rekeyed->getId());
+
+            // The old UID must no longer resolve to a document.
+            $this->assertTrue($auth->skip(fn () => $database->getDocument($collection, 'new_id'))->isEmpty());
+
+            // The main row must reflect the new permission set.
+            $finalDoc = $auth->skip(fn () => $database->getDocument($collection, 'final_id'));
+            $this->assertFalse($finalDoc->isEmpty());
+            $this->assertContains(Permission::read(Role::user('bob')), $finalDoc->getPermissions());
+            $this->assertNotContains(Permission::read(Role::user('alice')), $finalDoc->getPermissions());
+
+            // alice's permission rows were removed: as alice nothing is returned.
+            $this->assertCount(0, $database->find($collection));
+
+            // bob's permission rows landed under the new UID: as bob the renamed
+            // document is returned via the _perms join.
+            $auth->addRole(Role::user('bob')->toString());
+            $foundAsBob = $database->find($collection);
+            $this->assertCount(1, $foundAsBob);
+            $this->assertEquals('final_id', $foundAsBob[0]->getId());
+        } finally {
+            $auth->removeRole(Role::user('alice')->toString());
+            $auth->removeRole(Role::user('bob')->toString());
+
+            $auth->skip(fn () => $database->deleteCollection($collection));
+        }
     }
 
     public function testIncreaseDecrease(): Document


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document permission records when updating a document identifier: permission entries are now properly migrated to the new identifier and removed from the old one.
  * Permission updates are no longer skipped when an update changes document identity, ensuring permissions stay in sync with the latest document.
* **Tests**
  * Added end-to-end coverage verifying that changing a document’s ID (with or without permission changes) updates permission lookups and query results correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->