### PR TITLE
feat: bound MySQL writes with session lock-wait timeout

### DIFF
--- a/src/Database/Adapter/MySQL.php
+++ b/src/Database/Adapter/MySQL.php
@@ -32,6 +32,7 @@ class MySQL extends MariaDB
 
         $this->timeout = $milliseconds;
 
+        // Bound reads: the max_execution_time optimizer hint only applies to SELECTs.
         $this->before($event, 'timeout', function ($sql) use ($milliseconds) {
             return \preg_replace(
                 pattern: '/SELECT/',
@@ -40,6 +41,13 @@ class MySQL extends MariaDB
                 limit: 1
             );
         });
+
+        // Bound writes: hints are ignored by INSERT/UPDATE/DDL, so cap how long a
+        // statement waits on row (InnoDB) and metadata locks before failing fast.
+        // This is a connection-scoped floor: Pool re-applies it on each checkout,
+        // so it tracks the latest timeout without a paired reset to leak through.
+        $seconds = \max(1, (int) \ceil($milliseconds / 1000));
+        $this->getPDO()->exec("SET SESSION innodb_lock_wait_timeout = {$seconds}, SESSION lock_wait_timeout = {$seconds}");
     }
 
     /**
@@ -159,6 +167,11 @@ class MySQL extends MariaDB
 
         // Regex timeout
         if ($e->getCode() === 'HY000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 3699) {
+            return new TimeoutException('Query timed out', $e->getCode(), $e);
+        }
+
+        // Lock wait timeout (blocked write released by innodb_lock_wait_timeout/lock_wait_timeout)
+        if ($e->getCode() === 'HY000' && isset($e->errorInfo[1]) && $e->errorInfo[1] === 1205) {
             return new TimeoutException('Query timed out', $e->getCode(), $e);
         }
 


### PR DESCRIPTION
## Problem

`MySQL::setTimeout()` only injected a `max_execution_time` optimizer hint, which MySQL **honors for read-only SELECTs only**. INSERT/UPDATE/DDL had no app-level bound:

- InnoDB row-lock waits sat for the server default (**50s**)
- Metadata-lock waits sat for `lock_wait_timeout`'s default of **one year**

A blocked write held its connection the entire time instead of failing fast. (Unlike MariaDB, MySQL has no `SET STATEMENT … FOR <stmt>` syntax, so a connection-scoped lock-wait timeout is the real mechanism here.)

## Change (`src/Database/Adapter/MySQL.php`)

- **`setTimeout()`** — keeps the SELECT hint for reads, and adds a connection-scoped write bound: `SET SESSION innodb_lock_wait_timeout = N, lock_wait_timeout = N` (seconds, floored at 1). Blocked INSERT/UPDATE/DDL now fail fast with error **1205** and release the connection.
- **`processException()`** — maps error **1205** (`ER_LOCK_WAIT_TIMEOUT`) to the existing `TimeoutException`, consistent with how SELECT timeouts surface.

The bound is a connection-scoped floor that `Pool` re-applies on each checkout (tracking the latest timeout), so there is **no paired `clearTimeout` reset** — avoiding fragile set/teardown of connection state that may never run on exception paths and isn't reachable through the pool anyway.

## Scope

- MySQL only — MariaDB's `SET STATEMENT max_statement_time FOR` already bounds the statement types it wraps.
- No new test: proving "blocked write fails fast" requires a second connection holding a lock with transaction orchestration (brittle, no existing harness pattern). The existing `testQueryTimeout` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)