### PR TITLE
fix(transaction): tolerate desynced cleanup rollback on startTransaction

### DIFF
--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -38,11 +38,18 @@ class Postgres extends SQL
     {
         try {
             if ($this->inTransaction === 0) {
-                if ($this->getPDO()->inTransaction()) {
-                    $this->getPDO()->rollBack();
-                } else {
-                    // If no active transaction, this has no effect.
-                    $this->getPDO()->prepare('ROLLBACK')->execute();
+                try {
+                    if ($this->getPDO()->inTransaction()) {
+                        $this->getPDO()->rollBack();
+                    } else {
+                        // If no active transaction, this has no effect.
+                        $this->getPDO()->prepare('ROLLBACK')->execute();
+                    }
+                } catch (PDOException) {
+                    // A pooled connection can report a transaction it no longer
+                    // holds after a reconnect (e.g. Swoole PDOProxy keeps its own
+                    // counter), making this cleanup rollback throw. It is best
+                    // effort; swallow it and begin a fresh transaction below.
                 }
 
                 $result = $this->getPDO()->beginTransaction();

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -68,11 +68,18 @@ abstract class SQL extends Adapter
     {
         try {
             if ($this->inTransaction === 0) {
-                if ($this->getPDO()->inTransaction()) {
-                    $this->getPDO()->rollBack();
-                } else {
-                    // If no active transaction, this has no effect.
-                    $this->getPDO()->prepare('ROLLBACK')->execute();
+                try {
+                    if ($this->getPDO()->inTransaction()) {
+                        $this->getPDO()->rollBack();
+                    } else {
+                        // If no active transaction, this has no effect.
+                        $this->getPDO()->prepare('ROLLBACK')->execute();
+                    }
+                } catch (PDOException) {
+                    // A pooled connection can report a transaction it no longer
+                    // holds after a reconnect (e.g. Swoole PDOProxy keeps its own
+                    // counter), making this cleanup rollback throw. It is best
+                    // effort; swallow it and begin a fresh transaction below.
                 }
 
                 $this->getPDO()->beginTransaction();

--- a/tests/unit/SQLTransactionTest.php
+++ b/tests/unit/SQLTransactionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PDOException;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Adapter\MySQL;
+use Utopia\Database\Adapter\Postgres;
 use Utopia\Database\Exception\Transaction as TransactionException;
 
 class SQLTransactionTest extends TestCase
@@ -56,5 +57,25 @@ class SQLTransactionTest extends TestCase
         $this->expectExceptionMessage('Failed to start transaction: Connection lost');
 
         $adapter->startTransaction();
+    }
+
+    public function testPostgresStartTransactionRecoversFromDesyncedRollback(): void
+    {
+        $pdo = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdo->method('inTransaction')->willReturn(true);
+        $pdo->method('rollBack')->willThrowException(
+            new PDOException('There is no active transaction')
+        );
+        $pdo->expects($this->once())
+            ->method('beginTransaction')
+            ->willReturn(true);
+
+        $adapter = new Postgres($pdo);
+
+        $this->assertTrue($adapter->startTransaction());
+        $this->assertTrue($adapter->inTransaction());
     }
 }

--- a/tests/unit/SQLTransactionTest.php
+++ b/tests/unit/SQLTransactionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit;
+
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Adapter\MySQL;
+
+class SQLTransactionTest extends TestCase
+{
+    /**
+     * A pooled connection (e.g. Swoole PDOProxy) can keep its own transaction
+     * counter that survives a reconnect, so it reports an open transaction the
+     * underlying connection no longer holds. The cleanup rollBack() then throws
+     * "There is no active transaction". startTransaction() must swallow that and
+     * still begin a fresh transaction instead of surfacing it as a failure.
+     */
+    public function testStartTransactionRecoversFromDesyncedRollback(): void
+    {
+        $pdo = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdo->method('inTransaction')->willReturn(true);
+        $pdo->method('rollBack')->willThrowException(
+            new PDOException('There is no active transaction')
+        );
+        $pdo->expects($this->once())
+            ->method('beginTransaction')
+            ->willReturn(true);
+
+        $adapter = new MySQL($pdo);
+
+        $this->assertTrue($adapter->startTransaction());
+        $this->assertTrue($adapter->inTransaction());
+    }
+}

--- a/tests/unit/SQLTransactionTest.php
+++ b/tests/unit/SQLTransactionTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PDOException;
 use PHPUnit\Framework\TestCase;
 use Utopia\Database\Adapter\MySQL;
+use Utopia\Database\Exception\Transaction as TransactionException;
 
 class SQLTransactionTest extends TestCase
 {
@@ -33,5 +34,27 @@ class SQLTransactionTest extends TestCase
 
         $this->assertTrue($adapter->startTransaction());
         $this->assertTrue($adapter->inTransaction());
+    }
+
+    public function testStartTransactionDoesNotMaskBeginFailureAfterDesyncedRollback(): void
+    {
+        $pdo = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdo->method('inTransaction')->willReturn(true);
+        $pdo->method('rollBack')->willThrowException(
+            new PDOException('There is no active transaction')
+        );
+        $pdo->expects($this->once())
+            ->method('beginTransaction')
+            ->willThrowException(new PDOException('Connection lost'));
+
+        $adapter = new MySQL($pdo);
+
+        $this->expectException(TransactionException::class);
+        $this->expectExceptionMessage('Failed to start transaction: Connection lost');
+
+        $adapter->startTransaction();
     }
 }


### PR DESCRIPTION
## Problem

In production (Appwrite Cloud, nyc3) we see a high-volume, persistent error on `databases.updateDocument` / `tablesDB.updateRow`:

```
Utopia\Database\Exception\Transaction: Failed to start transaction: There is no active transaction
  at src/Database/Adapter/SQL.php:96  (startTransaction)
  caused by PDOException: There is no active transaction  (PDO::rollBack)
```

### Root cause

A pooled connection can report a transaction it no longer holds after a **reconnect**.

When a connection drops *mid-transaction* (e.g. MySQL group-replication failover / member expulsion / `wait_timeout`), Swoole's `PDOProxy` reconnects and builds a fresh underlying `PDO`, but **does not reset its own `inTransaction` counter** (and only decrements it on a *successful* `commit`/`rollback`). The proxy then reports an open transaction the real connection no longer has:

```php
public function inTransaction(): bool { return $this->inTransaction > 0; } // stale counter
```

`SQL::startTransaction()` trusts that and runs its pre-begin cleanup:

```php
if ($this->getPDO()->inTransaction()) { // true (stale)
    $this->getPDO()->rollBack();         // real PDO has no txn -> throws "There is no active transaction"
}
```

The `PDOException` is rewrapped as `Failed to start transaction: ...` and aborts an otherwise-valid start. Because the pool **reclaims** (rather than destroys) the connection on error, the desynced connection stays in rotation and every subsequent transaction on it fails the same way — explaining the sustained, "ongoing" error volume.

> Note: the utopia-native `Utopia\Database\PDO` wrapper is **not** affected — it reads the real connection's `inTransaction()` state, so it self-heals via `withTransaction`'s retry loop. This only bites when wrapped by a proxy that tracks transaction state independently (Swoole `PDOProxy`).

## Fix

Make the pre-begin cleanup rollback **best-effort**: swallow a `PDOException` from it and continue to `beginTransaction()` on the (clean, reconnected) connection. The start succeeds instead of throwing, which also breaks the poison-pill loop.

This does **not** mask genuine start failures — if the connection is truly unusable, the subsequent `beginTransaction()` still throws and is surfaced through the existing outer `catch`.

## Tests

Added `tests/unit/SQLTransactionTest.php` which mocks a PDO whose `inTransaction()` returns `true` while `rollBack()` throws `There is no active transaction` (the exact desync). It reproduces the production error **without** this change and passes **with** it.

- ✅ `tests/unit` (341 tests) green
- ✅ Pint
- ✅ PHPStan level 7

## Follow-up (out of scope)

To eliminate the residual swallowed exception per transaction-start on a desynced proxy, a pool-level improvement could call `PDOProxy::reset()` on reclaim, or `destroy()` connections that error mid-transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction startup to better handle desynchronized rollback states and continue cleanly after cleanup failures.
  * Ensures transaction start failures (e.g., when a begin operation cannot start) are surfaced with the correct error instead of being masked.

* **Tests**
  * Added unit test coverage for the failure path when cleanup succeeds but the transaction begin fails after a desynced rollback.
  * Extended existing coverage for recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->