### PR TITLE
refactor(transaction): own connection recovery in the adapter, drop Swoole PDOProxy dependency

### DIFF
--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -5,7 +5,6 @@ namespace Utopia\Database\Adapter;
 use Exception;
 use PDO;
 use PDOException;
-use Swoole\Database\PDOStatementProxy;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
@@ -18,6 +17,7 @@ use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Exception\Truncate as TruncateException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Operator;
+use Utopia\Database\PDOStatement;
 use Utopia\Database\Query;
 
 /**
@@ -2764,12 +2764,12 @@ class Postgres extends SQL
      * Bind operator parameters to statement
      * Override to handle PostgreSQL-specific JSON binding
      *
-     * @param \PDOStatement|PDOStatementProxy $stmt
+     * @param \PDOStatement|PDOStatement $stmt
      * @param Operator $operator
      * @param int &$bindIndex
      * @return void
      */
-    protected function bindOperatorParams(\PDOStatement|PDOStatementProxy $stmt, Operator $operator, int &$bindIndex): void
+    protected function bindOperatorParams(\PDOStatement|PDOStatement $stmt, Operator $operator, int &$bindIndex): void
     {
         $method = $operator->getMethod();
         $values = $operator->getValues();

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -4,7 +4,6 @@ namespace Utopia\Database\Adapter;
 
 use Exception;
 use PDOException;
-use Swoole\Database\PDOStatementProxy;
 use Utopia\Database\Adapter;
 use Utopia\Database\Change;
 use Utopia\Database\Database;
@@ -16,6 +15,7 @@ use Utopia\Database\Exception\NotFound as NotFoundException;
 use Utopia\Database\Exception\Timeout as TimeoutException;
 use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Operator;
+use Utopia\Database\PDOStatement;
 use Utopia\Database\Query;
 
 abstract class SQL extends Adapter
@@ -1978,12 +1978,12 @@ abstract class SQL extends Adapter
     /**
      * Bind operator parameters to prepared statement
      *
-     * @param \PDOStatement|PDOStatementProxy $stmt
+     * @param \PDOStatement|PDOStatement $stmt
      * @param \Utopia\Database\Operator $operator
      * @param int &$bindIndex
      * @return void
      */
-    protected function bindOperatorParams(\PDOStatement|PDOStatementProxy $stmt, Operator $operator, int &$bindIndex): void
+    protected function bindOperatorParams(\PDOStatement|PDOStatement $stmt, Operator $operator, int &$bindIndex): void
     {
         $method = $operator->getMethod();
         $values = $operator->getValues();

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -5,7 +5,6 @@ namespace Utopia\Database\Adapter;
 use Exception;
 use PDO;
 use PDOException;
-use Swoole\Database\PDOStatementProxy;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
@@ -18,6 +17,7 @@ use Utopia\Database\Exception\Transaction as TransactionException;
 use Utopia\Database\Exception\Truncate as TruncateException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Operator;
+use Utopia\Database\PDOStatement;
 use Utopia\Database\Query;
 
 /**
@@ -2002,12 +2002,12 @@ class SQLite extends MariaDB
      * Bind operator parameters to statement
      * Override to handle SQLite-specific operator bindings
      *
-     * @param \PDOStatement|PDOStatementProxy $stmt
+     * @param \PDOStatement|PDOStatement $stmt
      * @param Operator $operator
      * @param int &$bindIndex
      * @return void
      */
-    protected function bindOperatorParams(\PDOStatement|PDOStatementProxy $stmt, Operator $operator, int &$bindIndex): void
+    protected function bindOperatorParams(\PDOStatement|PDOStatement $stmt, Operator $operator, int &$bindIndex): void
     {
         $method = $operator->getMethod();
 

--- a/src/Database/PDO.php
+++ b/src/Database/PDO.php
@@ -26,12 +26,60 @@ class PDO
         protected ?string $password,
         protected array $config = []
     ) {
+        $this->config[\PDO::ATTR_ERRMODE] ??= \PDO::ERRMODE_EXCEPTION;
+
         $this->pdo = new \PDO(
             $this->dsn,
             $this->username,
             $this->password,
             $this->config
         );
+    }
+
+    /**
+     * Prepare a statement, returning a wrapper that transparently re-prepares
+     * itself on the underlying connection if that connection is lost before the
+     * statement is executed.
+     *
+     * @param array<mixed> $options
+     * @throws \Throwable
+     */
+    public function prepare(string $query, array $options = []): PDOStatement
+    {
+        return new PDOStatement($this, $this->prepareNative($query, $options), $query, $options);
+    }
+
+    /**
+     * Prepare a raw \PDOStatement on the underlying connection, reconnecting
+     * once if a stale connection surfaces during prepare. Used by
+     * {@see PDOStatement} to re-prepare after a reconnect without re-wrapping.
+     *
+     * Under emulated prepares this never reaches the server (so the loss
+     * surfaces at execution time instead and is recovered by {@see PDOStatement});
+     * with native prepares the server is contacted here, so a lost connection
+     * outside a transaction is reconnected and retried, matching __call().
+     *
+     * @param array<mixed> $options
+     * @throws \Throwable
+     */
+    public function prepareNative(string $query, array $options = []): \PDOStatement
+    {
+        try {
+            $statement = $this->pdo->prepare($query, $options);
+        } catch (\Throwable $e) {
+            if (!Connection::hasError($e) || $this->pdo->inTransaction()) {
+                throw $e;
+            }
+
+            $this->reconnect();
+            $statement = $this->pdo->prepare($query, $options);
+        }
+
+        if ($statement === false) {
+            throw new \PDOException("Failed to prepare statement: {$query}");
+        }
+
+        return $statement;
     }
 
     /**

--- a/src/Database/PDOStatement.php
+++ b/src/Database/PDOStatement.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Utopia\Database;
+
+use Utopia\Console;
+
+/**
+ * Wraps a \PDOStatement so a connection lost during execution is recovered
+ * transparently: the owning PDO reconnects, the statement is re-prepared
+ * against the fresh connection, previously bound parameters/columns/attributes
+ * are replayed, and the failed execute() is retried.
+ *
+ * Recovery is attempted only for execute(), and only outside a transaction:
+ * re-running any other method (fetch, rowCount, ...) without a fresh execute
+ * would return data from an unexecuted statement, and a connection cannot be
+ * healed in place mid-transaction (the uncommitted state is gone, so the call
+ * is rethrown for Adapter::withTransaction to roll back and replay).
+ *
+ * @mixin \PDOStatement
+ * @implements \IteratorAggregate<int, mixed>
+ */
+class PDOStatement implements \IteratorAggregate
+{
+    /**
+     * @var array<int|string, array{mixed, int}>
+     */
+    private array $values = [];
+
+    /**
+     * @var array<int|string, array{mixed, int, int, mixed}>
+     */
+    private array $params = [];
+
+    /**
+     * The order bindValue()/bindParam() were called, so a placeholder rebound
+     * across methods replays with the last binding winning, as PDO applies it.
+     *
+     * @var array<int, array{string, int|string}>
+     */
+    private array $bindOrder = [];
+
+    /**
+     * @var array<int|string, array{mixed, int, ?int, ?int, mixed}>
+     */
+    private array $columns = [];
+
+    /**
+     * @var array<int, mixed>
+     */
+    private array $attributes = [];
+
+    /**
+     * @var array<int|string, mixed>|null
+     */
+    private ?array $fetchMode = null;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function __construct(
+        private readonly PDO $pdo,
+        private \PDOStatement $statement,
+        private readonly string $query,
+        private readonly array $options = [],
+    ) {
+    }
+
+    public function __get(string $name): mixed
+    {
+        return $this->statement->{$name};
+    }
+
+    public function __set(string $name, mixed $value): void
+    {
+        $this->statement->{$name} = $value;
+    }
+
+    public function __isset(string $name): bool
+    {
+        return isset($this->statement->{$name});
+    }
+
+    public function __unset(string $name): void
+    {
+        unset($this->statement->{$name});
+    }
+
+    public function __clone(): void
+    {
+        throw new \Error('Trying to clone an uncloneable PDOStatement');
+    }
+
+    /**
+     * Preserve \PDOStatement's native iterability (foreach over rows), which
+     * does not route through __call().
+     */
+    public function getIterator(): \Traversable
+    {
+        return $this->statement;
+    }
+
+    /**
+     * @param array<mixed> $args
+     * @throws \Throwable
+     */
+    public function __call(string $method, array $args): mixed
+    {
+        try {
+            return $this->statement->{$method}(...$args);
+        } catch (\Throwable $e) {
+            if (
+                \strcasecmp($method, 'execute') !== 0
+                || $this->pdo->inTransaction()
+                || !Connection::hasError($e)
+            ) {
+                throw $e;
+            }
+
+            Console::warning('[Database] ' . $e->getMessage());
+            Console::warning('[Database] Lost connection detected. Re-preparing statement...');
+
+            $this->reprepare();
+
+            return $this->statement->{$method}(...$args);
+        }
+    }
+
+    public function getStatement(): \PDOStatement
+    {
+        return $this->statement;
+    }
+
+    public function setAttribute(int $attribute, mixed $value): bool
+    {
+        $this->attributes[$attribute] = $value;
+
+        return $this->statement->setAttribute($attribute, $value);
+    }
+
+    public function setFetchMode(int $mode, mixed ...$args): bool
+    {
+        $this->fetchMode = [$mode, ...$args];
+
+        return $this->statement->setFetchMode($mode, ...$args);
+    }
+
+    public function bindValue(int|string $param, mixed $value, int $type = \PDO::PARAM_STR): bool
+    {
+        $this->values[$param] = [$value, $type];
+        $this->bindOrder[] = ['value', $param];
+
+        return $this->statement->bindValue($param, $value, $type);
+    }
+
+    public function bindParam(int|string $param, mixed &$variable, int $type = \PDO::PARAM_STR, int $maxLength = 0, mixed $driverOptions = null): bool
+    {
+        // Store the variable by reference so a value changed between bind and
+        // execute is the value replayed after a reconnect (PDO binds late).
+        $this->params[$param] = [&$variable, $type, $maxLength, $driverOptions];
+        $this->bindOrder[] = ['param', $param];
+
+        return $this->statement->bindParam($param, $variable, $type, $maxLength, $driverOptions);
+    }
+
+    public function bindColumn(int|string $column, mixed &$variable, ?int $type = null, ?int $maxLength = null, mixed $driverOptions = null): bool
+    {
+        // Record how many optional arguments were actually supplied so omitted
+        // ones keep PDO's real defaults instead of being replayed as explicit
+        // nulls (which would change the call contract / emit deprecations).
+        $arity = \func_num_args();
+        $this->columns[$column] = [&$variable, $arity, $type, $maxLength, $driverOptions];
+
+        return $this->bindColumnTo($this->statement, $column, $variable, $arity, $type, $maxLength, $driverOptions);
+    }
+
+    private function reprepare(): void
+    {
+        $this->pdo->reconnect();
+        $this->statement = $this->pdo->prepareNative($this->query, $this->options);
+
+        foreach ($this->attributes as $attribute => $value) {
+            $this->statement->setAttribute($attribute, $value);
+        }
+
+        if ($this->fetchMode !== null) {
+            $this->statement->setFetchMode(...$this->fetchMode);
+        }
+
+        // Replay value/param bindings in the original call order so a placeholder
+        // rebound across methods ends up with the binding the caller applied last.
+        foreach ($this->bindOrder as [$kind, $key]) {
+            if ($kind === 'value') {
+                [$value, $type] = $this->values[$key];
+                $this->statement->bindValue($key, $value, $type);
+            } else {
+                $bind = $this->params[$key];
+                $this->statement->bindParam($key, $bind[0], $bind[1], $bind[2], $bind[3]);
+            }
+        }
+
+        foreach ($this->columns as $column => $bind) {
+            $this->bindColumnTo($this->statement, $column, $bind[0], $bind[1], $bind[2], $bind[3], $bind[4]);
+        }
+    }
+
+    /**
+     * Forward bindColumn passing only the optional arguments the caller
+     * supplied ($arity counts column + variable + supplied options).
+     */
+    private function bindColumnTo(\PDOStatement $statement, int|string $column, mixed &$variable, int $arity, ?int $type = null, ?int $maxLength = null, mixed $driverOptions = null): bool
+    {
+        return match (true) {
+            $arity <= 2 => $statement->bindColumn($column, $variable),
+            $arity === 3 => $statement->bindColumn($column, $variable, $type ?? \PDO::PARAM_STR),
+            $arity === 4 => $statement->bindColumn($column, $variable, $type ?? \PDO::PARAM_STR, $maxLength ?? 0),
+            default => $statement->bindColumn($column, $variable, $type ?? \PDO::PARAM_STR, $maxLength ?? 0, $driverOptions),
+        };
+    }
+}

--- a/tests/unit/PDOStatementTest.php
+++ b/tests/unit/PDOStatementTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Tests\Unit;
+
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\PDO;
+use Utopia\Database\PDOStatement;
+
+class PDOStatementTest extends TestCase
+{
+    /**
+     * @return PDO&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function pdoMock(bool $inTransaction): PDO
+    {
+        $pdo = $this->getMockBuilder(PDO::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['reconnect', 'prepareNative'])
+            ->addMethods(['inTransaction'])
+            ->getMock();
+
+        $pdo->method('inTransaction')->willReturn($inTransaction);
+
+        return $pdo;
+    }
+
+    /**
+     * @return \PDOStatement&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function statementMock(): \PDOStatement
+    {
+        return $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testExecuteReconnectsRePreparesAndReplaysWhenNotInTransaction(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+
+        $first = $this->statementMock();
+        $first->expects($this->once())
+            ->method('bindValue')
+            ->with(':id', 'abc', \PDO::PARAM_STR)
+            ->willReturn(true);
+        $first->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new PDOException('Max connect timeout reached'));
+
+        $second = $this->statementMock();
+        $second->expects($this->once())
+            ->method('bindValue')
+            ->with(':id', 'abc', \PDO::PARAM_STR)
+            ->willReturn(true);
+        $second->expects($this->once())
+            ->method('execute')
+            ->willReturn(true);
+
+        $pdo->expects($this->once())->method('reconnect');
+        $pdo->expects($this->once())
+            ->method('prepareNative')
+            ->with('SELECT :id', [])
+            ->willReturn($second);
+
+        $statement = new PDOStatement($pdo, $first, 'SELECT :id');
+        $statement->bindValue(':id', 'abc');
+
+        $this->assertTrue($statement->execute());
+    }
+
+    public function testExecuteRethrowsAndDoesNotReconnectInsideTransaction(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: true);
+        $pdo->expects($this->never())->method('reconnect');
+        $pdo->expects($this->never())->method('prepareNative');
+
+        $statement = $this->statementMock();
+        $statement->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new PDOException('Max connect timeout reached'));
+
+        $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('Max connect timeout reached');
+
+        $wrapper->execute();
+    }
+
+    public function testExecuteRethrowsNonConnectionErrors(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+        $pdo->expects($this->never())->method('reconnect');
+        $pdo->expects($this->never())->method('prepareNative');
+
+        $statement = $this->statementMock();
+        $statement->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new PDOException('SQLSTATE[42000]: Syntax error'));
+
+        $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('Syntax error');
+
+        $wrapper->execute();
+    }
+
+    public function testForwardsCallsAndPropertiesToUnderlyingStatement(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+
+        $statement = $this->statementMock();
+        $statement->expects($this->once())
+            ->method('rowCount')
+            ->willReturn(7);
+
+        $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
+
+        $this->assertSame($statement, $wrapper->getStatement());
+        $this->assertSame(7, $wrapper->rowCount());
+    }
+
+    public function testIsIterableAndDelegatesIterationToTheStatement(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+        $statement = $this->statementMock();
+
+        $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
+
+        $this->assertInstanceOf(\IteratorAggregate::class, $wrapper);
+        $this->assertSame($statement, $wrapper->getIterator());
+    }
+
+    public function testDoesNotReconnectForNonExecuteMethods(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+        $pdo->expects($this->never())->method('reconnect');
+        $pdo->expects($this->never())->method('prepareNative');
+
+        $statement = $this->statementMock();
+        $statement->expects($this->once())
+            ->method('fetch')
+            ->willThrowException(new PDOException('server has gone away'));
+
+        $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('server has gone away');
+
+        $wrapper->fetch();
+    }
+
+    public function testBindParamReplaysCurrentValueAfterReconnect(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+
+        $first = $this->statementMock();
+        $first->method('bindParam')->willReturn(true);
+        $first->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new PDOException('server has gone away'));
+
+        $replayed = null;
+        $second = $this->statementMock();
+        $second->expects($this->once())
+            ->method('bindParam')
+            ->willReturnCallback(function (int|string $param, mixed &$variable) use (&$replayed): bool {
+                $replayed = $variable;
+                return true;
+            });
+        $second->expects($this->once())->method('execute')->willReturn(true);
+
+        $pdo->expects($this->once())->method('reconnect');
+        $pdo->expects($this->once())->method('prepareNative')->willReturn($second);
+
+        $wrapper = new PDOStatement($pdo, $first, 'SELECT :id');
+
+        $value = 'old';
+        $wrapper->bindParam(':id', $value);
+        $value = 'new';
+
+        $this->assertTrue($wrapper->execute());
+        $this->assertSame('new', $replayed, 'reconnect must replay the value bound by reference at execute time');
+    }
+
+    public function testReplaysMixedBindingsInOriginalCallOrder(): void
+    {
+        $pdo = $this->pdoMock(inTransaction: false);
+
+        $first = $this->statementMock();
+        $first->method('bindValue')->willReturn(true);
+        $first->method('bindParam')->willReturn(true);
+        $first->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new PDOException('server has gone away'));
+
+        $replay = [];
+        $second = $this->statementMock();
+        $second->method('bindValue')->willReturnCallback(function (int|string $p, mixed $v) use (&$replay): bool {
+            $replay[] = "value:{$v}";
+            return true;
+        });
+        $second->method('bindParam')->willReturnCallback(function (int|string $p, mixed &$v) use (&$replay): bool {
+            $replay[] = "param:{$v}";
+            return true;
+        });
+        $second->expects($this->once())->method('execute')->willReturn(true);
+
+        $pdo->expects($this->once())->method('reconnect');
+        $pdo->expects($this->once())->method('prepareNative')->willReturn($second);
+
+        $wrapper = new PDOStatement($pdo, $first, 'SELECT :id');
+
+        // Caller rebinds the same placeholder: the later bindParam must win.
+        $wrapper->bindValue(':id', 'old');
+        $current = 'new';
+        $wrapper->bindParam(':id', $current);
+
+        $this->assertTrue($wrapper->execute());
+        $this->assertSame(['value:old', 'param:new'], $replay, 'replay must preserve original bind order so the last binding wins');
+    }
+}

--- a/tests/unit/PDOTest.php
+++ b/tests/unit/PDOTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Utopia\Database\PDO;
+use Utopia\Database\PDOStatement;
 
 class PDOTest extends TestCase
 {
@@ -148,6 +149,40 @@ class PDOTest extends TestCase
 
         $result = $pdoWrapper->prepare('SELECT * FROM table', [\PDO::ATTR_CURSOR => \PDO::CURSOR_FWDONLY]);
 
-        $this->assertSame($pdoStatementMock, $result);
+        $this->assertInstanceOf(PDOStatement::class, $result);
+        $this->assertSame($pdoStatementMock, $result->getStatement());
+    }
+
+    public function testPrepareNativeReconnectsOutsideTransaction(): void
+    {
+        $pdoWrapper = $this->getMockBuilder(PDO::class)
+            ->setConstructorArgs(['sqlite::memory:', null, null, []])
+            ->onlyMethods(['reconnect'])
+            ->getMock();
+
+        $pdoMock = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statementMock = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $pdoMock->method('inTransaction')->willReturn(false);
+        $pdoMock->expects($this->exactly(2))
+            ->method('prepare')
+            ->with('SELECT 1')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \PDOException('server has gone away')),
+                $statementMock
+            );
+
+        $reflection = new ReflectionClass($pdoWrapper);
+        $pdoProperty = $reflection->getProperty('pdo');
+        $pdoProperty->setAccessible(true);
+        $pdoProperty->setValue($pdoWrapper, $pdoMock);
+
+        $pdoWrapper->expects($this->once())->method('reconnect');
+
+        $this->assertSame($statementMock, $pdoWrapper->prepareNative('SELECT 1'));
     }
 }


### PR DESCRIPTION
> Stacked on #895. Diff against `fix/start-transaction-desynced-rollback`.

## Problem

#895 stops the *symptom* of the nyc3 write outage, but the root cause is upstream of this library: consumers wrap connections in `Swoole\Database\PDOProxy`, which keeps **its own** `inTransaction` counter that is incremented on `beginTransaction`, decremented only on a *successful* commit/rollback, not reset by `reconnect()`, and not reset on pool checkin (`utopia-php/pools` never calls the proxy's `reset()` — that hook only fires under Swoole's own `PDOPool`).

A connection lost mid-transaction leaks the counter and **poisons the pooled connection**: every later `startTransaction` cleanup probe trusts the stale `getPDO()->inTransaction()`, issues a `rollBack` the real connection no longer holds, and fails with `There is no active transaction` — across all projects, until pods restart. (nyc3: ~110k errors over ~1.5h, writes only.)

This can't be fixed by patching the cleanup probe while a second, unreconciled source of truth for "am I in a transaction" lives in the proxy. The fix removes the *need* for the proxy and makes the adapter own connection-loss recovery, with the real `\PDO` as the single source of truth.

## What changed

- **`PDOStatement`** (new) — wraps prepared statements. On a lost connection at execution time, when **not** in a transaction, it reconnects the owning `PDO`, re-prepares against the fresh connection, replays bound params/attributes/options, and retries. This restores the only genuinely load-bearing behaviour the Swoole `PDOStatementProxy` provided — reconnect-on-execute — and it's what heals a stale pooled connection at the `prepare('ROLLBACK')->execute()` probe that fronts `startTransaction` (that probe runs at `inTransaction === 0`). Inside a transaction it rethrows; the connection state is read from the real `\PDO`, so there is no separate counter to desync.
- **`PDO::prepare()`** returns the wrapper; **`prepareNative()`** re-prepares a raw `\PDOStatement` for the wrapper. `ERRMODE_EXCEPTION` is defaulted in the constructor so the library no longer depends on the proxy/consumer to set it.
- Replaced the `Swoole\Database\PDOStatementProxy` type hints in `SQL`/`Postgres`/`SQLite` with the new `PDOStatement`.

Connection-level calls (`beginTransaction`/`rollBack`/`commit`/`exec`) are already covered by the pre-existing `Utopia\Database\PDO::__call` reconnect, and `Adapter::withTransaction`'s pre-existing retry loop replays the closure — so the mid-transaction-death path recovers by replay on the connection that `__call` reconnects. No change to `withTransaction` is needed.

## Reviewed

Two independent reviews of this PR led to: **removing a speculative `withTransaction` reconnect block** that an earlier revision added — it was unreachable on the real SQL path (a dead-connection `rollBack` throws and is caught earlier in the loop) and, when reached (e.g. a *nested* transaction), would have discarded the outer `BEGIN` and committed the inner write standalone (silent partial commit). Recovery is correctly carried by `PDOStatement` re-prepare + `PDO::__call`, both unit-covered. Also threaded `prepare()` `$options` through re-prepare and tightened a `@throws`.

**Known limitation (pre-existing, out of scope):** connection loss *inside a nested* transaction is not safely recoverable by the retry loop in any version; this PR does not make it worse (it no longer adds a reconnect there).

## Tests

`PDOStatementTest` (reconnect/re-prepare/replay outside a txn; rethrow inside; non-connection rethrow; forwarding), `PDOTest` (`PDO::__call` reconnect, wrapper return), `SQLTransactionTest` (desynced-cleanup recovery, MySQL + Postgres). `phpunit` (full unit suite), `phpstan --level 7`, `pint` green locally.

**Recommended follow-up:** an e2e test that severs a live MySQL/Postgres connection mid-transaction (`KILL` / `wait_timeout`) and asserts recovery — the recovery path is currently only unit-mocked.

## Consumer follow-ups

- cloud [appwrite-labs/cloud#4399](https://github.com/appwrite-labs/cloud/pull/4399), server-ce [appwrite/appwrite#12616](https://github.com/appwrite/appwrite/pull/12616) — stop wrapping in `PDOProxy`, construct `Utopia\Database\PDO` directly. Re-pin from the branch alias to the release tag once this merges + tags.
- [utopia-php/pools#33](https://github.com/utopia-php/pools/pull/33) backstop (recover/destroy faulted pooled connections).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database connection resilience with automatic reconnection and statement re-preparation when connections are lost during execution
  * Improved error handling with exceptions enabled by default for database operations

* **Internal Improvements**
  * Updated database adapters for improved compatibility and stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->