### PR TITLE
refactor(transaction): inherit postgres startTransaction

### DIFF
--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -31,44 +31,6 @@ use Utopia\Database\Query;
 class Postgres extends SQL
 {
     public const MAX_IDENTIFIER_NAME = 63;
-    /**
-     * @inheritDoc
-     */
-    public function startTransaction(): bool
-    {
-        try {
-            if ($this->inTransaction === 0) {
-                try {
-                    if ($this->getPDO()->inTransaction()) {
-                        $this->getPDO()->rollBack();
-                    } else {
-                        // If no active transaction, this has no effect.
-                        $this->getPDO()->prepare('ROLLBACK')->execute();
-                    }
-                } catch (PDOException) {
-                    // A pooled connection can report a transaction it no longer
-                    // holds after a reconnect (e.g. Swoole PDOProxy keeps its own
-                    // counter), making this cleanup rollback throw. It is best
-                    // effort; swallow it and begin a fresh transaction below.
-                }
-
-                $result = $this->getPDO()->beginTransaction();
-            } else {
-                $this->getPDO()->exec('SAVEPOINT transaction' . $this->inTransaction);
-                $result = true;
-            }
-        } catch (PDOException $e) {
-            throw new TransactionException('Failed to start transaction: ' . $e->getMessage(), $e->getCode(), $e);
-        }
-
-        if (!$result) {
-            throw new TransactionException('Failed to start transaction');
-        }
-
-        $this->inTransaction++;
-
-        return $result;
-    }
 
     /**
      * @inheritDoc

--- a/tests/unit/SQLTransactionTest.php
+++ b/tests/unit/SQLTransactionTest.php
@@ -4,11 +4,13 @@ namespace Tests\Unit;
 
 use PDOException;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use Utopia\Database\Adapter\MySQL;
 use Utopia\Database\Adapter\Postgres;
+use Utopia\Database\Adapter\SQL;
 use Utopia\Database\Exception\Transaction as TransactionException;
 
-class SQLTransactionTest extends TestCase
+final class SQLTransactionTest extends TestCase
 {
     /**
      * A pooled connection (e.g. Swoole PDOProxy) can keep its own transaction
@@ -61,6 +63,9 @@ class SQLTransactionTest extends TestCase
 
     public function testPostgresStartTransactionRecoversFromDesyncedRollback(): void
     {
+        $method = new ReflectionMethod(Postgres::class, 'startTransaction');
+        $this->assertSame(SQL::class, $method->getDeclaringClass()->getName());
+
         $pdo = $this->getMockBuilder(\PDO::class)
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
## Summary
- remove the redundant Postgres `startTransaction()` override
- let Postgres inherit the shared `SQL::startTransaction()` behavior
- assert Postgres now uses the shared SQL transaction path while retaining the desynced rollback regression coverage

## Tests
- `./vendor/bin/phpunit tests/unit/SQLTransactionTest.php`
- `php -d memory_limit=2G ./vendor/bin/pint --test`
- `composer check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified transaction handling implementation for Postgres database connections.

* **Tests**
  * Updated transaction handling tests to validate correct behavior across database adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->