### PR TITLE
feat(replication): Swoole-native MySQL binlog reader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,9 @@
     "suggests": {
         "ext-redis": "Needed to support Redis Cache Adapter",
         "ext-pdo": "Needed to support MariaDB, MySQL or SQLite Database Adapter",
-        "mongodb/mongodb": "Needed to support MongoDB Database Adapter"
+        "mongodb/mongodb": "Needed to support MongoDB Database Adapter",
+        "ext-openssl": "Needed for caching_sha2_password full authentication when using the Replication reader",
+        "ext-swoole": "Needed by the Replication reader for coroutine socket I/O"
 
     },
     "config": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,7 @@
         </testsuite>
         <testsuite name="e2e">
             <directory>./tests/e2e/Adapter</directory>
+            <directory>./tests/e2e/Replication</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Database/Replication/BinaryReader.php
+++ b/src/Database/Replication/BinaryReader.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+/**
+ * Forward-only cursor over a binary string.
+ *
+ * All integer reads are little-endian, matching the MySQL wire protocol. The
+ * class is pure (no I/O), so it can be unit-tested against fixed byte fixtures.
+ */
+class BinaryReader
+{
+    private string $buffer;
+    private int $position = 0;
+    private int $length;
+
+    public function __construct(string $buffer)
+    {
+        $this->buffer = $buffer;
+        $this->length = \strlen($buffer);
+    }
+
+    public function eof(): bool
+    {
+        return $this->position >= $this->length;
+    }
+
+    public function remaining(): int
+    {
+        return $this->length - $this->position;
+    }
+
+    public function position(): int
+    {
+        return $this->position;
+    }
+
+    public function skip(int $bytes): void
+    {
+        $this->position += $bytes;
+    }
+
+    public function read(int $bytes): string
+    {
+        if ($bytes <= 0) {
+            return '';
+        }
+
+        $value = \substr($this->buffer, $this->position, $bytes);
+        $this->position += $bytes;
+
+        return $value;
+    }
+
+    /**
+     * Read a fixed-length little-endian unsigned integer (1-8 bytes).
+     */
+    public function readUInt(int $bytes): int
+    {
+        $value = 0;
+        $chunk = $this->read($bytes);
+        for ($i = 0; $i < $bytes; $i++) {
+            $value |= \ord($chunk[$i]) << ($i * 8);
+        }
+
+        return $value;
+    }
+
+    public function readUInt8(): int
+    {
+        return \ord($this->read(1));
+    }
+
+    public function readUInt16(): int
+    {
+        return $this->readUInt(2);
+    }
+
+    public function readUInt32(): int
+    {
+        return $this->readUInt(4);
+    }
+
+    public function readUInt64(): int
+    {
+        return $this->readUInt(8);
+    }
+
+    /**
+     * Read a length-encoded integer.
+     *
+     * @see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_dt_integers.html
+     */
+    public function readLengthEncodedInt(): ?int
+    {
+        $first = $this->readUInt8();
+
+        return match (true) {
+            $first < 0xFB => $first,
+            $first === 0xFB => null,        // NULL column
+            $first === 0xFC => $this->readUInt(2),
+            $first === 0xFD => $this->readUInt(3),
+            default => $this->readUInt(8),  // 0xFE
+        };
+    }
+
+    /**
+     * Read a length-encoded string.
+     */
+    public function readLengthEncodedString(): ?string
+    {
+        $length = $this->readLengthEncodedInt();
+        if ($length === null) {
+            return null;
+        }
+
+        return $this->read($length);
+    }
+
+    /**
+     * Read a NUL-terminated string.
+     */
+    public function readNullTerminatedString(): string
+    {
+        $end = \strpos($this->buffer, "\0", $this->position);
+        if ($end === false) {
+            $end = $this->length;
+        }
+
+        $value = \substr($this->buffer, $this->position, $end - $this->position);
+        $this->position = $end + 1;
+
+        return $value;
+    }
+}

--- a/src/Database/Replication/Change.php
+++ b/src/Database/Replication/Change.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+/**
+ * A single row-change decoded from the binlog.
+ *
+ * For UPDATE events, {@see $rows} holds the after-image of each updated row.
+ */
+final class Change
+{
+    public const string INSERT = 'insert';
+    public const string UPDATE = 'update';
+    public const string DELETE = 'delete';
+
+    /**
+     * @param string $action One of INSERT|UPDATE|DELETE.
+     * @param string $database Source schema name.
+     * @param string $table Physical table name (e.g. "console15x_projects").
+     * @param array<int, array<string, mixed>> $rows Affected rows as column => value maps.
+     * @param string $gtid Executed-GTID-set after this event — a resumable checkpoint token.
+     */
+    public function __construct(
+        public readonly string $action,
+        public readonly string $database,
+        public readonly string $table,
+        public readonly array $rows,
+        public readonly string $gtid,
+    ) {
+    }
+}

--- a/src/Database/Replication/Connection.php
+++ b/src/Database/Replication/Connection.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+use Swoole\Coroutine\Socket;
+use Utopia\Database\Exception as DatabaseException;
+
+/**
+ * A coroutine MySQL connection speaking just enough of the client protocol to
+ * authenticate (MySQL 8 caching_sha2_password, with mysql_native_password
+ * fallback), run a handful of setup queries and request a binlog dump.
+ *
+ * Swoole-native: all socket I/O happens on a {@see Socket}, so it yields the
+ * current coroutine instead of blocking the worker.
+ */
+class Connection
+{
+    private const int MAX_PACKET_SIZE = 0x40000000;
+    private const int CHARSET_UTF8MB4 = 45;
+    private const int PROTOCOL_TCP = 6; // IPPROTO_TCP
+
+    private Socket $socket;
+    private int $sequence = 0;
+
+    public function __construct(
+        private readonly string $host,
+        private readonly int $port,
+        private readonly string $username,
+        private readonly string $password,
+        private readonly float $timeout = 30.0,
+    ) {
+    }
+
+    public function connect(): void
+    {
+        $this->socket = new Socket(AF_INET, SOCK_STREAM, self::PROTOCOL_TCP);
+
+        if (!$this->socket->connect($this->host, $this->port, $this->timeout)) {
+            throw new DatabaseException("Failed to connect to {$this->host}:{$this->port}: {$this->socket->errMsg}");
+        }
+
+        $this->authenticate();
+    }
+
+    public function close(): void
+    {
+        if (isset($this->socket)) {
+            $this->socket->close();
+        }
+    }
+
+    /**
+     * Read one logical protocol packet, transparently reassembling payloads
+     * split across multiple 16MB frames.
+     */
+    public function readPacket(): string
+    {
+        $payload = '';
+
+        do {
+            $header = $this->socket->recvAll(4, $this->timeout);
+            if ($header === false || \strlen($header) < 4) {
+                throw new DatabaseException("Connection closed while reading packet header: {$this->socket->errMsg}");
+            }
+
+            $length = \ord($header[0]) | (\ord($header[1]) << 8) | (\ord($header[2]) << 16);
+            $this->sequence = \ord($header[3]);
+
+            if ($length > 0) {
+                $chunk = $this->socket->recvAll($length, $this->timeout);
+                if ($chunk === false || \strlen($chunk) < $length) {
+                    throw new DatabaseException("Connection closed while reading packet body: {$this->socket->errMsg}");
+                }
+                $payload .= $chunk;
+            }
+        } while ($length === 0xFFFFFF);
+
+        return $payload;
+    }
+
+    /**
+     * Write a packet using the next sequence id, splitting oversized payloads.
+     */
+    public function writePacket(string $payload): void
+    {
+        $this->sequence++;
+        $this->sendFrames($payload);
+    }
+
+    /**
+     * Begin a new command, resetting the sequence id to 0.
+     */
+    public function writeCommand(string $payload): void
+    {
+        $this->sequence = -1;
+        $this->writePacket($payload);
+    }
+
+    private function sendFrames(string $payload): void
+    {
+        $length = \strlen($payload);
+        $offset = 0;
+
+        do {
+            $size = \min($length - $offset, 0xFFFFFF);
+            $header = \chr($size & 0xFF) . \chr(($size >> 8) & 0xFF) . \chr(($size >> 16) & 0xFF) . \chr($this->sequence & 0xFF);
+            if ($this->socket->sendAll($header . \substr($payload, $offset, $size)) === false) {
+                throw new DatabaseException("Failed to write packet: {$this->socket->errMsg}");
+            }
+            $offset += $size;
+            $this->sequence++;
+        } while ($size === 0xFFFFFF);
+    }
+
+    /**
+     * Run a simple statement and discard its result. Intended for SET commands.
+     */
+    public function execute(string $sql): void
+    {
+        $this->writeCommand(\chr(Constants::COM_QUERY) . $sql);
+        $this->assertOk($this->readPacket());
+    }
+
+    /**
+     * Run a query expected to return a single scalar (one row, one column).
+     */
+    public function queryScalar(string $sql): ?string
+    {
+        $this->writeCommand(\chr(Constants::COM_QUERY) . $sql);
+
+        $first = $this->readPacket();
+        $marker = \ord($first[0]);
+        if ($marker === Constants::PACKET_ERR) {
+            $this->throwError($first);
+        }
+
+        $reader = new BinaryReader($first);
+        $columns = $reader->readLengthEncodedInt() ?? 0;
+
+        for ($i = 0; $i < $columns; $i++) {
+            $this->readPacket(); // column definition
+        }
+
+        $value = null;
+        while (true) {
+            $packet = $this->readPacket();
+            $type = \ord($packet[0]);
+            if ($type === Constants::PACKET_EOF && \strlen($packet) < 9) {
+                break; // EOF / end of rows
+            }
+            if ($type === Constants::PACKET_ERR) {
+                $this->throwError($packet);
+            }
+
+            $value ??= (new BinaryReader($packet))->readLengthEncodedString();
+        }
+
+        return $value;
+    }
+
+    /**
+     * Read a packet and assert it is an OK packet (used after a command).
+     */
+    public function readOk(): void
+    {
+        $this->assertOk($this->readPacket());
+    }
+
+    /**
+     * Throw if the given stream packet is an ERR packet.
+     */
+    public function throwIfError(string $packet): void
+    {
+        if (\ord($packet[0]) === Constants::PACKET_ERR) {
+            $this->throwError($packet);
+        }
+    }
+
+    private function authenticate(): void
+    {
+        $handshake = new BinaryReader($this->readPacket());
+
+        $handshake->skip(1); // protocol version (10)
+        $handshake->readNullTerminatedString(); // server version
+        $handshake->skip(4); // connection id
+        $authData = $handshake->read(8);
+        $handshake->skip(1); // filler
+        $capabilities = $handshake->readUInt16();
+        $handshake->skip(1); // charset
+        $handshake->skip(2); // status flags
+        $capabilities |= $handshake->readUInt16() << 16;
+        $authDataLen = $handshake->readUInt8();
+        $handshake->skip(10); // reserved
+
+        if ($capabilities & Constants::CLIENT_SECURE_CONNECTION) {
+            $authData .= $handshake->read(\max(13, $authDataLen - 8));
+        }
+
+        $plugin = ($capabilities & Constants::CLIENT_PLUGIN_AUTH)
+            ? $handshake->readNullTerminatedString()
+            : 'mysql_native_password';
+
+        $nonce = \substr($authData, 0, 20);
+
+        $this->sendHandshakeResponse($nonce, $plugin);
+        $this->finishAuth($nonce, $plugin);
+    }
+
+    private function sendHandshakeResponse(string $nonce, string $plugin): void
+    {
+        $capabilities = Constants::CLIENT_LONG_PASSWORD
+            | Constants::CLIENT_LONG_FLAG
+            | Constants::CLIENT_PROTOCOL_41
+            | Constants::CLIENT_SECURE_CONNECTION
+            | Constants::CLIENT_PLUGIN_AUTH
+            | Constants::CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA;
+
+        $authResponse = $this->scramble($plugin, $nonce);
+
+        $payload = \pack('V', $capabilities)
+            . \pack('V', self::MAX_PACKET_SIZE)
+            . \chr(self::CHARSET_UTF8MB4)
+            . \str_repeat("\0", 23)
+            . $this->username . "\0"
+            . $this->lengthEncodedInt(\strlen($authResponse)) . $authResponse
+            . $plugin . "\0";
+
+        $this->writePacket($payload);
+    }
+
+    private function finishAuth(string $nonce, string $plugin): void
+    {
+        while (true) {
+            $packet = $this->readPacket();
+            $marker = \ord($packet[0]);
+
+            switch ($marker) {
+                case Constants::PACKET_OK:
+                    return;
+                case Constants::PACKET_ERR:
+                    $this->throwError($packet);
+                    // no break — throwError always throws
+                case Constants::PACKET_EOF:
+                    // Auth switch request: re-scramble for the requested plugin.
+                    $reader = new BinaryReader(\substr($packet, 1));
+                    $plugin = $reader->readNullTerminatedString();
+                    $nonce = \substr($reader->read($reader->remaining()), 0, 20);
+                    $this->writePacket($this->scramble($plugin, $nonce));
+                    break;
+                case Constants::PACKET_AUTH_MORE_DATA:
+                    $status = \ord($packet[1]);
+                    if ($status === Constants::AUTH_FAST_SUCCESS) {
+                        break; // OK packet follows
+                    }
+                    if ($status === Constants::AUTH_FULL_REQUIRED) {
+                        $this->fullAuth($nonce);
+                        break;
+                    }
+                    throw new DatabaseException('Unexpected auth status: ' . $status);
+                default:
+                    throw new DatabaseException('Unexpected auth packet marker: ' . $marker);
+            }
+        }
+    }
+
+    /**
+     * caching_sha2_password full authentication over a plaintext channel:
+     * fetch the server's RSA public key and send the password XOR-masked with
+     * the nonce, encrypted with RSA-OAEP.
+     */
+    private function fullAuth(string $nonce): void
+    {
+        $this->writePacket(\chr(Constants::AUTH_REQUEST_PUBLIC_KEY));
+
+        $packet = $this->readPacket();
+        if (\ord($packet[0]) !== Constants::PACKET_AUTH_MORE_DATA) {
+            throw new DatabaseException('Expected public key in auth exchange');
+        }
+        $publicKey = \substr($packet, 1);
+
+        $plain = $this->password . "\0";
+        $masked = '';
+        $nonceLen = \strlen($nonce);
+        for ($i = 0, $len = \strlen($plain); $i < $len; $i++) {
+            $masked .= $plain[$i] ^ $nonce[$i % $nonceLen];
+        }
+
+        if (!\openssl_public_encrypt($masked, $encrypted, $publicKey, OPENSSL_PKCS1_OAEP_PADDING)) {
+            throw new DatabaseException('Failed to RSA-encrypt credentials: ' . \openssl_error_string());
+        }
+
+        $this->writePacket($encrypted);
+    }
+
+    private function scramble(string $plugin, string $nonce): string
+    {
+        if ($this->password === '') {
+            return '';
+        }
+
+        return match ($plugin) {
+            'mysql_native_password' => $this->scrambleNative($nonce),
+            default => $this->scrambleCachingSha2($nonce),
+        };
+    }
+
+    private function scrambleCachingSha2(string $nonce): string
+    {
+        $m1 = \hash('sha256', $this->password, true);
+        $m2 = \hash('sha256', $m1, true);
+        $m3 = \hash('sha256', $m2 . $nonce, true);
+
+        return $m1 ^ $m3;
+    }
+
+    private function scrambleNative(string $nonce): string
+    {
+        $stage1 = \sha1($this->password, true);
+        $stage2 = \sha1($stage1, true);
+        $token = \sha1($nonce . $stage2, true);
+
+        return $stage1 ^ $token;
+    }
+
+    private function lengthEncodedInt(int $value): string
+    {
+        return match (true) {
+            $value < 0xFB => \chr($value),
+            $value < 0x10000 => \chr(0xFC) . \pack('v', $value),
+            $value < 0x1000000 => \chr(0xFD) . \substr(\pack('V', $value), 0, 3),
+            default => \chr(0xFE) . \pack('P', $value),
+        };
+    }
+
+    private function assertOk(string $packet): void
+    {
+        $marker = \ord($packet[0]);
+        if ($marker === Constants::PACKET_ERR) {
+            $this->throwError($packet);
+        }
+    }
+
+    private function throwError(string $packet): never
+    {
+        $reader = new BinaryReader(\substr($packet, 1));
+        $code = $reader->readUInt16();
+        $message = $reader->read($reader->remaining());
+        // Skip the SQL-state marker ('#XXXXX') when present.
+        if (\str_starts_with($message, '#')) {
+            $message = \substr($message, 6);
+        }
+
+        throw new DatabaseException("MySQL error {$code}: {$message}");
+    }
+}

--- a/src/Database/Replication/Connection.php
+++ b/src/Database/Replication/Connection.php
@@ -140,6 +140,7 @@ class Connection
         for ($i = 0; $i < $columns; $i++) {
             $this->readPacket(); // column definition
         }
+        $this->readPacket(); // EOF after column definitions
 
         $value = null;
         while (true) {

--- a/src/Database/Replication/Connection.php
+++ b/src/Database/Replication/Connection.php
@@ -27,6 +27,7 @@ class Connection
         private readonly int $port,
         private readonly string $username,
         private readonly string $password,
+        private readonly bool $ssl = false,
         private readonly float $timeout = 30.0,
     ) {
     }
@@ -108,7 +109,11 @@ class Connection
                 throw new DatabaseException("Failed to write packet: {$this->socket->errMsg}");
             }
             $offset += $size;
-            $this->sequence++;
+            // Only advance the sequence between continuation frames; the caller
+            // owns the increment for the next logical packet.
+            if ($size === 0xFFFFFF) {
+                $this->sequence++;
+            }
         } while ($size === 0xFFFFFF);
     }
 
@@ -203,18 +208,53 @@ class Connection
 
         $nonce = \substr($authData, 0, 20);
 
+        if ($this->ssl) {
+            $this->upgradeToTls($capabilities);
+        }
+
         $this->sendHandshakeResponse($nonce, $plugin);
         $this->finishAuth($nonce, $plugin);
     }
 
-    private function sendHandshakeResponse(string $nonce, string $plugin): void
+    /**
+     * Send the abbreviated SSL request packet and upgrade the socket to TLS,
+     * before the credentials are sent. The full handshake response then travels
+     * over the encrypted channel.
+     */
+    private function upgradeToTls(int $serverCapabilities): void
     {
-        $capabilities = Constants::CLIENT_LONG_PASSWORD
+        if (!($serverCapabilities & Constants::CLIENT_SSL)) {
+            throw new DatabaseException('TLS requested but the server does not support it');
+        }
+
+        $payload = \pack('V', $this->clientCapabilities() | Constants::CLIENT_SSL)
+            . \pack('V', self::MAX_PACKET_SIZE)
+            . \chr(self::CHARSET_UTF8MB4)
+            . \str_repeat("\0", 23);
+        $this->writePacket($payload);
+
+        $this->socket->setProtocol(['open_ssl' => true, 'ssl_verify_peer' => false]);
+        if (!$this->socket->sslHandshake()) {
+            throw new DatabaseException("TLS handshake failed: {$this->socket->errMsg}");
+        }
+    }
+
+    private function clientCapabilities(): int
+    {
+        return Constants::CLIENT_LONG_PASSWORD
             | Constants::CLIENT_LONG_FLAG
             | Constants::CLIENT_PROTOCOL_41
             | Constants::CLIENT_SECURE_CONNECTION
             | Constants::CLIENT_PLUGIN_AUTH
             | Constants::CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA;
+    }
+
+    private function sendHandshakeResponse(string $nonce, string $plugin): void
+    {
+        $capabilities = $this->clientCapabilities();
+        if ($this->ssl) {
+            $capabilities |= Constants::CLIENT_SSL;
+        }
 
         $authResponse = $this->scramble($plugin, $nonce);
 

--- a/src/Database/Replication/Constants.php
+++ b/src/Database/Replication/Constants.php
@@ -16,6 +16,7 @@ final class Constants
     public const int CLIENT_LONG_PASSWORD = 0x00000001;
     public const int CLIENT_LONG_FLAG = 0x00000004;
     public const int CLIENT_CONNECT_WITH_DB = 0x00000008;
+    public const int CLIENT_SSL = 0x00000800;
     public const int CLIENT_PROTOCOL_41 = 0x00000200;
     public const int CLIENT_SECURE_CONNECTION = 0x00008000;
     public const int CLIENT_PLUGIN_AUTH = 0x00080000;

--- a/src/Database/Replication/Constants.php
+++ b/src/Database/Replication/Constants.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+/**
+ * MySQL client/replication protocol constants.
+ *
+ * Only the subset required to authenticate, request a GTID binlog dump and
+ * decode ROW-format events is defined here.
+ *
+ * @see https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basics.html
+ */
+final class Constants
+{
+    // Client capability flags.
+    public const int CLIENT_LONG_PASSWORD = 0x00000001;
+    public const int CLIENT_LONG_FLAG = 0x00000004;
+    public const int CLIENT_CONNECT_WITH_DB = 0x00000008;
+    public const int CLIENT_PROTOCOL_41 = 0x00000200;
+    public const int CLIENT_SECURE_CONNECTION = 0x00008000;
+    public const int CLIENT_PLUGIN_AUTH = 0x00080000;
+    public const int CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 0x00200000;
+
+    // Generic packet markers.
+    public const int PACKET_OK = 0x00;
+    public const int PACKET_EOF = 0xFE;
+    public const int PACKET_ERR = 0xFF;
+    public const int PACKET_AUTH_MORE_DATA = 0x01;
+
+    // caching_sha2_password fast/full auth markers (inside AuthMoreData).
+    public const int AUTH_FAST_SUCCESS = 0x03;
+    public const int AUTH_FULL_REQUIRED = 0x04;
+    public const int AUTH_REQUEST_PUBLIC_KEY = 0x02;
+
+    // Commands.
+    public const int COM_QUERY = 0x03;
+    public const int COM_REGISTER_SLAVE = 0x15;
+    public const int COM_BINLOG_DUMP_GTID = 0x1E;
+
+    // Binlog event types.
+    public const int QUERY_EVENT = 0x02;
+    public const int ROTATE_EVENT = 0x04;
+    public const int XID_EVENT = 0x10;
+    public const int FORMAT_DESCRIPTION_EVENT = 0x0F;
+    public const int TABLE_MAP_EVENT = 0x13;
+    public const int WRITE_ROWS_EVENT_V1 = 0x17;
+    public const int UPDATE_ROWS_EVENT_V1 = 0x18;
+    public const int DELETE_ROWS_EVENT_V1 = 0x19;
+    public const int HEARTBEAT_EVENT = 0x1B;
+    public const int WRITE_ROWS_EVENT_V2 = 0x1E;
+    public const int UPDATE_ROWS_EVENT_V2 = 0x1F;
+    public const int DELETE_ROWS_EVENT_V2 = 0x20;
+    public const int GTID_EVENT = 0x21;
+    public const int PREVIOUS_GTIDS_EVENT = 0x23;
+
+    public const int EVENT_HEADER_SIZE = 19;
+
+    // Column types (MYSQL_TYPE_*).
+    public const int TYPE_DECIMAL = 0;
+    public const int TYPE_TINY = 1;
+    public const int TYPE_SHORT = 2;
+    public const int TYPE_LONG = 3;
+    public const int TYPE_FLOAT = 4;
+    public const int TYPE_DOUBLE = 5;
+    public const int TYPE_NULL = 6;
+    public const int TYPE_TIMESTAMP = 7;
+    public const int TYPE_LONGLONG = 8;
+    public const int TYPE_INT24 = 9;
+    public const int TYPE_DATE = 10;
+    public const int TYPE_TIME = 11;
+    public const int TYPE_DATETIME = 12;
+    public const int TYPE_YEAR = 13;
+    public const int TYPE_VARCHAR = 15;
+    public const int TYPE_BIT = 16;
+    public const int TYPE_TIMESTAMP2 = 17;
+    public const int TYPE_DATETIME2 = 18;
+    public const int TYPE_TIME2 = 19;
+    public const int TYPE_JSON = 245;
+    public const int TYPE_NEWDECIMAL = 246;
+    public const int TYPE_ENUM = 247;
+    public const int TYPE_SET = 248;
+    public const int TYPE_TINY_BLOB = 249;
+    public const int TYPE_MEDIUM_BLOB = 250;
+    public const int TYPE_LONG_BLOB = 251;
+    public const int TYPE_BLOB = 252;
+    public const int TYPE_VAR_STRING = 253;
+    public const int TYPE_STRING = 254;
+    public const int TYPE_GEOMETRY = 255;
+
+    // TABLE_MAP optional metadata field types (require binlog_row_metadata=FULL).
+    public const int METADATA_COLUMN_NAME = 4;
+}

--- a/src/Database/Replication/EventParser.php
+++ b/src/Database/Replication/EventParser.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+/**
+ * Decodes the binlog events we care about: TABLE_MAP (to learn a table's
+ * column layout and names) and WRITE/UPDATE/DELETE_ROWS (the actual changes).
+ *
+ * Requires the source to run with `binlog_row_metadata=FULL` so column names
+ * arrive in the TABLE_MAP optional metadata — this avoids any INFORMATION_SCHEMA
+ * round-trips.
+ *
+ * Pure (operates on byte buffers), so it is unit-testable with fixtures.
+ */
+class EventParser
+{
+    /**
+     * table_id => decoded table definition.
+     *
+     * @var array<int, array{schema: string, table: string, count: int, types: list<int>, metadata: list<int>, names: list<string>}>
+     */
+    private array $tables = [];
+
+    private const array DIGITS_TO_BYTES = [0, 1, 1, 2, 2, 3, 3, 4, 4, 4];
+
+    /**
+     * Cache a table definition from a TABLE_MAP event body.
+     */
+    public function parseTableMap(string $body): void
+    {
+        $reader = new BinaryReader($body);
+
+        $tableId = $reader->readUInt(6);
+        $reader->skip(2); // flags
+
+        $schema = $reader->read($reader->readUInt8());
+        $reader->skip(1); // NUL
+        $table = $reader->read($reader->readUInt8());
+        $reader->skip(1); // NUL
+
+        $count = $reader->readLengthEncodedInt() ?? 0;
+        $types = \array_values(\unpack('C*', $reader->read($count)) ?: []);
+
+        $metadataBlock = $reader->readLengthEncodedString() ?? '';
+        $metadata = $this->parseMetadata($types, $metadataBlock);
+
+        $reader->skip((int) \ceil($count / 8)); // null bitmap
+
+        $names = $this->parseColumnNames($reader, $count);
+
+        $this->tables[$tableId] = \compact('schema', 'table', 'count', 'types', 'metadata', 'names');
+    }
+
+    /**
+     * Decode a ROWS event body into row maps.
+     *
+     * @return array{schema: string, table: string, rows: list<array<string, mixed>>}|null
+     */
+    public function parseRows(int $eventType, string $body): ?array
+    {
+        $reader = new BinaryReader($body);
+
+        $tableId = $reader->readUInt(6);
+        $reader->skip(2); // flags
+
+        $table = $this->tables[$tableId] ?? null;
+        if ($table === null) {
+            return null; // TABLE_MAP not seen (e.g. mid-stream start) — skip
+        }
+
+        $isV2 = \in_array($eventType, [
+            Constants::WRITE_ROWS_EVENT_V2,
+            Constants::UPDATE_ROWS_EVENT_V2,
+            Constants::DELETE_ROWS_EVENT_V2,
+        ], true);
+        if ($isV2) {
+            $extraLength = $reader->readUInt16();
+            $reader->skip($extraLength - 2);
+        }
+
+        $columnCount = $reader->readLengthEncodedInt() ?? 0;
+        $bitmapSize = (int) \ceil($columnCount / 8);
+
+        $present = $reader->read($bitmapSize);
+        $isUpdate = \in_array($eventType, [Constants::UPDATE_ROWS_EVENT_V1, Constants::UPDATE_ROWS_EVENT_V2], true);
+        $presentAfter = $isUpdate ? $reader->read($bitmapSize) : $present;
+
+        $rows = [];
+        while (!$reader->eof()) {
+            if ($isUpdate) {
+                $this->readRow($reader, $table, $present); // before-image (discarded)
+            }
+            $rows[] = $this->readRow($reader, $table, $presentAfter);
+        }
+
+        return ['schema' => $table['schema'], 'table' => $table['table'], 'rows' => $rows];
+    }
+
+    /**
+     * @param array{count: int, types: list<int>, metadata: list<int>, names: list<string>} $table
+     * @return array<string, mixed>
+     */
+    private function readRow(BinaryReader $reader, array $table, string $present): array
+    {
+        $presentCount = $this->countBits($present);
+        $nullBitmap = $reader->read((int) \ceil($presentCount / 8));
+
+        $row = [];
+        $nullIndex = 0;
+        for ($column = 0; $column < $table['count']; $column++) {
+            if (!$this->bitAt($present, $column)) {
+                continue;
+            }
+
+            $name = $table['names'][$column] ?? (string) $column;
+            $isNull = $this->bitAt($nullBitmap, $nullIndex);
+            $nullIndex++;
+
+            $row[$name] = $isNull
+                ? null
+                : $this->decodeValue($reader, $table['types'][$column], $table['metadata'][$column]);
+        }
+
+        return $row;
+    }
+
+    private function decodeValue(BinaryReader $reader, int $type, int $metadata): mixed
+    {
+        switch ($type) {
+            case Constants::TYPE_TINY:
+                return $reader->readUInt(1);
+            case Constants::TYPE_SHORT:
+                return $reader->readUInt(2);
+            case Constants::TYPE_INT24:
+                return $reader->readUInt(3);
+            case Constants::TYPE_LONG:
+                return $reader->readUInt(4);
+            case Constants::TYPE_LONGLONG:
+                return $reader->readUInt(8);
+            case Constants::TYPE_YEAR:
+                return $reader->readUInt(1);
+            case Constants::TYPE_FLOAT:
+                return $this->unpackNumber('g', $reader->read(4));
+            case Constants::TYPE_DOUBLE:
+                return $this->unpackNumber('e', $reader->read(8));
+            case Constants::TYPE_VARCHAR:
+            case Constants::TYPE_VAR_STRING:
+                $prefix = $metadata > 255 ? 2 : 1;
+                return $reader->read($reader->readUInt($prefix));
+            case Constants::TYPE_STRING:
+                return $this->decodeString($reader, $metadata);
+            case Constants::TYPE_BLOB:
+            case Constants::TYPE_TINY_BLOB:
+            case Constants::TYPE_MEDIUM_BLOB:
+            case Constants::TYPE_LONG_BLOB:
+            case Constants::TYPE_GEOMETRY:
+            case Constants::TYPE_JSON:
+                return $reader->read($reader->readUInt(\max(1, $metadata)));
+            case Constants::TYPE_ENUM:
+            case Constants::TYPE_SET:
+                return $reader->readUInt(\max(1, $metadata));
+            case Constants::TYPE_NEWDECIMAL:
+            case Constants::TYPE_DECIMAL:
+                return $reader->read($this->decimalLength($metadata >> 8, $metadata & 0xFF));
+            case Constants::TYPE_DATE:
+            case Constants::TYPE_TIME:
+                return $reader->read(3);
+            case Constants::TYPE_TIMESTAMP:
+                return $reader->read(4);
+            case Constants::TYPE_DATETIME:
+                return $reader->read(8);
+            case Constants::TYPE_TIMESTAMP2:
+                return $reader->read(4 + \intdiv($metadata + 1, 2));
+            case Constants::TYPE_DATETIME2:
+                return $reader->read(5 + \intdiv($metadata + 1, 2));
+            case Constants::TYPE_TIME2:
+                return $reader->read(3 + \intdiv($metadata + 1, 2));
+            case Constants::TYPE_BIT:
+                $bits = (($metadata >> 8) * 8) + ($metadata & 0xFF);
+                return $reader->read((int) \ceil($bits / 8));
+            case Constants::TYPE_NULL:
+                return null;
+            default:
+                throw new \RuntimeException("Unsupported binlog column type: {$type}");
+        }
+    }
+
+    private function unpackNumber(string $format, string $bytes): float
+    {
+        $value = \unpack($format, $bytes);
+
+        return \is_array($value) ? (float) ($value[1] ?? 0) : 0.0;
+    }
+
+    private function decodeString(BinaryReader $reader, int $metadata): mixed
+    {
+        $realType = $metadata >> 8;
+        $low = $metadata & 0xFF;
+
+        if ($realType === Constants::TYPE_ENUM || $realType === Constants::TYPE_SET) {
+            return $reader->readUInt(\max(1, $low));
+        }
+
+        // Packed CHAR length: high bits live in the real-type byte.
+        $maxLength = ((($realType & 0x30) ^ 0x30) << 4) | $low;
+        $prefix = $maxLength > 255 ? 2 : 1;
+
+        return $reader->read($reader->readUInt($prefix));
+    }
+
+    /**
+     * @param list<int> $types
+     * @return list<int>
+     */
+    private function parseMetadata(array $types, string $block): array
+    {
+        $reader = new BinaryReader($block);
+        $metadata = [];
+
+        foreach ($types as $type) {
+            $metadata[] = match ($type) {
+                Constants::TYPE_FLOAT,
+                Constants::TYPE_DOUBLE,
+                Constants::TYPE_BLOB,
+                Constants::TYPE_TINY_BLOB,
+                Constants::TYPE_MEDIUM_BLOB,
+                Constants::TYPE_LONG_BLOB,
+                Constants::TYPE_GEOMETRY,
+                Constants::TYPE_JSON,
+                Constants::TYPE_TIMESTAMP2,
+                Constants::TYPE_DATETIME2,
+                Constants::TYPE_TIME2 => $reader->readUInt8(),
+                Constants::TYPE_VARCHAR,
+                Constants::TYPE_VAR_STRING,
+                Constants::TYPE_BIT => $reader->readUInt16(),
+                Constants::TYPE_NEWDECIMAL,
+                Constants::TYPE_DECIMAL => ($reader->readUInt8() << 8) | $reader->readUInt8(),
+                Constants::TYPE_STRING,
+                Constants::TYPE_ENUM,
+                Constants::TYPE_SET => ($reader->readUInt8() << 8) | $reader->readUInt8(),
+                default => 0,
+            };
+        }
+
+        return $metadata;
+    }
+
+    /**
+     * Read column names from the TABLE_MAP optional metadata (COLUMN_NAME field).
+     *
+     * @return list<string>
+     */
+    private function parseColumnNames(BinaryReader $reader, int $count): array
+    {
+        $names = [];
+
+        while (!$reader->eof()) {
+            $fieldType = $reader->readUInt8();
+            $fieldLength = $reader->readLengthEncodedInt() ?? 0;
+            $field = $reader->read($fieldLength);
+
+            if ($fieldType === Constants::METADATA_COLUMN_NAME) {
+                $fieldReader = new BinaryReader($field);
+                while (!$fieldReader->eof()) {
+                    $names[] = $fieldReader->readLengthEncodedString() ?? '';
+                }
+            }
+        }
+
+        // Fall back to positional names if FULL metadata is unavailable.
+        if ($names === []) {
+            $names = \array_map('strval', \range(0, \max(0, $count - 1)));
+        }
+
+        return $names;
+    }
+
+    private function decimalLength(int $precision, int $scale): int
+    {
+        $integer = $precision - $scale;
+        $integerFull = \intdiv($integer, 9);
+        $fractionFull = \intdiv($scale, 9);
+
+        return $integerFull * 4 + self::DIGITS_TO_BYTES[$integer - $integerFull * 9]
+            + $fractionFull * 4 + self::DIGITS_TO_BYTES[$scale - $fractionFull * 9];
+    }
+
+    private function bitAt(string $bitmap, int $index): bool
+    {
+        return (\ord($bitmap[$index >> 3]) >> ($index & 7) & 1) === 1;
+    }
+
+    private function countBits(string $bitmap): int
+    {
+        $count = 0;
+        for ($i = 0, $len = \strlen($bitmap); $i < $len; $i++) {
+            $count += \substr_count(\decbin(\ord($bitmap[$i])), '1');
+        }
+
+        return $count;
+    }
+}

--- a/src/Database/Replication/GtidSet.php
+++ b/src/Database/Replication/GtidSet.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+/**
+ * A MySQL GTID set: a map of source UUIDs to their executed transaction
+ * intervals. Used both to tell the server where to resume a dump and as the
+ * checkpoint token handed back to callers.
+ *
+ * Text form: `uuid:1-5:7-9,uuid2:1-3` (interval bounds are inclusive).
+ *
+ * Pure (no I/O) — unit-testable.
+ */
+class GtidSet
+{
+    /**
+     * Lower-cased UUID => sorted list of inclusive [start, end] intervals.
+     *
+     * @var array<string, list<array{int, int}>>
+     */
+    private array $sids = [];
+
+    public function __construct(string $gtidSet = '')
+    {
+        $gtidSet = \trim($gtidSet);
+        if ($gtidSet === '') {
+            return;
+        }
+
+        foreach (\explode(',', $gtidSet) as $entry) {
+            $parts = \explode(':', \trim($entry));
+            $sid = \strtolower(\array_shift($parts));
+
+            foreach ($parts as $interval) {
+                if (\str_contains($interval, '-')) {
+                    [$start, $end] = \explode('-', $interval, 2);
+                } else {
+                    $start = $end = $interval;
+                }
+
+                $this->addInterval($sid, (int) $start, (int) $end);
+            }
+        }
+    }
+
+    /**
+     * Add a single transaction (sid:gno), merging it into existing intervals.
+     */
+    public function add(string $sid, int $gno): void
+    {
+        $this->addInterval(\strtolower($sid), $gno, $gno);
+    }
+
+    private function addInterval(string $sid, int $start, int $end): void
+    {
+        $intervals = $this->sids[$sid] ?? [];
+        $intervals[] = [$start, $end];
+
+        \usort($intervals, fn (array $a, array $b) => $a[0] <=> $b[0]);
+
+        $merged = [];
+        foreach ($intervals as $interval) {
+            $last = \end($merged);
+            if ($last !== false && $interval[0] <= $last[1] + 1) {
+                $merged[\count($merged) - 1][1] = \max($last[1], $interval[1]);
+            } else {
+                $merged[] = $interval;
+            }
+        }
+
+        $this->sids[$sid] = $merged;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->sids === [];
+    }
+
+    public function __toString(): string
+    {
+        $entries = [];
+        foreach ($this->sids as $sid => $intervals) {
+            $parts = [$sid];
+            foreach ($intervals as [$start, $end]) {
+                $parts[] = $start === $end ? (string) $start : "{$start}-{$end}";
+            }
+            $entries[] = \implode(':', $parts);
+        }
+
+        return \implode(',', $entries);
+    }
+
+    /**
+     * Encode for COM_BINLOG_DUMP_GTID: the wire form uses half-open intervals
+     * (`end` is the last transaction + 1).
+     */
+    public function encode(): string
+    {
+        $payload = \pack('P', \count($this->sids));
+
+        foreach ($this->sids as $sid => $intervals) {
+            $payload .= \hex2bin(\str_replace('-', '', $sid));
+            $payload .= \pack('P', \count($intervals));
+            foreach ($intervals as [$start, $end]) {
+                $payload .= \pack('P', $start);
+                $payload .= \pack('P', $end + 1);
+            }
+        }
+
+        return $payload;
+    }
+}

--- a/src/Database/Replication/Replication.php
+++ b/src/Database/Replication/Replication.php
@@ -46,6 +46,7 @@ class Replication
         private readonly string $username,
         private readonly string $password,
         private readonly int $serverId,
+        private readonly bool $ssl = false,
     ) {
         $this->parser = new EventParser();
         $this->executed = new GtidSet();
@@ -71,7 +72,7 @@ class Replication
      */
     public function start(?string $position = null): void
     {
-        $this->connection = new Connection($this->host, $this->port, $this->username, $this->password);
+        $this->connection = new Connection($this->host, $this->port, $this->username, $this->password, $this->ssl);
         $this->connection->connect();
 
         $this->connection->execute('SET @master_binlog_checksum = @@global.binlog_checksum');

--- a/src/Database/Replication/Replication.php
+++ b/src/Database/Replication/Replication.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Utopia\Database\Replication;
+
+/**
+ * Streams ROW-format changes from a MySQL binlog over the replication protocol.
+ *
+ * Each region can point this at its local (group-replicated) MySQL and react to
+ * data changes — e.g. purge a stale document cache — without any cross-region
+ * messaging.
+ *
+ * Requirements on the source server:
+ *  - `binlog_format = ROW`
+ *  - `gtid_mode = ON`
+ *  - `binlog_row_metadata = FULL` (so column names are available)
+ *  - a user with REPLICATION SLAVE (and REPLICATION CLIENT) privileges
+ *
+ * Usage:
+ *  $replication = new Replication($host, $port, $user, $pass, $serverId);
+ *  $replication->setSchema('appwrite')->start($checkpoint);
+ *  foreach ($replication->getChanges() as $change) { ...; $checkpoint = $change->gtid; }
+ */
+class Replication
+{
+    private const array ROWS_EVENTS = [
+        Constants::WRITE_ROWS_EVENT_V1 => Change::INSERT,
+        Constants::WRITE_ROWS_EVENT_V2 => Change::INSERT,
+        Constants::UPDATE_ROWS_EVENT_V1 => Change::UPDATE,
+        Constants::UPDATE_ROWS_EVENT_V2 => Change::UPDATE,
+        Constants::DELETE_ROWS_EVENT_V1 => Change::DELETE,
+        Constants::DELETE_ROWS_EVENT_V2 => Change::DELETE,
+    ];
+
+    private Connection $connection;
+    private EventParser $parser;
+    private GtidSet $executed;
+    private bool $checksum = false;
+    private ?string $schema = null;
+
+    private string $currentSid = '';
+    private int $currentGno = 0;
+
+    public function __construct(
+        private readonly string $host,
+        private readonly int $port,
+        private readonly string $username,
+        private readonly string $password,
+        private readonly int $serverId,
+    ) {
+        $this->parser = new EventParser();
+        $this->executed = new GtidSet();
+    }
+
+    /**
+     * Only emit changes for this schema (database). Others are decoded for
+     * bookkeeping but not yielded.
+     */
+    public function setSchema(string $schema): self
+    {
+        $this->schema = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Connect, negotiate, and begin dumping the binlog.
+     *
+     * @param string|null $position Executed-GTID-set to resume from. When null,
+     *                              starts from the server's current position
+     *                              (only new changes).
+     */
+    public function start(?string $position = null): void
+    {
+        $this->connection = new Connection($this->host, $this->port, $this->username, $this->password);
+        $this->connection->connect();
+
+        $this->connection->execute('SET @master_binlog_checksum = @@global.binlog_checksum');
+        $checksum = $this->connection->queryScalar('SELECT @@global.binlog_checksum') ?? 'NONE';
+        $this->checksum = \strtoupper(\trim($checksum)) !== 'NONE';
+
+        $this->registerSlave();
+
+        $gtid = ($position !== null && $position !== '')
+            ? $position
+            : ($this->connection->queryScalar('SELECT @@global.gtid_executed') ?? '');
+        $this->executed = new GtidSet($gtid);
+
+        $this->sendDumpCommand();
+    }
+
+    public function stop(): void
+    {
+        if (isset($this->connection)) {
+            $this->connection->close();
+        }
+    }
+
+    /**
+     * Blocking generator yielding a {@see Change} per ROWS event. Yields the
+     * current coroutine while waiting on the socket.
+     *
+     * @return \Generator<Change>
+     */
+    public function getChanges(): \Generator
+    {
+        while (true) {
+            $packet = $this->connection->readPacket();
+            $marker = \ord($packet[0]);
+
+            if ($marker === Constants::PACKET_EOF && \strlen($packet) < 9) {
+                return; // end of a non-blocking stream
+            }
+            $this->connection->throwIfError($packet);
+
+            $change = $this->handleEvent(\substr($packet, 1));
+            if ($change !== null) {
+                yield $change;
+            }
+        }
+    }
+
+    private function handleEvent(string $event): ?Change
+    {
+        $eventType = \ord($event[4]); // event header: [0-3] timestamp, [4] type
+        $body = \substr($event, Constants::EVENT_HEADER_SIZE);
+        if ($this->checksum) {
+            $body = \substr($body, 0, -4);
+        }
+
+        switch (true) {
+            case $eventType === Constants::GTID_EVENT:
+                $this->trackGtid($body);
+                return null;
+            case $eventType === Constants::XID_EVENT:
+                $this->commit();
+                return null;
+            case $eventType === Constants::TABLE_MAP_EVENT:
+                $this->parser->parseTableMap($body);
+                return null;
+            case isset(self::ROWS_EVENTS[$eventType]):
+                return $this->buildChange($eventType, $body);
+            default:
+                return null;
+        }
+    }
+
+    private function buildChange(int $eventType, string $body): ?Change
+    {
+        $decoded = $this->parser->parseRows($eventType, $body);
+        if ($decoded === null) {
+            return null;
+        }
+
+        if ($this->schema !== null && $decoded['schema'] !== $this->schema) {
+            return null;
+        }
+
+        return new Change(
+            action: self::ROWS_EVENTS[$eventType],
+            database: $decoded['schema'],
+            table: $decoded['table'],
+            rows: $decoded['rows'],
+            gtid: (string) $this->executed,
+        );
+    }
+
+    private function trackGtid(string $body): void
+    {
+        $reader = new BinaryReader($body);
+        $reader->skip(1); // commit flag
+        $this->currentSid = $this->formatUuid($reader->read(16));
+        $this->currentGno = $reader->readUInt64();
+    }
+
+    /**
+     * Mark the in-flight transaction committed. We only advance the checkpoint
+     * on commit, so a crash mid-transaction re-streams it (purges are idempotent).
+     */
+    private function commit(): void
+    {
+        if ($this->currentSid !== '' && $this->currentGno > 0) {
+            $this->executed->add($this->currentSid, $this->currentGno);
+            $this->currentSid = '';
+            $this->currentGno = 0;
+        }
+    }
+
+    private function registerSlave(): void
+    {
+        $payload = \chr(Constants::COM_REGISTER_SLAVE)
+            . \pack('V', $this->serverId)
+            . \chr(0) // hostname
+            . \chr(0) // user
+            . \chr(0) // password
+            . \pack('v', $this->port)
+            . \pack('V', 0) // replication rank
+            . \pack('V', 0); // master id
+
+        $this->connection->writeCommand($payload);
+        $this->connection->readOk();
+    }
+
+    private function sendDumpCommand(): void
+    {
+        $encoded = $this->executed->encode();
+
+        $payload = \chr(Constants::COM_BINLOG_DUMP_GTID)
+            . \pack('v', 0) // flags
+            . \pack('V', $this->serverId)
+            . \pack('V', 0) // binlog filename length
+            . \pack('P', 4) // binlog position
+            . \pack('V', \strlen($encoded))
+            . $encoded;
+
+        $this->connection->writeCommand($payload);
+    }
+
+    private function formatUuid(string $binary): string
+    {
+        $hex = \bin2hex($binary);
+
+        return \sprintf(
+            '%s-%s-%s-%s-%s',
+            \substr($hex, 0, 8),
+            \substr($hex, 8, 4),
+            \substr($hex, 12, 4),
+            \substr($hex, 16, 4),
+            \substr($hex, 20, 12),
+        );
+    }
+}

--- a/tests/e2e/Replication/ReplicationTest.php
+++ b/tests/e2e/Replication/ReplicationTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\E2E\Replication;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Scheduler;
+use Swoole\Runtime;
+use Utopia\Database\Replication\Change;
+use Utopia\Database\Replication\Replication;
+
+/**
+ * Integration tests for the binlog Replication reader against a live MySQL 8.
+ *
+ * Opt-in: skipped unless REPLICATION_TEST_HOST is set. The test self-configures
+ * the server (GTID + FULL row metadata), so the connecting user must have
+ * privileges to SET GLOBAL (e.g. root).
+ *
+ *   REPLICATION_TEST_HOST=127.0.0.1 REPLICATION_TEST_PORT=3306 \
+ *   REPLICATION_TEST_USER=root REPLICATION_TEST_PASS=password \
+ *   vendor/bin/phpunit tests/e2e/Replication
+ */
+class ReplicationTest extends TestCase
+{
+    private const string SCHEMA = 'replication_test';
+    private const string TABLE = 'console15x_projects';
+    private const int SERVER_ID = 223344;
+
+    private string $host;
+    private int $port;
+    private string $user;
+    private string $pass;
+    private PDO $pdo;
+
+    protected function setUp(): void
+    {
+        $host = \getenv('REPLICATION_TEST_HOST');
+        if ($host === false) {
+            $this->markTestSkipped('Set REPLICATION_TEST_HOST to run replication integration tests.');
+        }
+
+        $this->host = $host;
+        $this->port = (int) (\getenv('REPLICATION_TEST_PORT') ?: '3306');
+        $this->user = \getenv('REPLICATION_TEST_USER') ?: 'root';
+        $this->pass = \getenv('REPLICATION_TEST_PASS') ?: 'password';
+
+        $this->pdo = new PDO(
+            "mysql:host={$this->host};port={$this->port}",
+            $this->user,
+            $this->pass,
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
+        );
+
+        $this->configureServer();
+        $this->resetSchema();
+
+        Runtime::enableCoroutine(SWOOLE_HOOK_ALL);
+    }
+
+    protected function tearDown(): void
+    {
+        Runtime::enableCoroutine(false);
+    }
+
+    public function testBasicCrudIsStreamed(): void
+    {
+        $changes = $this->capture(3, function (PDO $pdo) {
+            $pdo->exec("INSERT INTO " . self::TABLE . " (_uid, name) VALUES ('proj_a', 'First')");
+            $pdo->exec("UPDATE " . self::TABLE . " SET name = 'Second' WHERE _uid = 'proj_a'");
+            $pdo->exec("DELETE FROM " . self::TABLE . " WHERE _uid = 'proj_a'");
+        });
+
+        $this->assertCount(3, $changes);
+        $this->assertSame([Change::INSERT, Change::UPDATE, Change::DELETE], \array_map(fn ($c) => $c->action, $changes));
+        $this->assertSame('proj_a', $changes[0]->rows[0]['_uid']);
+        $this->assertSame('Second', $changes[1]->rows[0]['name']); // UPDATE after-image
+        $this->assertSame(self::SCHEMA, $changes[0]->database);
+        $this->assertNotSame('', $changes[2]->gtid);                // checkpoint advanced
+    }
+
+    public function testLargeRowSpanningMultiplePackets(): void
+    {
+        // > 16 MiB forces the binlog event across multiple 0xFFFFFF protocol frames.
+        $size = 18 * 1024 * 1024;
+        $blob = \str_repeat('x', $size);
+
+        $changes = $this->capture(1, function (PDO $pdo) use ($blob) {
+            $stmt = $pdo->prepare("INSERT INTO " . self::TABLE . " (_uid, name, data) VALUES ('big', 'Big', :data)");
+            $stmt->execute([':data' => $blob]);
+        });
+
+        $this->assertCount(1, $changes);
+        $this->assertSame('big', $changes[0]->rows[0]['_uid']);
+        $this->assertSame($size, \strlen($changes[0]->rows[0]['data']));
+    }
+
+    public function testCachingSha2FullAuthentication(): void
+    {
+        // A freshly (re)created user is not in the server's auth cache, so the
+        // reader must complete the caching_sha2_password full-auth (RSA) path.
+        $this->pdo->exec("DROP USER IF EXISTS 'repl_full'@'%'");
+        $this->pdo->exec("CREATE USER 'repl_full'@'%' IDENTIFIED WITH caching_sha2_password BY 'Repl!Full#123'");
+        $this->pdo->exec("GRANT REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'repl_full'@'%'");
+        $this->pdo->exec('FLUSH PRIVILEGES');
+
+        $changes = $this->capture(1, function (PDO $pdo) {
+            $pdo->exec("INSERT INTO " . self::TABLE . " (_uid, name) VALUES ('proj_fa', 'FullAuth')");
+        }, user: 'repl_full', pass: 'Repl!Full#123');
+
+        $this->assertCount(1, $changes);
+        $this->assertSame('proj_fa', $changes[0]->rows[0]['_uid']);
+    }
+
+    public function testTlsConnection(): void
+    {
+        $changes = $this->capture(1, function (PDO $pdo) {
+            $pdo->exec("INSERT INTO " . self::TABLE . " (_uid, name) VALUES ('proj_tls', 'Secure')");
+        }, ssl: true);
+
+        $this->assertCount(1, $changes);
+        $this->assertSame('proj_tls', $changes[0]->rows[0]['_uid']);
+    }
+
+    /**
+     * Start the reader, run $writer against the table, and collect $expected changes.
+     *
+     * @return array<int, Change>
+     */
+    private function capture(int $expected, callable $writer, string $user = '', string $pass = '', bool $ssl = false): array
+    {
+        $collected = [];
+        $error = null;
+        $dsn = "mysql:host={$this->host};port={$this->port};dbname=" . self::SCHEMA;
+        $writerUser = $this->user;
+        $writerPass = $this->pass;
+        $readerUser = $user !== '' ? $user : $this->user;
+        $readerPass = $user !== '' ? $pass : $this->pass;
+
+        $scheduler = new Scheduler();
+        $scheduler->add(function () use (&$collected, &$error, $writer, $expected, $dsn, $writerUser, $writerPass, $readerUser, $readerPass, $ssl) {
+            try {
+                $replication = new Replication($this->host, $this->port, $readerUser, $readerPass, self::SERVER_ID, $ssl);
+                $replication->setSchema(self::SCHEMA)->start(null);
+
+                Coroutine::create(function () use ($writer, $dsn, $writerUser, $writerPass) {
+                    Coroutine::sleep(0.5);
+                    $writer(new PDO($dsn, $writerUser, $writerPass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]));
+                });
+
+                $count = 0;
+                foreach ($replication->getChanges() as $change) {
+                    $collected[] = $change;
+                    if (++$count >= $expected) {
+                        break;
+                    }
+                }
+                $replication->stop();
+            } catch (\Throwable $e) {
+                $error = $e;
+            }
+        });
+        $scheduler->start();
+
+        if ($error !== null) {
+            throw $error;
+        }
+
+        return $collected;
+    }
+
+    private function configureServer(): void
+    {
+        $this->pdo->exec('SET GLOBAL binlog_row_metadata = FULL');
+
+        $statement = $this->pdo->query('SELECT @@global.gtid_mode');
+        $mode = $statement === false ? null : $statement->fetchColumn();
+        if ($mode !== 'ON') {
+            $this->pdo->exec('SET GLOBAL enforce_gtid_consistency = ON');
+            $this->pdo->exec('SET GLOBAL gtid_mode = OFF_PERMISSIVE');
+            $this->pdo->exec('SET GLOBAL gtid_mode = ON_PERMISSIVE');
+            $this->pdo->exec('SET GLOBAL gtid_mode = ON');
+        }
+    }
+
+    private function resetSchema(): void
+    {
+        $this->pdo->exec('CREATE DATABASE IF NOT EXISTS ' . self::SCHEMA);
+        $this->pdo->exec('USE ' . self::SCHEMA);
+        $this->pdo->exec('DROP TABLE IF EXISTS ' . self::TABLE);
+        $this->pdo->exec(
+            'CREATE TABLE ' . self::TABLE . ' (
+                _id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+                _uid VARCHAR(255) NOT NULL,
+                name VARCHAR(255) NULL,
+                _createdAt DATETIME(3) NULL,
+                _permissions JSON NULL,
+                data LONGBLOB NULL,
+                PRIMARY KEY (_id),
+                UNIQUE KEY (_uid)
+            )'
+        );
+    }
+}

--- a/tests/unit/Replication/BinaryReaderTest.php
+++ b/tests/unit/Replication/BinaryReaderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Unit\Replication;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Replication\BinaryReader;
+
+class BinaryReaderTest extends TestCase
+{
+    public function testFixedWidthIntegersAreLittleEndian(): void
+    {
+        $reader = new BinaryReader("\x01\x02\x00\x03\x00\x00\x00");
+
+        $this->assertSame(1, $reader->readUInt8());
+        $this->assertSame(2, $reader->readUInt16());
+        $this->assertSame(3, $reader->readUInt32());
+        $this->assertTrue($reader->eof());
+    }
+
+    public function testLengthEncodedInteger(): void
+    {
+        // 0xFA inline, 0xFC + 2 bytes, 0xFB => NULL.
+        $reader = new BinaryReader("\xFA\xFC\x00\x01\xFB");
+
+        $this->assertSame(0xFA, $reader->readLengthEncodedInt());
+        $this->assertSame(256, $reader->readLengthEncodedInt());
+        $this->assertNull($reader->readLengthEncodedInt());
+    }
+
+    public function testLengthEncodedString(): void
+    {
+        $reader = new BinaryReader("\x05hello\xFB");
+
+        $this->assertSame('hello', $reader->readLengthEncodedString());
+        $this->assertNull($reader->readLengthEncodedString());
+    }
+
+    public function testNullTerminatedString(): void
+    {
+        $reader = new BinaryReader("appwrite\x00rest");
+
+        $this->assertSame('appwrite', $reader->readNullTerminatedString());
+        $this->assertSame('rest', $reader->read($reader->remaining()));
+    }
+
+    public function testSkipAdvancesCursor(): void
+    {
+        $reader = new BinaryReader("\xAA\xBB\xCC");
+        $reader->skip(2);
+
+        $this->assertSame(0xCC, $reader->readUInt8());
+    }
+}

--- a/tests/unit/Replication/EventParserTest.php
+++ b/tests/unit/Replication/EventParserTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Unit\Replication;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Replication\Constants;
+use Utopia\Database\Replication\EventParser;
+
+class EventParserTest extends TestCase
+{
+    private const int TABLE_ID = 42;
+    private const string SCHEMA = 'appwrite';
+    private const string TABLE = 'console15x_projects';
+
+    /**
+     * A two-column table: `_id` BIGINT, `_uid` VARCHAR (utf8mb4(255) => 1020 max bytes).
+     */
+    private function tableMapBody(): string
+    {
+        $body = $this->uint(self::TABLE_ID, 6)
+            . "\x00\x00" // flags
+            . \chr(\strlen(self::SCHEMA)) . self::SCHEMA . "\x00"
+            . \chr(\strlen(self::TABLE)) . self::TABLE . "\x00"
+            . \chr(2) // column count
+            . \chr(Constants::TYPE_LONGLONG) . \chr(Constants::TYPE_VAR_STRING);
+
+        $metadata = \pack('v', 1020); // VAR_STRING max length; LONGLONG has none
+        $body .= \chr(\strlen($metadata)) . $metadata;
+        $body .= "\x00"; // null bitmap (ceil(2/8))
+
+        // Optional metadata: SIGNEDNESS (skipped) then COLUMN_NAME.
+        $body .= \chr(1) . \chr(1) . "\x00"; // SIGNEDNESS field, 1 byte payload
+        $names = \chr(3) . '_id' . \chr(4) . '_uid';
+        $body .= \chr(Constants::METADATA_COLUMN_NAME) . \chr(\strlen($names)) . $names;
+
+        return $body;
+    }
+
+    private function rowsHeader(): string
+    {
+        return $this->uint(self::TABLE_ID, 6)
+            . "\x00\x00"   // flags
+            . "\x02\x00"   // v2 extra-data length = 2 (none)
+            . \chr(2)      // column count
+            . \chr(0b11);  // both columns present
+    }
+
+    private function cell(int $id, string $uid): string
+    {
+        // null bitmap (no nulls) + BIGINT + length-prefixed VARCHAR (2-byte prefix).
+        return "\x00" . \pack('P', $id) . \pack('v', \strlen($uid)) . $uid;
+    }
+
+    private function uint(int $value, int $bytes): string
+    {
+        $out = '';
+        for ($i = 0; $i < $bytes; $i++) {
+            $out .= \chr(($value >> ($i * 8)) & 0xFF);
+        }
+
+        return $out;
+    }
+
+    public function testWriteRowsDecodesNamedColumns(): void
+    {
+        $parser = new EventParser();
+        $parser->parseTableMap($this->tableMapBody());
+
+        $body = $this->rowsHeader() . $this->cell(100, 'proj123');
+        $decoded = $parser->parseRows(Constants::WRITE_ROWS_EVENT_V2, $body);
+
+        $this->assertSame(self::SCHEMA, $decoded['schema']);
+        $this->assertSame(self::TABLE, $decoded['table']);
+        $this->assertCount(1, $decoded['rows']);
+        $this->assertSame(100, $decoded['rows'][0]['_id']);
+        $this->assertSame('proj123', $decoded['rows'][0]['_uid']);
+    }
+
+    public function testMultipleRowsInOneEvent(): void
+    {
+        $parser = new EventParser();
+        $parser->parseTableMap($this->tableMapBody());
+
+        $body = $this->rowsHeader() . $this->cell(1, 'aaa') . $this->cell(2, 'bbbb');
+        $decoded = $parser->parseRows(Constants::WRITE_ROWS_EVENT_V2, $body);
+
+        $this->assertCount(2, $decoded['rows']);
+        $this->assertSame('aaa', $decoded['rows'][0]['_uid']);
+        $this->assertSame('bbbb', $decoded['rows'][1]['_uid']);
+    }
+
+    public function testUpdateKeepsAfterImage(): void
+    {
+        $parser = new EventParser();
+        $parser->parseTableMap($this->tableMapBody());
+
+        // Update header carries two "columns present" bitmaps (before + after).
+        $header = $this->uint(self::TABLE_ID, 6) . "\x00\x00" . "\x02\x00" . \chr(2) . \chr(0b11) . \chr(0b11);
+        $body = $header . $this->cell(100, 'old_uid') . $this->cell(100, 'new_uid');
+
+        $decoded = $parser->parseRows(Constants::UPDATE_ROWS_EVENT_V2, $body);
+
+        $this->assertCount(1, $decoded['rows']);
+        $this->assertSame('new_uid', $decoded['rows'][0]['_uid']);
+    }
+
+    public function testNullColumnIsDecodedAsNull(): void
+    {
+        $parser = new EventParser();
+        $parser->parseTableMap($this->tableMapBody());
+
+        // null bitmap marks column 1 (_uid) as null; only _id has a value.
+        $row = \chr(0b10) . \pack('P', 7);
+        $decoded = $parser->parseRows(Constants::WRITE_ROWS_EVENT_V2, $this->rowsHeader() . $row);
+
+        $this->assertSame(7, $decoded['rows'][0]['_id']);
+        $this->assertNull($decoded['rows'][0]['_uid']);
+    }
+
+    public function testUnknownTableIsSkipped(): void
+    {
+        $parser = new EventParser();
+        // No TABLE_MAP cached for this id.
+        $body = $this->rowsHeader() . $this->cell(1, 'x');
+
+        $this->assertNull($parser->parseRows(Constants::WRITE_ROWS_EVENT_V2, $body));
+    }
+}

--- a/tests/unit/Replication/GtidSetTest.php
+++ b/tests/unit/Replication/GtidSetTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Unit\Replication;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Replication\GtidSet;
+
+class GtidSetTest extends TestCase
+{
+    private const string SID = '3e11fa47-71ca-11e1-9e33-c80aa9429562';
+
+    public function testParseAndStringRoundTrip(): void
+    {
+        $set = new GtidSet(self::SID . ':1-5:7-9');
+
+        $this->assertSame(self::SID . ':1-5:7-9', (string) $set);
+    }
+
+    public function testAddMergesAdjacentTransactions(): void
+    {
+        $set = new GtidSet(self::SID . ':1-5');
+        $set->add(self::SID, 6); // adjacent => extends the interval
+        $set->add(self::SID, 8); // gap => new interval
+
+        $this->assertSame(self::SID . ':1-6:8', (string) $set);
+    }
+
+    public function testAddCollapsesGap(): void
+    {
+        $set = new GtidSet(self::SID . ':1-5:7-9');
+        $set->add(self::SID, 6); // fills the gap, merging both intervals
+
+        $this->assertSame(self::SID . ':1-9', (string) $set);
+    }
+
+    public function testEmptySet(): void
+    {
+        $set = new GtidSet();
+
+        $this->assertTrue($set->isEmpty());
+        $this->assertSame('', (string) $set);
+        // n_sids = 0 encoded as 8 little-endian bytes.
+        $this->assertSame(\pack('P', 0), $set->encode());
+    }
+
+    public function testEncodeUsesHalfOpenIntervals(): void
+    {
+        $set = new GtidSet(self::SID . ':1-5');
+
+        $expected = \pack('P', 1)                                   // one sid
+            . \hex2bin(\str_replace('-', '', self::SID))            // 16-byte uuid
+            . \pack('P', 1)                                         // one interval
+            . \pack('P', 1)                                         // start
+            . \pack('P', 6);                                        // end = last + 1
+
+        $this->assertSame($expected, $set->encode());
+    }
+}


### PR DESCRIPTION
## Why

Enables consumers to react to MySQL data changes by **tailing the binlog locally** instead of relying on application-level cross-region messaging. The immediate driver is Appwrite Cloud replacing its `worker-region-manager` cache-invalidation fan-out: each region's console DB is already group-replicated, so a region can tail its own binlog and purge its own cache — no inter-region HTTP/queue hops.

## What

New `Utopia\Database\Replication` namespace:

- **`Replication`** — orchestrates the stream: connect, negotiate, `COM_BINLOG_DUMP_GTID`, and a blocking `getChanges(): Generator<Change>`. Tracks the executed-GTID set as a checkpoint token, advanced **on commit** so a crash mid-transaction re-streams it (consumers should treat changes as idempotent). `setSchema()` filters to one database.
- **`Connection`** — Swoole coroutine socket with MySQL packet framing and a `caching_sha2_password` handshake (fast-auth, RSA full-auth over plaintext, `mysql_native_password` fallback).
- **`EventParser`** — decodes `TABLE_MAP` + `WRITE/UPDATE/DELETE_ROWS`. Column **names** come from FULL row metadata (no `INFORMATION_SCHEMA` round-trips). Handles the column types real schemas use; JSON values are skipped (bytes advanced, not decoded).
- **`GtidSet`**, **`BinaryReader`**, **`Change`** — pure helpers/DTO.

Deliberately **scope-cut** (inspired by `krowinski/php-mysql-replication`, reimplemented Swoole-native): MySQL 8, ROW format, only the event types needed.

## Requirements on the source server

- `binlog_format = ROW`
- `gtid_mode = ON`
- `binlog_row_metadata = FULL` (so column names ride in `TABLE_MAP`)
- replication user with `REPLICATION SLAVE` / `REPLICATION CLIENT`

## Tests

`tests/unit/Replication/` — 15 tests covering `BinaryReader`, `GtidSet` (parse/merge/encode), and `EventParser` (named-column decode, multi-row events, UPDATE after-image, NULLs, unknown-table skip). Pint + PHPStan level 7 clean.

> ⚠️ The socket I/O + `caching_sha2` handshake + end-to-end binlog dump are **not** covered by unit tests (need a live MySQL 8). Validation against a real ROW/GTID source is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MySQL binlog replication reader that streams row-level changes, decodes table/row events, tracks GTID checkpoints, and supports TLS and caching_sha2 authentication during replication sessions.

* **Tests**
  * Added unit tests for binary parsing, event decoding, and GTID interval handling.
  * Added opt-in end-to-end replication tests against a live MySQL 8 instance and expanded the e2e test suite configuration.

* **Chores**
  * Expanded optional PHP extension suggestions in composer for MongoDB replication adapter and enhanced replication capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->