### PR TITLE
fix(cache): gate the query cache write on a lease to reject stale lists

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8709,6 +8709,16 @@ class Database
             }
         }
 
+        // Capture the generation before the callback runs its read: if a
+        // concurrent write purges this query key in between, saveWithLease()
+        // below rejects the now-stale list instead of re-poisoning the cache.
+        $generation = '0';
+        try {
+            $generation = $this->cache->getGeneration($key);
+        } catch (Throwable $e) {
+            Console::warning('Warning: Failed to get cache generation: ' . $e->getMessage());
+        }
+
         $callbackValue = $callback();
 
         if ($callbackValue !== false) {
@@ -8795,7 +8805,7 @@ class Database
                 }
 
                 if ($encoded !== false) {
-                    $this->cache->save($key, $encoded, $hash);
+                    $this->cache->saveWithLease($key, $encoded, $hash, $generation);
                 }
             } catch (Throwable $e) {
                 Console::warning('Warning: Failed to save cache value: ' . $e->getMessage());

--- a/tests/unit/WithCacheLeaseTest.php
+++ b/tests/unit/WithCacheLeaseTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter;
+use Utopia\Cache\Cache;
+use Utopia\Cache\Feature\Leasable;
+use Utopia\Database\Adapter\Memory as DatabaseMemory;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+
+class WithCacheLeaseTest extends TestCase
+{
+    private LeasableMemoryCache $cacheAdapter;
+
+    private Database $database;
+
+    private string $key;
+
+    protected function setUp(): void
+    {
+        $this->cacheAdapter = new LeasableMemoryCache();
+        $this->database = new Database(new DatabaseMemory(), new Cache($this->cacheAdapter));
+        $this->database
+            ->setDatabase('utopiaTests')
+            ->setNamespace('with_cache_' . \uniqid());
+
+        $this->database->create();
+        $this->database->createCollection('projects');
+        $this->database->createAttribute('projects', 'name', Database::VAR_STRING, 255, false);
+        $this->database->createDocument('projects', new Document([
+            '$id' => 'project',
+            '$permissions' => [
+                Permission::read(Role::any()),
+            ],
+            'name' => 'fresh',
+        ]));
+
+        $this->key = $this->database->getQueryCacheKey('projects');
+    }
+
+    public function testStaleListWriteAfterConcurrentPurgeIsRejected(): void
+    {
+        $hash = 'list-hash';
+
+        $document = $this->database->getDocument('projects', 'project');
+
+        // The callback stands in for the database read of an older request: a
+        // concurrent writer purges the query key after the read started but
+        // before the result is cached. Without a lease the stale list below
+        // would land in the cache after the purge.
+        $result = $this->database->withCache($this->key, function () use ($hash, $document) {
+            $this->cacheAdapter->purge($this->key, $hash);
+
+            return [$document];
+        }, $hash);
+
+        $this->assertCount(1, $result);
+        $this->assertFalse(
+            $this->cacheAdapter->load($this->key, Database::TTL, $hash),
+            'A list read whose query key was purged mid-flight must not be re-cached.'
+        );
+    }
+
+    public function testListWriteLandsWhenNoConcurrentPurge(): void
+    {
+        $hash = 'list-hash';
+
+        $document = $this->database->getDocument('projects', 'project');
+
+        $result = $this->database->withCache($this->key, fn () => [$document], $hash);
+
+        $this->assertCount(1, $result);
+        $this->assertNotFalse(
+            $this->cacheAdapter->load($this->key, Database::TTL, $hash),
+            'A list read with no concurrent purge must populate the cache.'
+        );
+    }
+}
+
+class LeasableMemoryCache implements Adapter, Leasable
+{
+    private const string GENERATION_FIELD = '__utopia_gen__';
+
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private array $store = [];
+
+    public function load(string $key, int $ttl, string $hash = ''): mixed
+    {
+        if ($hash === '') {
+            $hash = $key;
+        }
+
+        if (! isset($this->store[$key][$hash])) {
+            return false;
+        }
+
+        $saved = $this->store[$key][$hash];
+
+        return ($saved['time'] + $ttl > \time()) ? $saved['data'] : false;
+    }
+
+    public function save(string $key, array|string $data, string $hash = ''): bool|string|array
+    {
+        if (empty($key) || empty($data)) {
+            return false;
+        }
+
+        if ($hash === '') {
+            $hash = $key;
+        }
+
+        if ($hash === self::GENERATION_FIELD) {
+            return false;
+        }
+
+        $this->store[$key][$hash] = ['time' => \time(), 'data' => $data];
+
+        return $data;
+    }
+
+    public function getGeneration(string $key): string
+    {
+        return $this->store[$key][self::GENERATION_FIELD]['data'] ?? '0';
+    }
+
+    public function saveWithLease(string $key, array|string $data, string $hash, string $generation): bool|string|array
+    {
+        if (empty($key) || empty($data)) {
+            return false;
+        }
+
+        if ($this->getGeneration($key) !== $generation) {
+            return false;
+        }
+
+        return $this->save($key, $data, $hash);
+    }
+
+    public function touch(string $key, string $hash = ''): bool
+    {
+        if ($hash === '') {
+            $hash = $key;
+        }
+
+        if (! isset($this->store[$key][$hash])) {
+            return false;
+        }
+
+        $this->store[$key][$hash]['time'] = \time();
+
+        return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function list(string $key): array
+    {
+        return \array_values(\array_filter(
+            \array_keys($this->store[$key] ?? []),
+            fn (string $field): bool => $field !== self::GENERATION_FIELD
+        ));
+    }
+
+    public function purge(string $key, string $hash = ''): bool
+    {
+        $generation = (string) (((int) $this->getGeneration($key)) + 1);
+
+        if ($hash !== '' && $hash !== self::GENERATION_FIELD) {
+            unset($this->store[$key][$hash]);
+        } else {
+            $this->store[$key] = [];
+        }
+
+        $this->store[$key][self::GENERATION_FIELD] = ['time' => \time(), 'data' => $generation];
+
+        return true;
+    }
+
+    public function flush(): bool
+    {
+        $this->store = [];
+
+        return true;
+    }
+
+    public function ping(): bool
+    {
+        return true;
+    }
+
+    public function getSize(): int
+    {
+        return \count($this->store);
+    }
+
+    public function getName(?string $key = null): string
+    {
+        return 'leasable-memory';
+    }
+}


### PR DESCRIPTION
## The race

`utopia-php/cache` 3.1.0 added the **Leasable** primitive (`getGeneration()` / `saveWithLease()`, PR #75/#77) to close the cache-aside read-after-write race: a reader that fetched a row from the database just before a concurrent purge must not re-populate the cache with the now-stale value after the purge has run. `Database::getDocument()` adopted it (PR #904 `feat/leasable-getdocument`): it captures the generation before the database read and uses `saveWithLease(...)` on save, so a purge that lands in between rejects the stale write.

The query/list cache added in PR #894 (`feat/cached-find`) was left unprotected. `withCache()` reads through the cache, runs the callback (the database read), then **saves unconditionally**. If a concurrent create/update/delete calls `purgeCachedQueries()` between the callback's read and the save, the older request writes the stale list back into the cache *after* the purge — re-poisoning exactly the race the lease was meant to kill, this time for lists instead of single documents.

## The fix

In `withCache()` (`src/Database/Database.php`):

- **Capture `getGeneration($key)` before the callback runs** (wrapped in try/catch, degrading to `'0'` on cache failure) — placed after the optional rejected-value purge so the captured token reflects the generation as of the start of the database read.
- **Replace the unconditional `cache->save($key, $encoded, $hash)` with `cache->saveWithLease($key, $encoded, $hash, $generation)`** — a purge between read and save advances the generation and the now-stale list write is rejected.

This mirrors the `getDocument()` reference pattern exactly. Non-Leasable adapters (e.g. the `Memory` cache adapter) fall back to an unconditional save inside `Cache`, so behaviour is unchanged for them.

### Writers fixed

| Writer | File:line | Before | After |
| --- | --- | --- | --- |
| `withCache()` query/list cache | `src/Database/Database.php:8808` | `cache->save(...)` (unconditional) | `cache->saveWithLease(..., $generation)` (lease-gated) |

`getDocument()` (`src/Database/Database.php:4946`) was already lease-gated by PR #904 and is unchanged. The storage file-content cache in downstream consumers (Appwrite `app/controllers/shared/api.php`) is a Filesystem-backed HTTP response cache with its own invalidation log — not a database list cache — and is out of scope.

## Tests

New `tests/unit/WithCacheLeaseTest.php` with a self-contained Leasable in-memory cache adapter (the shipped `Memory` adapter is intentionally non-Leasable, so it could not exercise the lease):

- `testStaleListWriteAfterConcurrentPurgeIsRejected` — the callback purges the query key mid-read; asserts the stale list is **not** re-cached. **Fails without the fix** (the old list lands in the cache after the purge), passes with it.
- `testListWriteLandsWhenNoConcurrentPurge` — with no concurrent purge, the list is cached as normal.

## Verification

- Pint (full repo): passed
- PHPStan level 7 (`src` + `tests`): no errors
- Unit suite: 397 tests, 2243 assertions, all passing (includes the 2 new regression tests)
- Confirmed the new regression test fails against the pre-fix `save()` and passes with `saveWithLease()`

## Dependency / propagation

The cache constraint is already `utopia-php/cache: 3.1.*` and `composer.lock` already resolves `3.1.0`, which provides `getGeneration`/`saveWithLease` — no constraint bump needed. This fix lives in `utopia-php/database`, so it needs a new database release and a downstream `composer update` (Appwrite/Cloud/Edge) to take effect for list endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for cache lease behavior, including handling of stale data when a cache entry is purged during an in-flight write.
  * Added a second test to verify normal cache population and retrieval still works as expected.
  * Introduced an in-memory cache implementation for testing lease and expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->