### PR TITLE
fix: purge collection cache after commit in createRelationship

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -3813,6 +3813,14 @@ class Database
                 throw new DatabaseException('Failed to create relationship: ' . $e->getMessage());
             }
 
+            // updateDocument's purge ran inside this outer transaction (nested commits don't
+            // commit), so it fired pre-commit and a stale collection can stay cached. Re-purge
+            // after the real commit, else createIndex below re-reads it without the new column.
+            $this->withRetries(fn () => $this->purgeCachedCollection($collection->getId()));
+            $this->withRetries(fn () => $this->purgeCachedDocumentInternal(self::METADATA, $collection->getId()));
+            $this->withRetries(fn () => $this->purgeCachedCollection($relatedCollection->getId()));
+            $this->withRetries(fn () => $this->purgeCachedDocumentInternal(self::METADATA, $relatedCollection->getId()));
+
             $indexKey = '_index_' . $id;
             $twoWayIndexKey = '_index_' . $twoWayKey;
             $indexesCreated = [];


### PR DESCRIPTION
## Summary

Fixes a flaky failure when creating a two-way relationship:

```
Failed to create relationship indexes: Invalid index attribute "..." not found
```

It surfaces intermittently under concurrency + a shared cache (e.g. shared-tables migrations/restores), and effectively never single-threaded — the classic signature of a read-after-write cache race.

## Root cause

`createRelationship()` does three things in order:

1. appends the new relationship column to the in-memory `$collection` / `$relatedCollection`,
2. persists both via `updateDocument(self::METADATA, ...)` **inside its own outer `withTransaction()`**,
3. creates the relationship's FK index via `createIndex()`, which **re-reads** the collection (`getCollection()`) and validates the index attributes against that copy.

`updateDocument()` already guards against stale caching — it purges again *after commit* (`Database.php:6407`, "Purge again after commit so readers cannot re-cache the pre-commit version"). But that guard only works when `updateDocument()` owns the transaction.

Here it doesn't. The adapter nests transactions with a counter and only commits at the outermost level (`Adapter::commitTransaction`: *"If there is more than one active transaction, this decrement the transaction count... If the transaction count is 1, it will be committed"*). So:

```
outer withTransaction      startTransaction   count 0->1   real BEGIN
  updateDocument
    inner withTransaction   startTransaction   count 1->2   no BEGIN
      write the new column                                  (uncommitted)
    inner commitTransaction count 2->1   NOT a real commit, just a decrement
    purgeCachedDocumentInternal()  <- fires HERE, count==1, txn STILL OPEN  (pre-commit)
outer commitTransaction    count 1->0   the REAL commit
  // no purge between here and createIndex
createIndex() re-reads -> may hit a stale, pre-commit copy
```

Between the (pre-commit) purge and the outer commit, a concurrent reader can load the collection metadata, read the still-uncommitted (column-less) row from the DB, and re-cache it. The lease (`saveWithLease` / `getGeneration`) doesn't catch this because no purge bumps the generation during that read. After the outer commit there is no purge, so `createIndex()`'s re-read serves the stale copy → the new relationship column is missing → index validation throws.

## Fix

Purge the collection caches **after the outer transaction commits and before `createIndex()`** — the post-commit purge `updateDocument()` intended to do but couldn't, because nesting deferred the real commit past it. This both (a) forces the re-read to miss the cache and read committed data, and (b) bumps the generation so any straggler stale write is rejected by the lease.

This mirrors the existing post-commit purge pattern already used elsewhere in this file (e.g. lines 6406, 7795, and the metadata-mutation purges around 2260-2261).

## Scope / risk

- 4 lines added in `createRelationship`; no signature or behavior change on any existing path.
- Only runs once per relationship creation; negligible cost.
- Residual: genuine DB **read-replica lag** is out of scope (same residual the existing post-commit purges accept; not present on single-DB CI).

## Testing

Covered by the existing relationship test suite (all relationship types still create their indexes correctly). The race itself is timing-dependent; this change removes the dependency on a post-commit re-read served from a potentially poisoned shared cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation after creating relationships so related data is refreshed only after the transaction fully commits.
  * Prevents stale metadata from appearing when changes occur within nested transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->