### PR TITLE
Mongo array dates 

### DIFF
--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -46,7 +46,10 @@ class Document extends ArrayObject
             }
 
             foreach ($value as $childKey => $child) {
-                if ((isset($child['$id']) || isset($child['$collection'])) && (!$child instanceof self)) {
+                // Only wrap array children that look like sub-documents. Non-array elements
+                // (e.g. MongoDB\BSON\UTCDateTime in a datetime array, scalars, other objects)
+                // are not array-accessible, so isset($child['$id']) would fatal on them.
+                if (\is_array($child) && (isset($child['$id']) || isset($child['$collection']))) {
                     $value[$childKey] = new self($child);
                 }
             }

--- a/src/Database/Document.php
+++ b/src/Database/Document.php
@@ -46,9 +46,10 @@ class Document extends ArrayObject
             }
 
             foreach ($value as $childKey => $child) {
-                // Only wrap array children that look like sub-documents. Non-array elements
-                // (e.g. MongoDB\BSON\UTCDateTime in a datetime array, scalars, other objects)
-                // are not array-accessible, so isset($child['$id']) would fatal on them.
+                // An array value is either a list of nested sub-documents or a list of
+                // plain items (dates, numbers, strings): wrap the former, leave the latter.
+                // is_array() tells them apart and avoids array-accessing a non-array
+                // value (e.g. a UTCDateTime), which would otherwise fatal.
                 if (\is_array($child) && (isset($child['$id']) || isset($child['$collection']))) {
                     $value[$childKey] = new self($child);
                 }

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -6123,6 +6123,42 @@ trait DocumentTests
         $database->deleteCollection($collection);
     }
 
+    public function testDateTimeArrayDocument(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $collection = 'datetime_array_doc';
+        $database->createCollection($collection);
+        $this->assertEquals(true, $database->createAttribute($collection, 'dates', Database::VAR_DATETIME, 0, false, null, false, true, null, [], ['datetime']));
+
+        $d1 = '2000-01-01T10:00:00.000+00:00';
+        $d2 = '2001-02-03T05:06:07.000+00:00';
+
+        $database->createDocument($collection, new Document([
+            '$id' => 'doc1',
+            '$permissions' => [Permission::read(Role::any()), Permission::update(Role::any())],
+            'dates' => [$d1, $d2],
+        ]));
+
+        // Regression: reading a datetime (object) array used to throw in Mongo with
+        // "Cannot use object of type MongoDB\BSON\UTCDateTime as array" because the
+        // Document constructor tried to array-access non-array elements.
+        $doc = $database->getDocument($collection, 'doc1');
+        $dates = $doc->getAttribute('dates');
+        $this->assertIsArray($dates);
+        $this->assertCount(2, $dates);
+        $this->assertEquals($d1, $dates[0]);
+        $this->assertEquals($d2, $dates[1]);
+
+        // Same values must round-trip through find()
+        $found = $database->find($collection, [Query::equal('$id', ['doc1'])]);
+        $this->assertCount(1, $found);
+        $this->assertEquals([$d1, $d2], $found[0]->getAttribute('dates'));
+
+        $database->deleteCollection($collection);
+    }
+
     public function testInvalidCreatedAndUpdatedAtThrowStructureException(): void
     {
         /** @var Database $database */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested document data so non-array values no longer trigger errors during processing.
  * Fixed support for datetime arrays, ensuring values can be saved and read back consistently in the original order.
* **Tests**
  * Added end-to-end coverage for datetime array documents to verify round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->