### PR TITLE
fix: defer cache purge until the outermost transaction commits

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -31,6 +31,18 @@ abstract class Adapter
 
     protected int $inTransaction = 0;
 
+    /**
+     * Document cache keys purged while a transaction was open, keyed by
+     * "collectionId:id" for de-duplication. The Database flushes these once
+     * the outermost transaction commits so a reader that re-cached the
+     * pre-commit version in the meantime gets invalidated. Lives on the
+     * adapter because transaction depth and cache are shared here across
+     * Database wrappers (e.g. Mirror shares its source's adapter and cache).
+     *
+     * @var array<string, array{0: string, 1: string}>
+     */
+    protected array $purgeAfterCommit = [];
+
     protected bool $alterLocks = false;
 
     protected bool $skipDuplicates = false;
@@ -392,6 +404,32 @@ abstract class Adapter
     public function inTransaction(): bool
     {
         return $this->inTransaction > 0;
+    }
+
+    /**
+     * Queue a document cache key to be purged again once the outermost
+     * transaction commits.
+     *
+     * @param string $collectionId
+     * @param string $id
+     * @return void
+     */
+    public function queueCachePurge(string $collectionId, string $id): void
+    {
+        $this->purgeAfterCommit[$collectionId . ':' . $id] = [$collectionId, $id];
+    }
+
+    /**
+     * Return and clear the queued post-commit cache purges.
+     *
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public function dequeueCachePurges(): array
+    {
+        $purges = $this->purgeAfterCommit;
+        $this->purgeAfterCommit = [];
+
+        return $purges;
     }
 
     /**

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -184,6 +184,7 @@ abstract class SQL extends Adapter
     {
         $this->getPDO()->reconnect();
         $this->inTransaction = 0;
+        $this->purgeAfterCommit = [];
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1555,7 +1555,29 @@ class Database
      */
     public function withTransaction(callable $callback): mixed
     {
-        return $this->adapter->withTransaction($callback);
+        try {
+            $result = $this->adapter->withTransaction($callback);
+        } catch (\Throwable $e) {
+            // Only the outermost frame owns the queue; nested frames leave it
+            // for the parent. On a full rollback nothing committed, so drop the
+            // queued purges rather than evicting cache for changes that reverted.
+            if (!$this->adapter->inTransaction()) {
+                $this->adapter->dequeueCachePurges();
+            }
+            throw $e;
+        }
+
+        // The rows are now committed and visible. Re-purge every key touched
+        // during the transaction so a reader that cached a pre-commit version
+        // in the meantime is invalidated. The queue lives on the (shared)
+        // adapter, so this covers writes routed through wrapper databases too.
+        if (!$this->adapter->inTransaction()) {
+            foreach ($this->adapter->dequeueCachePurges() as [$collectionId, $id]) {
+                $this->purgeCachedDocumentInternal($collectionId, $id);
+            }
+        }
+
+        return $result;
     }
 
     /**
@@ -6397,9 +6419,6 @@ class Database
             return $document;
         }
 
-        // Purge again after commit so readers cannot re-cache the pre-commit version
-        $this->purgeCachedDocumentInternal($collection->getId(), $id);
-
         if (!$this->inBatchRelationshipPopulation && $this->resolveRelationships) {
             $documents = $this->silent(fn () => $this->populateDocumentsRelationships([$document], $collection, $this->relationshipFetchDepth));
             $document = $documents[0];
@@ -7786,8 +7805,6 @@ class Database
         });
 
         if ($deleted) {
-            // Purge again after commit so readers cannot re-cache the pre-commit version
-            $this->purgeCachedDocumentInternal($collection->getId(), $id);
             $this->trigger(self::EVENT_DOCUMENT_DELETE, $document);
         }
 
@@ -8389,6 +8406,15 @@ class Database
 
         $this->cache->purge($collectionKey, $documentKey);
         $this->cache->purge($documentKey);
+
+        // A purge inside an open transaction targets rows that are not yet
+        // committed. A concurrent reader can re-populate the cache with the
+        // pre-commit version before this transaction commits, leaving stale
+        // data behind. Queue the key to purge again once the outermost
+        // transaction commits and the new rows are visible to everyone.
+        if ($this->adapter->inTransaction()) {
+            $this->adapter->queueCachePurge($collectionId, $id);
+        }
 
         return true;
     }


### PR DESCRIPTION
## Problem

`updateDocument()` / `deleteDocument()` purge the document cache twice: once inside their transaction, then again "after commit" so a concurrent reader cannot re-cache the pre-commit version:

```php
$document = $this->withTransaction(fn () => { ...write...; $this->purgeCachedDocument(...); });
// "Purge again after commit so readers cannot re-cache the pre-commit version"
$this->purgeCachedDocumentInternal($collection->getId(), $id);
```

That second purge only lands after the real `COMMIT` **when the write owns the outermost transaction**. Transactions here are reference-counted (`Adapter::$inTransaction`, SAVEPOINTs for nested frames) — the real `COMMIT` only fires when the outermost frame closes.

When a caller wraps the write in its own `withTransaction()` (common — e.g. a read-modify-write with `forUpdate: true` for lost-update safety), the inner `updateDocument`'s "after commit" purge runs while `inTransaction > 0` — **before** the real commit. In that window, any concurrent reader reads the old committed row and re-populates the cache. The outer transaction then commits, and the cache is left holding the stale value.

## Fix

Queue every purge issued inside a transaction and replay it once the **outermost** frame commits, so the invalidation always lands after the rows are visible to other connections.

- `Adapter` — holds the `purgeAfterCommit` queue (keyed `collectionId:id`, deduped) + `queueCachePurge()` / `dequeueCachePurges()`. It lives on the adapter because transaction depth **and** the cache are shared there across `Database` wrappers — notably `Mirror`, which shares its source's adapter and cache.
- `purgeCachedDocumentInternal()` — when a transaction is open, also enqueues the key. This makes *every* purge (single-doc, relationship, bulk) self-healing, not just the two hand-patched spots.
- `Database::withTransaction()` — flushes the queue after the outermost commit; discards it on outermost rollback (nothing committed → nothing to invalidate).
- `SQL::reconnect()` — clears the queue defensively.
- Removed the two now-redundant "Purge again after commit" band-aids in `updateDocument`/`deleteDocument`.

## Verification

Reproduced against real MariaDB + Redis with genuine multi-process concurrency: one writer running the nested-transaction shape (`withTransaction { getDocument(forUpdate) + updateDocument }`) + 16 reader processes hammering `getDocument` through shared Redis to poison the cache. Single writer, so every non-matching read is unambiguously stale (the previous value).

| Version | Writes | Concurrent poison reads | Stale reads | Stale rate |
|---|---|---|---|---|
| Before | 3000 | 585,933 | 1219 | **40.6%** |
| After  | 3000 | 467,647 | 0 | **0%** |

## Notes

- Pint ✓. PHPStan level 7 introduces no new findings (pre-existing `Cache::getGeneration`/`saveWithLease` errors are unrelated, from an out-of-date `utopia-php/cache` in the local vendor).
- Motivating downstream case: flaky Appwrite email-template read-after-write tests, where the project config is written inside an endpoint-level `withTransaction` and read back from the cached project document. Callers currently work around this with manual `purgeCachedDocument()` calls after the transaction; this fix removes that need.

Draft pending the repo's own test suite run.