### PR TITLE
fix(mongo): honour query timeout on count() and sum() aggregate paths

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -349,6 +349,11 @@ abstract class Adapter
     {
         // Clear existing callback
         $this->before($event, 'timeout');
+
+        // Adapters that apply the timeout from this property on every statement
+        // (e.g. Postgres SET statement_timeout) would otherwise keep enforcing a
+        // cleared timeout on all subsequent queries.
+        $this->timeout = 0;
     }
 
     /**

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -2718,10 +2718,6 @@ class Mongo extends Adapter
             $options['limit'] = $max;
         }
 
-        if ($this->timeout) {
-            $options['maxTimeMS'] = $this->timeout;
-        }
-
         // Build filters from queries
         $filters = $this->buildFilters($queries);
 
@@ -2745,6 +2741,11 @@ class Mongo extends Adapter
          **/
 
         $options = $this->getTransactionOptions();
+
+        if ($this->timeout) {
+            $options['maxTimeMS'] = $this->timeout;
+        }
+
         $pipeline = [];
 
         // Add match stage if filters are provided
@@ -2848,6 +2849,11 @@ class Mongo extends Adapter
         ];
 
         $options = $this->getTransactionOptions();
+
+        if ($this->timeout) {
+            $options['maxTimeMS'] = $this->timeout;
+        }
+
         return $this->client->aggregate($name, $pipeline, $options)->cursor->firstBatch[0]->total ?? 0;
     }
 

--- a/src/Database/Adapter/Mongo.php
+++ b/src/Database/Adapter/Mongo.php
@@ -2712,11 +2712,6 @@ class Mongo extends Adapter
         $this->escapeQueryAttributes($collection, $queries);
 
         $filters = [];
-        $options = [];
-
-        if (!\is_null($max) && $max > 0) {
-            $options['limit'] = $max;
-        }
 
         // Build filters from queries
         $filters = $this->buildFilters($queries);
@@ -2791,6 +2786,11 @@ class Mongo extends Adapter
 
             return 0;
         } catch (MongoException $e) {
+            $processed = $this->processException($e);
+            if ($processed instanceof TimeoutException) {
+                throw $processed;
+            }
+
             return 0;
         }
     }
@@ -2854,7 +2854,11 @@ class Mongo extends Adapter
             $options['maxTimeMS'] = $this->timeout;
         }
 
-        return $this->client->aggregate($name, $pipeline, $options)->cursor->firstBatch[0]->total ?? 0;
+        try {
+            return $this->client->aggregate($name, $pipeline, $options)->cursor->firstBatch[0]->total ?? 0;
+        } catch (MongoException $e) {
+            throw $this->processException($e);
+        }
     }
 
     /**

--- a/tests/e2e/Adapter/Scopes/GeneralTests.php
+++ b/tests/e2e/Adapter/Scopes/GeneralTests.php
@@ -126,8 +126,10 @@ trait GeneralTests
 
             $thrown = null;
             try {
+                // A substring scan forces the engine to walk every huge value; a
+                // cheap filter (e.g. notEqual) lets COUNT finish inside the timeout.
                 $database->count('count-timeouts', [
-                    Query::notEqual('longtext', 'appwrite'),
+                    Query::contains('longtext', ['needle-that-does-not-exist']),
                 ]);
             } catch (\Exception $e) {
                 $thrown = $e;

--- a/tests/e2e/Adapter/Scopes/GeneralTests.php
+++ b/tests/e2e/Adapter/Scopes/GeneralTests.php
@@ -109,9 +109,10 @@ trait GeneralTests
             )
         );
 
+        $longtext = file_get_contents(__DIR__ . '/../../../resources/longtext.txt');
         for ($i = 0; $i < 20; $i++) {
             $database->createDocument('count-timeouts', new Document([
-                'longtext' => file_get_contents(__DIR__ . '/../../../resources/longtext.txt'),
+                'longtext' => $longtext,
                 '$permissions' => [
                     Permission::read(Role::any()),
                     Permission::update(Role::any()),
@@ -120,17 +121,22 @@ trait GeneralTests
             ]));
         }
 
-        $database->setTimeout(1);
-
         try {
-            $database->count('count-timeouts', [
-                Query::notEqual('longtext', 'appwrite'),
-            ]);
-            $this->fail('count() failed to throw a timeout exception');
-        } catch (\Exception $e) {
+            $database->setTimeout(1);
+
+            $thrown = null;
+            try {
+                $database->count('count-timeouts', [
+                    Query::notEqual('longtext', 'appwrite'),
+                ]);
+            } catch (\Exception $e) {
+                $thrown = $e;
+            }
+
+            $this->assertInstanceOf(TimeoutException::class, $thrown, 'count() must throw a timeout exception');
+        } finally {
             $database->clearTimeout();
             $database->deleteCollection('count-timeouts');
-            $this->assertInstanceOf(TimeoutException::class, $e);
         }
     }
 

--- a/tests/e2e/Adapter/Scopes/GeneralTests.php
+++ b/tests/e2e/Adapter/Scopes/GeneralTests.php
@@ -86,7 +86,53 @@ trait GeneralTests
         }
     }
 
+    public function testCountTimeout(): void
+    {
+        if (!$this->getDatabase()->getAdapter()->getSupportForTimeouts()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
 
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $database->createCollection('count-timeouts');
+
+        $this->assertEquals(
+            true,
+            $database->createAttribute(
+                collection: 'count-timeouts',
+                id: 'longtext',
+                type: Database::VAR_STRING,
+                size: 100000000,
+                required: true
+            )
+        );
+
+        for ($i = 0; $i < 20; $i++) {
+            $database->createDocument('count-timeouts', new Document([
+                'longtext' => file_get_contents(__DIR__ . '/../../../resources/longtext.txt'),
+                '$permissions' => [
+                    Permission::read(Role::any()),
+                    Permission::update(Role::any()),
+                    Permission::delete(Role::any())
+                ]
+            ]));
+        }
+
+        $database->setTimeout(1);
+
+        try {
+            $database->count('count-timeouts', [
+                Query::notEqual('longtext', 'appwrite'),
+            ]);
+            $this->fail('count() failed to throw a timeout exception');
+        } catch (\Exception $e) {
+            $database->clearTimeout();
+            $database->deleteCollection('count-timeouts');
+            $this->assertInstanceOf(TimeoutException::class, $e);
+        }
+    }
 
     public function testPreserveDatesUpdate(): void
     {


### PR DESCRIPTION
## Problem

The Mongo adapter drops `maxTimeMS` on the `count()` and `sum()` aggregation paths, so those operations run **unbounded** even when a query timeout is set via `setTimeout()`:

- `count()` sets `$options['maxTimeMS']` early, but then **reassigns** `$options = $this->getTransactionOptions();` before building the aggregate pipeline, discarding the timeout.
- `sum()` never sets `maxTimeMS` at all.

`find()` is unaffected (it sets `maxTimeMS` on the options it actually passes), which is why this went unnoticed.

Impact: a `total=true` document list issues `count()`, so a large/slow Mongo read hangs until the client gives up instead of failing fast with a `Timeout`. Downstream (Appwrite Cloud DocumentsDB) this surfaced as a request stuck ~90s → 503, tying up a worker the whole time.

## Fix

Set `maxTimeMS` on the options actually passed to `aggregate()` in both `count()` and `sum()`, and remove the now-dead early assignment in `count()`.

## Test

`testCountTimeout` (shared adapter scope): builds a large collection, sets a 1ms timeout, and asserts `count()` throws `Timeout`. Fails without this change on Mongo (count completes unbounded); passes with it. `count()` is type-agnostic so it is safe across all timeout-supporting adapters (Mongo `maxTimeMS`, MariaDB `MAX_EXECUTION_TIME`, Postgres `statement_timeout`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for aggregation-based count and sum operations, applying very short limits more consistently.
  * When clearing timeouts, the adapter now fully resets its internal timeout state to avoid carrying limits into later statements.
* **Tests**
  * Added an end-to-end test covering count behavior under extremely short timeouts, validating that timeout exceptions are raised when supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->