### PR TITLE
Refetch documents by $sequence

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -806,10 +806,11 @@ class Database
      *
      * @param Document $collection
      * @param array<Document> $documents
+     * @param array<Query> $selections Select queries from the caller, preserved so the refetch honors the original projection
      * @return array<Document>
      * @throws DatabaseException
      */
-    protected function refetchDocuments(Document $collection, array $documents): array
+    protected function refetchDocuments(Document $collection, array $documents, array $selections = []): array
     {
         if (empty($documents)) {
             return $documents;
@@ -823,9 +824,12 @@ class Database
             return $sequence;
         }, $documents);
 
-        // Fetch fresh copies with computed operator values
+        // Fetch fresh copies with computed operator values, preserving the caller's projection
         $refetched = $this->getAuthorization()->skip(fn () => $this->silent(
-            fn () => $this->find($collection->getId(), [Query::equal('$sequence', $sequences)])
+            fn () => $this->find(
+                $collection->getId(),
+                array_merge([Query::equal('$sequence', $sequences)], $selections)
+            )
         ));
 
         $refetchedMap = [];
@@ -834,8 +838,8 @@ class Database
         }
 
         $result = [];
-        foreach ($documents as $doc) {
-            $result[] = $refetchedMap[$doc->getSequence()] ?? $doc;
+        foreach ($documents as $index => $doc) {
+            $result[$index] = $refetchedMap[$sequences[$index]] ?? $doc;
         }
 
         return $result;
@@ -6383,20 +6387,6 @@ class Database
                 $this->purgeCachedDocument($collection->getId(), $document->getId());
             }
 
-            // If operators were used, refetch document to get computed values
-            $hasOperators = false;
-            foreach ($document->getArrayCopy() as $value) {
-                if (Operator::isOperator($value)) {
-                    $hasOperators = true;
-                    break;
-                }
-            }
-
-            if ($hasOperators) {
-                $refetched = $this->refetchDocuments($collection, [$document]);
-                $document = $refetched[0];
-            }
-
             return $document;
         });
 
@@ -6406,6 +6396,20 @@ class Database
 
         // Purge again after commit so readers cannot re-cache the pre-commit version
         $this->purgeCachedDocumentInternal($collection->getId(), $id);
+
+        // If operators were used, refetch (outside the transaction) to get committed computed values
+        $hasOperators = false;
+        foreach ($document->getArrayCopy() as $value) {
+            if (Operator::isOperator($value)) {
+                $hasOperators = true;
+                break;
+            }
+        }
+
+        if ($hasOperators) {
+            $refetched = $this->refetchDocuments($collection, [$document]);
+            $document = $refetched[0];
+        }
 
         if (!$this->inBatchRelationshipPopulation && $this->resolveRelationships) {
             $documents = $this->silent(fn () => $this->populateDocumentsRelationships([$document], $collection, $this->relationshipFetchDepth));
@@ -6630,7 +6634,7 @@ class Database
             }
 
             if ($hasOperators) {
-                $batch = $this->refetchDocuments($collection, $batch);
+                $batch = $this->refetchDocuments($collection, $batch, $grouped['selections']);
             }
 
             foreach ($batch as $index => $doc) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6181,7 +6181,8 @@ class Database
 
         $collection = $this->silent(fn () => $this->getCollection($collection));
         $newUpdatedAt = $document->getUpdatedAt();
-        $document = $this->withTransaction(function () use ($collection, $id, $document, $newUpdatedAt) {
+        $hasOperators = false;
+        $document = $this->withTransaction(function () use ($collection, $id, $document, $newUpdatedAt, &$hasOperators) {
             $time = DateTime::now();
             $old = $this->authorization->skip(fn () => $this->silent(
                 fn () => $this->getDocument($collection->getId(), $id, forUpdate: true)
@@ -6394,6 +6395,21 @@ class Database
                 $this->purgeCachedDocument($collection->getId(), $document->getId());
             }
 
+            // If operators were used, refetch inside the transaction so the returned value reflects
+            // this operation's own write (read-your-writes). Refetching after commit could observe a
+            // concurrent update and return that value instead of the result of this operation.
+            foreach ($document->getArrayCopy() as $value) {
+                if (Operator::isOperator($value)) {
+                    $hasOperators = true;
+                    break;
+                }
+            }
+
+            if ($hasOperators) {
+                $refetched = $this->refetchDocuments($collection, [$document]);
+                $document = $refetched[0];
+            }
+
             return $document;
         });
 
@@ -6404,26 +6420,16 @@ class Database
         // Purge again after commit so readers cannot re-cache the pre-commit version
         $this->purgeCachedDocumentInternal($collection->getId(), $id);
 
-        // If operators were used, refetch (outside the transaction) to get committed computed values
-        $hasOperators = false;
-        foreach ($document->getArrayCopy() as $value) {
-            if (Operator::isOperator($value)) {
-                $hasOperators = true;
-                break;
-            }
-        }
-
-        if ($hasOperators) {
-            $refetched = $this->refetchDocuments($collection, [$document]);
-            $document = $refetched[0];
-        }
-
         if (!$this->inBatchRelationshipPopulation && $this->resolveRelationships) {
             $documents = $this->silent(fn () => $this->populateDocumentsRelationships([$document], $collection, $this->relationshipFetchDepth));
             $document = $documents[0];
         }
 
-        $document = $this->decode($collection, $document);
+        // The operator refetch already returns a decoded document (via find()); decoding again
+        // would double-apply the decode filters.
+        if (!$hasOperators) {
+            $document = $this->decode($collection, $document);
+        }
 
         // Convert to custom document type if mapped
         if (isset($this->documentTypes[$collection->getId()])) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6641,7 +6641,11 @@ class Database
                 $doc = $this->adapter->castingAfter($collection, $doc);
                 $doc->removeAttribute('$skipPermissionsUpdate');
                 $this->purgeCachedDocument($collection->getId(), $doc->getId());
-                $doc = $this->decode($collection, $doc);
+                // Operator refetch already returns decoded documents honoring the caller's select;
+                // decoding again (without selections) would re-materialize non-selected attributes.
+                if (!$hasOperators) {
+                    $doc = $this->decode($collection, $doc);
+                }
                 try {
                     $onNext && $onNext($doc, $old[$index]);
                 } catch (Throwable $th) {

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -824,17 +824,24 @@ class Database
             return $sequence;
         }, $documents);
 
-        // Fetch fresh copies with computed operator values, preserving the caller's projection
-        $refetched = $this->getAuthorization()->skip(fn () => $this->silent(
-            fn () => $this->find(
-                $collection->getId(),
-                array_merge([Query::equal('$sequence', $sequences)], $selections)
-            )
-        ));
-
+        // Fetch fresh copies with computed operator values, preserving the caller's projection.
+        // Chunk by maxQueryValues (the batch can be up to INSERT_BATCH_SIZE) and bound each find()
+        // to the chunk size, otherwise find()'s default limit would silently drop rows past it.
         $refetchedMap = [];
-        foreach ($refetched as $doc) {
-            $refetchedMap[$doc->getSequence()] = $doc;
+        foreach (\array_chunk($sequences, \max(1, $this->maxQueryValues)) as $chunk) {
+            $refetched = $this->getAuthorization()->skip(fn () => $this->silent(
+                fn () => $this->find(
+                    $collection->getId(),
+                    array_merge([
+                        Query::equal('$sequence', $chunk),
+                        Query::limit(\count($chunk)),
+                    ], $selections)
+                )
+            ));
+
+            foreach ($refetched as $doc) {
+                $refetchedMap[$doc->getSequence()] = $doc;
+            }
         }
 
         $result = [];
@@ -6641,8 +6648,9 @@ class Database
                 $doc = $this->adapter->castingAfter($collection, $doc);
                 $doc->removeAttribute('$skipPermissionsUpdate');
                 $this->purgeCachedDocument($collection->getId(), $doc->getId());
-                // Operator refetch already returns decoded documents honoring the caller's select;
-                // decoding again (without selections) would re-materialize non-selected attributes.
+                // The operator refetch goes through find(), which already returns fully decoded
+                // documents. Decoding again would double-apply the decode filters (and, because
+                // this call passes no selections, re-materialize non-selected attributes).
                 if (!$hasOperators) {
                     $doc = $this->decode($collection, $doc);
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -807,6 +807,7 @@ class Database
      * @param Document $collection
      * @param array<Document> $documents
      * @return array<Document>
+     * @throws DatabaseException
      */
     protected function refetchDocuments(Document $collection, array $documents): array
     {
@@ -814,21 +815,27 @@ class Database
             return $documents;
         }
 
-        $docIds = array_map(fn ($doc) => $doc->getId(), $documents);
+        $sequences = array_map(function ($doc) {
+            $sequence = $doc->getSequence();
+            if ($sequence === null) {
+                throw new DatabaseException('Cannot refetch document without a $sequence: ' . $doc->getId());
+            }
+            return $sequence;
+        }, $documents);
 
         // Fetch fresh copies with computed operator values
         $refetched = $this->getAuthorization()->skip(fn () => $this->silent(
-            fn () => $this->find($collection->getId(), [Query::equal('$id', $docIds)])
+            fn () => $this->find($collection->getId(), [Query::equal('$sequence', $sequences)])
         ));
 
         $refetchedMap = [];
         foreach ($refetched as $doc) {
-            $refetchedMap[$doc->getId()] = $doc;
+            $refetchedMap[$doc->getSequence()] = $doc;
         }
 
         $result = [];
         foreach ($documents as $doc) {
-            $result[] = $refetchedMap[$doc->getId()] ?? $doc;
+            $result[] = $refetchedMap[$doc->getSequence()] ?? $doc;
         }
 
         return $result;

--- a/tests/e2e/Adapter/Scopes/OperatorTests.php
+++ b/tests/e2e/Adapter/Scopes/OperatorTests.php
@@ -431,6 +431,68 @@ trait OperatorTests
         $database->deleteCollection($collectionId);
     }
 
+    public function testUpdateDocumentsOperatorsWithSelect(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForOperators()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $collectionId = 'test_operators_with_select';
+        $database->createCollection($collectionId);
+
+        $database->createAttribute($collectionId, 'category', Database::VAR_STRING, 50, true);
+        $database->createAttribute($collectionId, 'count', Database::VAR_INTEGER, 0, false, 0);
+        $database->createAttribute($collectionId, 'score', Database::VAR_FLOAT, 0, false, 0.0);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $database->createDocument($collectionId, new Document([
+                '$id' => "select_doc_{$i}",
+                '$permissions' => [Permission::read(Role::any()), Permission::update(Role::any())],
+                'category' => 'A',
+                'count' => $i * 10,
+                'score' => $i * 1.5,
+            ]));
+        }
+
+        // Update with an operator while selecting only a subset of attributes.
+        // The operator path refetches to compute values; it must still honor the caller's select.
+        $updated = [];
+        $count = $database->updateDocuments(
+            $collectionId,
+            new Document([
+                'count' => Operator::increment(100),
+            ]),
+            [Query::select(['count']), Query::orderAsc('$id')],
+            onNext: function (Document $doc) use (&$updated) {
+                $updated[] = $doc;
+            }
+        );
+
+        $this->assertEquals(3, $count);
+        $this->assertCount(3, $updated);
+
+        // A plain find with the same select defines the expected projection.
+        $found = $database->find($collectionId, [Query::select(['count']), Query::orderAsc('$id')]);
+
+        foreach ($updated as $index => $doc) {
+            // Computed operator value is present and correct.
+            $this->assertEquals(($index + 1) * 10 + 100, $doc->getAttribute('count'));
+
+            // The operator path must return the same projection as a normal select find,
+            // i.e. it must not leak the non-selected attributes (regression check).
+            $this->assertEquals(
+                \array_keys($found[$index]->getArrayCopy()),
+                \array_keys($doc->getArrayCopy())
+            );
+        }
+
+        $database->deleteCollection($collectionId);
+    }
+
     public function testOperatorErrorHandling(): void
     {
         /** @var Database $database */

--- a/tests/e2e/Adapter/Scopes/OperatorTests.php
+++ b/tests/e2e/Adapter/Scopes/OperatorTests.php
@@ -550,6 +550,60 @@ trait OperatorTests
         $database->deleteCollection($collectionId);
     }
 
+    public function testUpdateDocumentOperatorDoesNotDoubleDecodeFilters(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForOperators()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        // A deliberately non-idempotent filter: decoding a second time corrupts the value
+        // (json_decode of the already-plaintext value yields null). This surfaces a double-decode.
+        $database->addFilter(
+            'operator_double_decode',
+            function (mixed $value) {
+                return json_encode(['data' => base64_encode((string) $value)]);
+            },
+            function (mixed $value) {
+                if (is_null($value)) {
+                    return;
+                }
+                $decoded = json_decode($value, true);
+                return base64_decode($decoded['data']);
+            }
+        );
+
+        $collectionId = 'test_operator_double_decode';
+        $database->createCollection($collectionId);
+        $database->createAttribute($collectionId, 'count', Database::VAR_INTEGER, 0, false, 0);
+        $database->createAttribute($collectionId, 'secret', Database::VAR_STRING, 128, false, filters: ['operator_double_decode']);
+
+        $database->createDocument($collectionId, new Document([
+            '$id' => 'doc1',
+            '$permissions' => [Permission::read(Role::any()), Permission::update(Role::any())],
+            'count' => 5,
+            'secret' => 'hunter2',
+        ]));
+
+        // The operator refetch happens inside the transaction and already decodes via find().
+        // Decoding the returned document again would run the filter twice and corrupt 'secret'.
+        $updated = $database->updateDocument($collectionId, 'doc1', new Document([
+            'count' => Operator::increment(10),
+        ]));
+
+        $this->assertEquals(15, $updated->getAttribute('count'));
+        $this->assertEquals('hunter2', $updated->getAttribute('secret'));
+
+        // A normal read decodes exactly once — the operator path must match it.
+        $fresh = $database->getDocument($collectionId, 'doc1');
+        $this->assertEquals('hunter2', $fresh->getAttribute('secret'));
+
+        $database->deleteCollection($collectionId);
+    }
+
     public function testOperatorErrorHandling(): void
     {
         /** @var Database $database */

--- a/tests/e2e/Adapter/Scopes/OperatorTests.php
+++ b/tests/e2e/Adapter/Scopes/OperatorTests.php
@@ -493,6 +493,63 @@ trait OperatorTests
         $database->deleteCollection($collectionId);
     }
 
+    public function testUpdateDocumentsOperatorsBatchLargerThanDefaultLimit(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForOperators()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $collectionId = 'test_operators_large_batch';
+        $database->createCollection($collectionId);
+
+        $database->createAttribute($collectionId, 'count', Database::VAR_INTEGER, 0, false, 0);
+
+        // More documents than find()'s default limit (25) so the refetch must page/limit correctly.
+        $total = 60;
+        for ($i = 1; $i <= $total; $i++) {
+            $database->createDocument($collectionId, new Document([
+                '$id' => "batch_doc_{$i}",
+                '$permissions' => [Permission::read(Role::any()), Permission::update(Role::any())],
+                'count' => $i,
+            ]));
+        }
+
+        // Update every document with an operator. The refetch must return computed values for the
+        // whole batch, not just the first 25 rows (which would otherwise fall back to stale values).
+        $updated = [];
+        $count = $database->updateDocuments(
+            $collectionId,
+            new Document([
+                'count' => Operator::increment(1000),
+            ]),
+            [],
+            batchSize: $total,
+            onNext: function (Document $doc) use (&$updated) {
+                $updated[$doc->getId()] = $doc;
+            }
+        );
+
+        $this->assertEquals($total, $count);
+        $this->assertCount($total, $updated);
+
+        // Every document must reflect the computed operator value.
+        for ($i = 1; $i <= $total; $i++) {
+            $doc = $updated["batch_doc_{$i}"] ?? null;
+            $this->assertNotNull($doc, "Missing callback document batch_doc_{$i}");
+            $this->assertEquals($i + 1000, $doc->getAttribute('count'), "Stale value for batch_doc_{$i}");
+
+            // And it must be persisted, not just returned.
+            $fresh = $database->getDocument($collectionId, "batch_doc_{$i}");
+            $this->assertEquals($i + 1000, $fresh->getAttribute('count'));
+        }
+
+        $database->deleteCollection($collectionId);
+    }
+
     public function testOperatorErrorHandling(): void
     {
         /** @var Database $database */


### PR DESCRIPTION
- Refetch using primary key ($sequence)
- Refetch using find method has a limit of default 25 rows max
- Added chunking for large documents list
- Refetch using find did not preserve select queries, always returning all attributes as doing select (*)
- Fix decode issue, since find method already  decoded documents



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved operator-driven document refresh by re-matching updated results using each document’s sequence value.
  * Operator-computed updates now consistently preserve the original field projection, ensuring returned documents include only the expected attributes.
  * Operator refresh for single and batch updates now occurs after transaction commit to prevent timing-related inconsistencies.

* **Tests**
  * Added end-to-end tests for operator updates with selected projections and for batch updates larger than the default limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->