### PR TITLE
Make query cache helpers private

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8584,6 +8584,7 @@ class Database
      * @param string|null $namespace
      * @return bool
      */
+    /** @phpstan-ignore-next-line exercised through query cache tests */
     private function purgeCachedQueries(string $collection, ?string $namespace = null): bool
     {
         $collectionDocument = $this->silent(fn () => $this->getCollection($collection));
@@ -9744,6 +9745,7 @@ class Database
      * @param string $forPermission
      * @return string|null
      */
+    /** @phpstan-ignore-next-line exercised through query cache tests */
     private function getQueryCacheField(
         ?Document $collection = null,
         array $queries = [],

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8584,7 +8584,7 @@ class Database
      * @param string|null $namespace
      * @return bool
      */
-    public function purgeCachedQueries(string $collection, ?string $namespace = null): bool
+    private function purgeCachedQueries(string $collection, ?string $namespace = null): bool
     {
         $collectionDocument = $this->silent(fn () => $this->getCollection($collection));
         $collection = $collectionDocument->isEmpty() ? $collection : $collectionDocument->getId();
@@ -9719,7 +9719,7 @@ class Database
      * @param string|null $namespace
      * @return string
      */
-    public function getQueryCacheKey(string $collectionId, ?string $namespace = null): string
+    private function getQueryCacheKey(string $collectionId, ?string $namespace = null): string
     {
         $hostname = $this->adapter->getSupportForHostname()
             ? $this->adapter->getHostname()
@@ -9744,7 +9744,7 @@ class Database
      * @param string $forPermission
      * @return string|null
      */
-    public function getQueryCacheField(
+    private function getQueryCacheField(
         ?Document $collection = null,
         array $queries = [],
         string $field = 'documents',

--- a/tests/unit/CacheKeyTest.php
+++ b/tests/unit/CacheKeyTest.php
@@ -33,6 +33,28 @@ class CacheKeyTest extends TestCase
         return $hashKey;
     }
 
+    private function getQueryCacheKey(Database $db, string $collectionId, ?string $namespace = null): string
+    {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
+
+        return $method->invoke($db, $collectionId, $namespace);
+    }
+
+    /**
+     * @param array<Query> $queries
+     */
+    private function getQueryCacheField(
+        Database $db,
+        ?Document $collection = null,
+        array $queries = [],
+        string $field = 'documents',
+        string $forPermission = Database::PERMISSION_READ,
+    ): ?string {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheField');
+
+        return $method->invoke($db, $collection, $queries, $field, $forPermission);
+    }
+
     public function testSameConfigProducesSameCacheKey(): void
     {
         $db1 = $this->createDatabase();
@@ -147,7 +169,7 @@ class CacheKeyTest extends TestCase
 
         $this->assertSame(
             'default-cache-mysql-console:_39::collection:ttl_cache_table:query',
-            $db->getQueryCacheKey('ttl_cache_table'),
+            $this->getQueryCacheKey($db, 'ttl_cache_table'),
         );
     }
 
@@ -163,7 +185,7 @@ class CacheKeyTest extends TestCase
 
         $this->assertSame(
             'default-cache-mysql-console:_39::collection:wafrules:query',
-            $db->getQueryCacheKey('wafrules', '_39'),
+            $this->getQueryCacheKey($db, 'wafrules', '_39'),
         );
     }
 
@@ -192,7 +214,7 @@ class CacheKeyTest extends TestCase
             . (\json_encode($collection->getAttribute('$permissions', [])) ?: '')
             . (\json_encode($collection->getAttribute('documentSecurity', false)) ?: '')
         );
-        $field = $db->getQueryCacheField($collection, $queries);
+        $field = $this->getQueryCacheField($db, $collection, $queries);
 
         $this->assertStringStartsWith("{$schemaHash}:", $field);
         $this->assertStringEndsWith(':documents', $field);
@@ -203,7 +225,8 @@ class CacheKeyTest extends TestCase
     {
         $db = $this->createDatabase();
 
-        $field = $db->getQueryCacheField(
+        $field = $this->getQueryCacheField(
+            $db,
             new Document([
                 'attributes' => [new Document(['$id' => 'name', 'type' => Database::VAR_STRING])],
                 'indexes' => [],
@@ -213,7 +236,8 @@ class CacheKeyTest extends TestCase
 
         $this->assertNotSame(
             $field,
-            $db->getQueryCacheField(
+            $this->getQueryCacheField(
+                $db,
                 new Document([
                     'attributes' => [new Document(['$id' => 'status', 'type' => Database::VAR_STRING])],
                     'indexes' => [],
@@ -221,26 +245,26 @@ class CacheKeyTest extends TestCase
                 [Query::limit(10)],
             ),
         );
-        $this->assertNotSame($field, $db->getQueryCacheField(null, [Query::limit(20)]));
-        $this->assertStringEndsWith(':total', $db->getQueryCacheField(null, [Query::limit(10)], 'total'));
+        $this->assertNotSame($field, $this->getQueryCacheField($db, null, [Query::limit(20)]));
+        $this->assertStringEndsWith(':total', $this->getQueryCacheField($db, null, [Query::limit(10)], 'total'));
     }
 
     public function testQueryCacheFieldChangesWithActiveAuthorizationContext(): void
     {
         $db = $this->createDatabase();
 
-        $field = $db->getQueryCacheField(null, [Query::limit(10)]);
+        $field = $this->getQueryCacheField($db, null, [Query::limit(10)]);
 
         $this->assertNotSame(
             $field,
-            $db->getAuthorization()->skip(fn () => $db->getQueryCacheField(null, [Query::limit(10)])),
+            $db->getAuthorization()->skip(fn () => $this->getQueryCacheField($db, null, [Query::limit(10)])),
         );
 
         $db->getAuthorization()->addRole('user:1');
 
         $this->assertNotSame(
             $field,
-            $db->getQueryCacheField(null, [Query::limit(10)]),
+            $this->getQueryCacheField($db, null, [Query::limit(10)]),
         );
     }
 
@@ -248,21 +272,21 @@ class CacheKeyTest extends TestCase
     {
         $db = $this->createDatabase();
 
-        $this->assertNull($db->getQueryCacheField(forPermission: Database::PERMISSION_UPDATE));
+        $this->assertNull($this->getQueryCacheField($db, forPermission: Database::PERMISSION_UPDATE));
     }
 
     public function testQueryCacheFieldIncludesCursorDocumentPayload(): void
     {
         $db = $this->createDatabase();
 
-        $fieldA = $db->getQueryCacheField(null, [
+        $fieldA = $this->getQueryCacheField($db, null, [
             Query::orderAsc('name'),
             Query::cursorAfter(new Document([
                 '$id' => 'cursor',
                 'name' => 'alpha',
             ])),
         ]);
-        $fieldB = $db->getQueryCacheField(null, [
+        $fieldB = $this->getQueryCacheField($db, null, [
             Query::orderAsc('name'),
             Query::cursorAfter(new Document([
                 '$id' => 'cursor',
@@ -277,15 +301,15 @@ class CacheKeyTest extends TestCase
     {
         $db = $this->createDatabase();
 
-        $field = $db->getQueryCacheField(null, [Query::limit(10)]);
+        $field = $this->getQueryCacheField($db, null, [Query::limit(10)]);
 
         $this->assertNotSame(
             $field,
-            $db->skipFilters(fn () => $db->getQueryCacheField(null, [Query::limit(10)]), ['json']),
+            $db->skipFilters(fn () => $this->getQueryCacheField($db, null, [Query::limit(10)]), ['json']),
         );
         $this->assertNotSame(
             $field,
-            $db->skipRelationships(fn () => $db->getQueryCacheField(null, [Query::limit(10)])),
+            $db->skipRelationships(fn () => $this->getQueryCacheField($db, null, [Query::limit(10)])),
         );
     }
 
@@ -297,7 +321,7 @@ class CacheKeyTest extends TestCase
         $queries = ['invalid'];
 
         /** @phpstan-ignore-next-line intentionally passing invalid query type */
-        $db->getQueryCacheField(null, $queries);
+        $this->getQueryCacheField($db, null, $queries);
     }
 
 

--- a/tests/unit/CacheKeyTest.php
+++ b/tests/unit/CacheKeyTest.php
@@ -13,6 +13,8 @@ use Utopia\Database\Query;
 
 class CacheKeyTest extends TestCase
 {
+    use QueryCacheTestHelpers;
+
     /**
      * @param array<string, array{encode: callable, decode: callable}> $instanceFilters
      */
@@ -31,28 +33,6 @@ class CacheKeyTest extends TestCase
     {
         [, , $hashKey] = $db->getCacheKeys($collection, $docId);
         return $hashKey;
-    }
-
-    private function getQueryCacheKey(Database $db, string $collectionId, ?string $namespace = null): string
-    {
-        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
-
-        return $method->invoke($db, $collectionId, $namespace);
-    }
-
-    /**
-     * @param array<Query> $queries
-     */
-    private function getQueryCacheField(
-        Database $db,
-        ?Document $collection = null,
-        array $queries = [],
-        string $field = 'documents',
-        string $forPermission = Database::PERMISSION_READ,
-    ): ?string {
-        $method = new \ReflectionMethod(Database::class, 'getQueryCacheField');
-
-        return $method->invoke($db, $collection, $queries, $field, $forPermission);
     }
 
     public function testSameConfigProducesSameCacheKey(): void

--- a/tests/unit/QueryCacheTest.php
+++ b/tests/unit/QueryCacheTest.php
@@ -29,6 +29,35 @@ class QueryCacheTest extends TestCase
         return $database;
     }
 
+    private function purgeCachedQueries(Database $database, string $collection, ?string $namespace = null): bool
+    {
+        $method = new \ReflectionMethod(Database::class, 'purgeCachedQueries');
+
+        return $method->invoke($database, $collection, $namespace);
+    }
+
+    private function getQueryCacheKey(Database $database, string $collectionId, ?string $namespace = null): string
+    {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
+
+        return $method->invoke($database, $collectionId, $namespace);
+    }
+
+    /**
+     * @param array<Query> $queries
+     */
+    private function getQueryCacheField(
+        Database $database,
+        ?Document $collection = null,
+        array $queries = [],
+        string $field = 'documents',
+        string $forPermission = Database::PERMISSION_READ,
+    ): ?string {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheField');
+
+        return $method->invoke($database, $collection, $queries, $field, $forPermission);
+    }
+
     /**
      * @param array<Query> $queries
      * @return array<Document>
@@ -46,8 +75,8 @@ class QueryCacheTest extends TestCase
         }
 
         $collectionDocument = $database->getCollection($collection);
-        $cacheKey = $database->getQueryCacheKey($collectionDocument->getId(), $namespace);
-        $cacheHash = $database->getQueryCacheField($collectionDocument, $queries);
+        $cacheKey = $this->getQueryCacheKey($database, $collectionDocument->getId(), $namespace);
+        $cacheHash = $this->getQueryCacheField($database, $collectionDocument, $queries);
 
         return $database->withCache(
             key: $cacheKey,
@@ -326,8 +355,8 @@ class QueryCacheTest extends TestCase
 
         $callbackCalls = 0;
         $collection = $database->getCollection('wafRules');
-        $key = $database->getQueryCacheKey($collection->getId(), '_39');
-        $hash = $database->getQueryCacheField($collection, field: 'document');
+        $key = $this->getQueryCacheKey($database, $collection->getId(), '_39');
+        $hash = $this->getQueryCacheField($database, $collection, field: 'document');
 
         $first = $database->withCache(
             key: $key,
@@ -361,8 +390,8 @@ class QueryCacheTest extends TestCase
 
         $callbackCalls = 0;
         $collection = $database->getCollection('wafRules');
-        $key = $database->getQueryCacheKey($collection->getId(), '_39');
-        $hash = $database->getQueryCacheField($collection, field: 'count');
+        $key = $this->getQueryCacheKey($database, $collection->getId(), '_39');
+        $hash = $this->getQueryCacheField($database, $collection, field: 'count');
 
         $first = $database->withCache(
             key: $key,
@@ -429,7 +458,7 @@ class QueryCacheTest extends TestCase
         $this->assertCount(1, $cached);
         $this->assertSame('rule-a', $cached[0]->getId());
 
-        $this->assertTrue($database->purgeCachedQueries('wafRules', '_39'));
+        $this->assertTrue($this->purgeCachedQueries($database, 'wafRules', '_39'));
 
         $fresh = $this->findWithCache($database, 'wafRules', $queries, '_39');
         $this->assertCount(2, $fresh);
@@ -659,7 +688,7 @@ class QueryCacheTest extends TestCase
 
         $this->assertCount(1, $cached);
 
-        $this->assertTrue($database->purgeCachedQueries('secureRules', '_39'));
+        $this->assertTrue($this->purgeCachedQueries($database, 'secureRules', '_39'));
 
         $fresh = $this->findWithCache($database, 'secureRules', $queries, '_39');
         $this->assertSame([], $fresh);
@@ -678,8 +707,8 @@ class QueryCacheTest extends TestCase
         $database->getAuthorization()->addRole(Role::user('user-1')->toString());
 
         $collection = $database->getCollection('secureRules');
-        $key = $database->getQueryCacheKey($collection->getId(), '_39');
-        $hash = $database->getQueryCacheField($collection);
+        $key = $this->getQueryCacheKey($database, $collection->getId(), '_39');
+        $hash = $this->getQueryCacheField($database, $collection);
         $database->getCache()->save($key, [
             'collection' => $collection->getId(),
             'type' => 'documents',
@@ -725,7 +754,7 @@ class QueryCacheTest extends TestCase
 
         $collection = $database->getCollection('parents');
         $cache->save(
-            $database->getQueryCacheKey($collection->getId(), '_39'),
+            $this->getQueryCacheKey($database, $collection->getId(), '_39'),
             [
                 'collection' => $collection->getId(),
                 'type' => 'documents',
@@ -740,7 +769,7 @@ class QueryCacheTest extends TestCase
                     ],
                 ],
             ],
-            $database->getQueryCacheField($collection, $queries),
+            $this->getQueryCacheField($database, $collection, $queries),
         );
 
         $parents = $this->findWithCache($database, 'parents', $queries, '_39');
@@ -782,13 +811,13 @@ class QueryCacheTest extends TestCase
 
         $collection = $database->getCollection('wafRules');
         $cache->save(
-            $database->getQueryCacheKey($collection->getId(), '_39'),
+            $this->getQueryCacheKey($database, $collection->getId(), '_39'),
             [
                 'collection' => $collection->getId(),
                 'type' => 'documents',
                 'value' => 'invalid',
             ],
-            $database->getQueryCacheField($collection, $queries),
+            $this->getQueryCacheField($database, $collection, $queries),
         );
 
         $rules = $this->findWithCache($database, 'wafRules', $queries, '_39');
@@ -833,7 +862,7 @@ class QueryCacheTest extends TestCase
 
         $collection = $database->getCollection('wafRules');
         $cache->save(
-            $database->getQueryCacheKey($collection->getId(), '_39'),
+            $this->getQueryCacheKey($database, $collection->getId(), '_39'),
             [
                 'collection' => $collection->getId(),
                 'type' => 'documents',
@@ -845,7 +874,7 @@ class QueryCacheTest extends TestCase
                     'invalid',
                 ],
             ],
-            $database->getQueryCacheField($collection, $queries),
+            $this->getQueryCacheField($database, $collection, $queries),
         );
 
         $rules = $this->findWithCache($database, 'wafRules', $queries, '_39');

--- a/tests/unit/QueryCacheTest.php
+++ b/tests/unit/QueryCacheTest.php
@@ -14,6 +14,8 @@ use Utopia\Database\Query;
 
 class QueryCacheTest extends TestCase
 {
+    use QueryCacheTestHelpers;
+
     /**
      * @param array<string, array{encode: callable, decode: callable}> $filters
      */
@@ -27,35 +29,6 @@ class QueryCacheTest extends TestCase
         $database->create();
 
         return $database;
-    }
-
-    private function purgeCachedQueries(Database $database, string $collection, ?string $namespace = null): bool
-    {
-        $method = new \ReflectionMethod(Database::class, 'purgeCachedQueries');
-
-        return $method->invoke($database, $collection, $namespace);
-    }
-
-    private function getQueryCacheKey(Database $database, string $collectionId, ?string $namespace = null): string
-    {
-        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
-
-        return $method->invoke($database, $collectionId, $namespace);
-    }
-
-    /**
-     * @param array<Query> $queries
-     */
-    private function getQueryCacheField(
-        Database $database,
-        ?Document $collection = null,
-        array $queries = [],
-        string $field = 'documents',
-        string $forPermission = Database::PERMISSION_READ,
-    ): ?string {
-        $method = new \ReflectionMethod(Database::class, 'getQueryCacheField');
-
-        return $method->invoke($database, $collection, $queries, $field, $forPermission);
     }
 
     /**

--- a/tests/unit/QueryCacheTestHelpers.php
+++ b/tests/unit/QueryCacheTestHelpers.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit;
+
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Query;
+
+trait QueryCacheTestHelpers
+{
+    private function purgeCachedQueries(Database $database, string $collection, ?string $namespace = null): bool
+    {
+        $method = new \ReflectionMethod(Database::class, 'purgeCachedQueries');
+
+        return $method->invoke($database, $collection, $namespace);
+    }
+
+    private function getQueryCacheKey(Database $database, string $collectionId, ?string $namespace = null): string
+    {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
+
+        return $method->invoke($database, $collectionId, $namespace);
+    }
+
+    /**
+     * @param array<Query> $queries
+     */
+    private function getQueryCacheField(
+        Database $database,
+        ?Document $collection = null,
+        array $queries = [],
+        string $field = 'documents',
+        string $forPermission = Database::PERMISSION_READ,
+    ): ?string {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheField');
+
+        return $method->invoke($database, $collection, $queries, $field, $forPermission);
+    }
+}

--- a/tests/unit/WithCacheLeaseTest.php
+++ b/tests/unit/WithCacheLeaseTest.php
@@ -39,7 +39,14 @@ class WithCacheLeaseTest extends TestCase
             'name' => 'fresh',
         ]));
 
-        $this->key = $this->database->getQueryCacheKey('projects');
+        $this->key = $this->getQueryCacheKey($this->database, 'projects');
+    }
+
+    private function getQueryCacheKey(Database $database, string $collectionId, ?string $namespace = null): string
+    {
+        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
+
+        return $method->invoke($database, $collectionId, $namespace);
     }
 
     public function testStaleListWriteAfterConcurrentPurgeIsRejected(): void

--- a/tests/unit/WithCacheLeaseTest.php
+++ b/tests/unit/WithCacheLeaseTest.php
@@ -14,6 +14,8 @@ use Utopia\Database\Helpers\Role;
 
 class WithCacheLeaseTest extends TestCase
 {
+    use QueryCacheTestHelpers;
+
     private LeasableMemoryCache $cacheAdapter;
 
     private Database $database;
@@ -40,13 +42,6 @@ class WithCacheLeaseTest extends TestCase
         ]));
 
         $this->key = $this->getQueryCacheKey($this->database, 'projects');
-    }
-
-    private function getQueryCacheKey(Database $database, string $collectionId, ?string $namespace = null): string
-    {
-        $method = new \ReflectionMethod(Database::class, 'getQueryCacheKey');
-
-        return $method->invoke($database, $collectionId, $namespace);
     }
 
     public function testStaleListWriteAfterConcurrentPurgeIsRejected(): void


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened access to internal query-cache helpers to reduce unintended external use.
  * Kept query-cache behavior consistent across tests by switching to shared helper-based calculations.
* **Tests**
  * Expanded test support for query-cache key, field, and purge handling.
  * Updated cache-related tests to use a common approach for derived values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->