### PR TITLE
Upgrade PHP to 8.5 and validators to 0.3.*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN composer install \
     --no-scripts \
     --prefer-dist
 
-FROM php:8.4.18-cli-alpine3.22 AS compile
+FROM php:8.5-cli-alpine AS compile
 
 ENV PHP_REDIS_VERSION="6.3.0" \
     PHP_SWOOLE_VERSION="v6.1.6" \
@@ -55,7 +55,9 @@ RUN \
   && cd phpredis \
   && phpize \
   && ./configure \
-  && make && make install
+  && make && make install \
+  && mkdir -p /ext \
+  && cp $(php-config --extension-dir)/redis.so /ext/redis.so
 
 ## Swoole Extension
 FROM compile AS swoole
@@ -64,7 +66,9 @@ RUN \
   && cd swoole-src \
   && phpize \
   && ./configure --enable-http2 \
-  && make && make install
+  && make && make install \
+  && mkdir -p /ext \
+  && cp $(php-config --extension-dir)/swoole.so /ext/swoole.so
 
 ## PCOV Extension
 FROM compile AS pcov
@@ -73,7 +77,9 @@ RUN \
    && cd pcov \
    && phpize \
    && ./configure --enable-pcov \
-   && make && make install
+   && make && make install \
+   && mkdir -p /ext \
+   && cp $(php-config --extension-dir)/pcov.so /ext/pcov.so
 
 ## XDebug Extension
 FROM compile AS xdebug
@@ -82,7 +88,9 @@ RUN \
   cd xdebug && \
   phpize && \
   ./configure && \
-  make && make install
+  make && make install \
+  && mkdir -p /ext \
+  && cp $(php-config --extension-dir)/xdebug.so /ext/xdebug.so
 
 FROM compile AS final
 
@@ -92,6 +100,16 @@ ARG DEBUG=false
 ENV DEBUG=$DEBUG
 
 WORKDIR /usr/src/code
+
+COPY --from=composer /usr/local/src/vendor /usr/src/code/vendor
+COPY --from=swoole /ext/swoole.so /ext/swoole.so
+COPY --from=redis /ext/redis.so /ext/redis.so
+COPY --from=pcov /ext/pcov.so /ext/pcov.so
+COPY --from=xdebug /ext/xdebug.so /ext/xdebug.so
+
+RUN EXT_DIR=$(php-config --extension-dir) \
+  && mkdir -p $EXT_DIR \
+  && cp /ext/*.so $EXT_DIR/
 
 RUN echo extension=redis.so >> /usr/local/etc/php/conf.d/redis.ini
 RUN echo extension=swoole.so >> /usr/local/etc/php/conf.d/swoole.ini
@@ -104,12 +122,6 @@ RUN echo "opcache.enable_cli=1" >> $PHP_INI_DIR/php.ini
 
 RUN echo "memory_limit=1024M" >> $PHP_INI_DIR/php.ini
 
-COPY --from=composer /usr/local/src/vendor /usr/src/code/vendor
-COPY --from=swoole /usr/local/lib/php/extensions/no-debug-non-zts-20240924/swoole.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-COPY --from=redis /usr/local/lib/php/extensions/no-debug-non-zts-20240924/redis.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-COPY --from=pcov /usr/local/lib/php/extensions/no-debug-non-zts-20240924/pcov.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-COPY --from=xdebug /usr/local/lib/php/extensions/no-debug-non-zts-20240924/xdebug.so /usr/local/lib/php/extensions/no-debug-non-zts-20240924/
-
 COPY ./bin /usr/src/code/bin
 COPY ./src /usr/src/code/src
 COPY ./dev /usr/src/code/dev
@@ -118,6 +130,6 @@ COPY ./dev /usr/src/code/dev
 RUN if [ "$DEBUG" = "true" ]; then cp /usr/src/code/dev/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini; fi
 RUN if [ "$DEBUG" = "true" ]; then mkdir -p /tmp/xdebug; fi
 RUN if [ "$DEBUG" = "false" ]; then rm -rf /usr/src/code/dev; fi
-RUN if [ "$DEBUG" = "false" ]; then rm -f /usr/local/lib/php/extensions/no-debug-non-zts-20240924/xdebug.so; fi
+RUN if [ "$DEBUG" = "false" ]; then rm -f $(php-config --extension-dir)/xdebug.so; fi
 
 CMD [ "tail", "-f", "/dev/null" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,9 @@ RUN apk update && apk add --no-cache \
       && cd / \
       && rm -rf /tmp/mongodb)) \
  && docker-php-ext-enable mongodb \
- && docker-php-ext-install opcache pgsql pdo_mysql pdo_pgsql \
+ && for ext in opcache pgsql pdo_mysql pdo_pgsql; do \
+      docker-php-ext-configure $ext && make -C /usr/src/php/ext/$ext -j$(nproc) && cp /usr/src/php/ext/$ext/modules/*.so $(php-config --extension-dir)/; \
+    done \
  && apk del libpq-dev \
  && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM php:8.5-cli-alpine AS compile
 ENV PHP_REDIS_VERSION="6.3.0" \
     PHP_SWOOLE_VERSION="v6.1.6" \
     PHP_XDEBUG_VERSION="3.4.2" \
-    PHP_MONGODB_VERSION="2.1.1"
+    PHP_MONGODB_VERSION="2.3.3"
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apk update && apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN apk update && apk add --no-cache \
       && phpize \
       && ./configure \
       && make \
-      && make install \
+      && cp modules/mongodb.so $(php-config --extension-dir)/ \
       && cd / \
       && rm -rf /tmp/mongodb)) \
  && docker-php-ext-enable mongodb \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk update && apk add --no-cache \
     gcc \
     g++ \
     git \
+    file \
     brotli-dev \
     linux-headers \
     docker-cli \

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
         "coverage": "./vendor/bin/coverage-check ./tmp/clover.xml 90"
     },
     "require": {
-        "php": ">=8.4",
+        "php": ">=8.5",
         "ext-pdo": "*",
         "ext-mongodb": "*",
         "ext-mbstring": "*",
         "ext-redis": "*",
-        "utopia-php/validators": "0.2.*",
+        "utopia-php/validators": "0.3.*",
         "utopia-php/console": "0.1.*",
         "utopia-php/cache": "^3.1.0",
         "utopia-php/pools": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "303946dd9bf955b4399408d70489260b",
+    "content-hash": "17a58fb8abac14f34ded3cfc0c7efb73",
     "packages": [
         {
             "name": "brick/math",
@@ -2364,25 +2364,20 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.2.2",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "5d7d494e64457cd4eb67fdcfd9481f2c89796aa6"
+                "reference": "5a3ef67ce17c2e148da7895e8de699614f0afdfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/5d7d494e64457cd4eb67fdcfd9481f2c89796aa6",
-                "reference": "5d7d494e64457cd4eb67fdcfd9481f2c89796aa6",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/5a3ef67ce17c2e148da7895e8de699614f0afdfa",
+                "reference": "5a3ef67ce17c2e148da7895e8de699614f0afdfa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0"
-            },
-            "require-dev": {
-                "laravel/pint": "1.*",
-                "phpstan/phpstan": "2.*",
-                "phpunit/phpunit": "11.*"
+                "php": ">=8.5"
             },
             "type": "library",
             "autoload": {
@@ -2403,9 +2398,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.2.2"
+                "source": "https://github.com/utopia-php/validators/tree/0.3.0"
             },
-            "time": "2026-04-27T16:30:24+00:00"
+            "time": "2026-07-13T09:46:33+00:00"
         }
     ],
     "packages-dev": [
@@ -4654,7 +4649,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.4",
+        "php": ">=8.5",
         "ext-pdo": "*",
         "ext-mongodb": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
Upgrades `utopia-php/validators` from `0.2.*` to `0.3.*` and bumps PHP requirement to `>=8.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum supported PHP version to 8.5.
  * Upgraded the validation package to version 0.3.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->