### PR TITLE
fix(database): drop poisoned pooled connection on any lost-connection error (DAT-1904)

### DIFF
--- a/src/Database/PDOStatement.php
+++ b/src/Database/PDOStatement.php
@@ -10,11 +10,19 @@ use Utopia\Console;
  * against the fresh connection, previously bound parameters/columns/attributes
  * are replayed, and the failed execute() is retried.
  *
- * Recovery is attempted only for execute(), and only outside a transaction:
- * re-running any other method (fetch, rowCount, ...) without a fresh execute
- * would return data from an unexecuted statement, and a connection cannot be
- * healed in place mid-transaction (the uncommitted state is gone, so the call
- * is rethrown for Adapter::withTransaction to roll back and replay).
+ * Transparent retry is attempted only for execute(), and only outside a
+ * transaction: re-running any other method (fetch, rowCount, ...) without a
+ * fresh execute would return data from an unexecuted statement, and a
+ * connection cannot be healed in place mid-transaction (the uncommitted state
+ * is gone, so the call is rethrown for Adapter::withTransaction to roll back
+ * and replay).
+ *
+ * In every lost-connection case that cannot be retried, the poisoned connection
+ * is still discarded (reconnect) before the rethrow: the failed fetch/execute
+ * leaves the socket wire-desynced, and a pooled connection reclaimed with a
+ * partial result frame still buffered would bleed that frame into the next
+ * borrower's query. Reconnecting guarantees the connection returned to the pool
+ * is always clean.
  *
  * @mixin \PDOStatement
  * @implements \IteratorAggregate<int, mixed>
@@ -108,20 +116,28 @@ class PDOStatement implements \IteratorAggregate
         try {
             return $this->statement->{$method}(...$args);
         } catch (\Throwable $e) {
-            if (
-                \strcasecmp($method, 'execute') !== 0
-                || $this->pdo->inTransaction()
-                || !Connection::hasError($e)
-            ) {
+            if (!Connection::hasError($e)) {
                 throw $e;
             }
 
-            Console::warning('[Database] ' . $e->getMessage());
-            Console::warning('[Database] Lost connection detected. Re-preparing statement...');
+            if (\strcasecmp($method, 'execute') === 0 && !$this->pdo->inTransaction()) {
+                Console::warning('[Database] ' . $e->getMessage());
+                Console::warning('[Database] Lost connection detected. Re-preparing statement...');
 
-            $this->reprepare();
+                $this->reprepare();
 
-            return $this->statement->{$method}(...$args);
+                return $this->statement->{$method}(...$args);
+            }
+
+            // A lost connection during fetch/fetchAll/closeCursor, or during
+            // execute inside a transaction, cannot be retried in place -- but the
+            // socket is now wire-desynced and may still hold a partial result
+            // frame. Drop the connection so it can never be reclaimed to the pool
+            // and bleed that frame into the next borrower's query; the rethrow
+            // still lets withTransaction roll back and replay on a fresh one.
+            $this->pdo->reconnect();
+
+            throw $e;
         }
     }
 

--- a/tests/unit/PDOStatementTest.php
+++ b/tests/unit/PDOStatementTest.php
@@ -69,10 +69,12 @@ class PDOStatementTest extends TestCase
         $this->assertTrue($statement->execute());
     }
 
-    public function testExecuteRethrowsAndDoesNotReconnectInsideTransaction(): void
+    public function testExecuteInsideTransactionReconnectsThenRethrows(): void
     {
         $pdo = $this->pdoMock(inTransaction: true);
-        $pdo->expects($this->never())->method('reconnect');
+        // Cannot retry in place (the uncommitted state is gone), but the poisoned
+        // socket must still be dropped so it is not reclaimed to the pool.
+        $pdo->expects($this->once())->method('reconnect');
         $pdo->expects($this->never())->method('prepareNative');
 
         $statement = $this->statementMock();
@@ -133,15 +135,20 @@ class PDOStatementTest extends TestCase
         $this->assertSame($statement, $wrapper->getIterator());
     }
 
-    public function testDoesNotReconnectForNonExecuteMethods(): void
+    public function testFetchPhaseLostConnectionReconnectsBeforeRethrowing(): void
     {
+        // DAT-1904: a lost connection during the fetch phase leaves the socket
+        // wire-desynced (a partial result frame may remain buffered). The poisoned
+        // connection must be dropped (reconnect) before the rethrow so it can never
+        // be reclaimed to the pool and bled into the next borrower's query.
         $pdo = $this->pdoMock(inTransaction: false);
-        $pdo->expects($this->never())->method('reconnect');
+        $pdo->expects($this->once())->method('reconnect');
+        // Not re-prepared/retried in place: a fresh fetch would read no rows.
         $pdo->expects($this->never())->method('prepareNative');
 
         $statement = $this->statementMock();
         $statement->expects($this->once())
-            ->method('fetch')
+            ->method('fetchAll')
             ->willThrowException(new PDOException('server has gone away'));
 
         $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
@@ -149,7 +156,29 @@ class PDOStatementTest extends TestCase
         $this->expectException(PDOException::class);
         $this->expectExceptionMessage('server has gone away');
 
-        $wrapper->fetch();
+        $wrapper->fetchAll();
+    }
+
+    public function testDoesNotReconnectForNonExecuteNonConnectionError(): void
+    {
+        // A business-logic error (not a lost connection) leaves the pooled
+        // connection untouched: reconnecting a healthy connection would thrash the
+        // pool on every ordinary query error.
+        $pdo = $this->pdoMock(inTransaction: false);
+        $pdo->expects($this->never())->method('reconnect');
+        $pdo->expects($this->never())->method('prepareNative');
+
+        $statement = $this->statementMock();
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->willThrowException(new PDOException('SQLSTATE[42000]: Syntax error'));
+
+        $wrapper = new PDOStatement($pdo, $statement, 'SELECT 1');
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('Syntax error');
+
+        $wrapper->fetchAll();
     }
 
     public function testBindParamReplaysCurrentValueAfterReconnect(): void


### PR DESCRIPTION
## Problem (DAT-1904)

A pooled DB connection is checked out per operation from a worker-shared, per-host pool. The reconnect wrapper in `PDOStatement::__call()` only self-healed a lost connection for the **`execute()`-outside-a-transaction** case. Every other lost-connection error was rethrown while the underlying PDO connection was left untouched and reclaimed to the pool as-is:

- `fetch()` / `fetchAll()` / `closeCursor()` (the fetch phase of every read, e.g. `SQL::getDocument()` at `execute()` → `fetchAll()` → `closeCursor()`, and `SQL::find()`)
- `execute()` **inside** a transaction

A connection lost mid-result is **wire-desynced**: a partial or stale result frame can remain buffered on the socket (classically a client-side read timeout while the server keeps streaming the result set). Returning that connection to the pool poisons it.

## Blast radius

The next coroutine to pop the poisoned connection runs *its own* query and reads the **leftover frame** first:

- **Reads**: returns a different document than requested — cross-document, and **cross-tenant on shared shards** (the leftover rows belong to whoever ran the failed query).
- **Writes**: the desynced protocol state produces the "no active transaction" class of failures (see utopia-php/database#895, #896) and can corrupt transactional writes.

Because `Adapter::withTransaction()` replays its callback up to 2× and calls `getPDO()` afresh on each attempt, a reclaimed poisoned connection can be handed straight back into the replay.

## Fix

Extend the recovery in `PDOStatement::__call()` so that on **any** detected lost-connection error (same detection as today, `Connection::hasError()` / `DetectsLostConnections`) that is *not* the `execute()`-outside-transaction fast path, we call `PDO::reconnect()` to **discard the wire-desynced socket before rethrowing**. This guarantees the connection reclaimed to the pool is always clean.

- The existing transparent `execute()`-outside-transaction retry (reprepare + replay bindings + re-execute) is **unchanged**.
- Non-connection errors (syntax errors, constraint violations, business logic) still rethrow **untouched** — a healthy connection is never thrashed on ordinary query errors.
- Callers / `withTransaction` still see the rethrow and roll back / replay on the now-fresh connection. In the server-genuinely-down case, `reconnect()` may itself throw `Connection refused`, which is already in the lost-connection needle set, so callers classify it identically.

### Why the fetch phase must *reconnect* rather than retry

A fetch cannot be retried in place: re-running `fetch()` on a freshly prepared statement would read no rows. The only safe recovery is to drop the desynced socket and let the caller replay the whole operation on a clean connection.

## Tests

`tests/unit/PDOStatementTest.php` (mock-based, no live DB):

- **`testFetchPhaseLostConnectionReconnectsBeforeRethrowing`** (new, key regression) — a lost connection during `fetchAll()` invokes `reconnect()` exactly once and does **not** re-prepare, then the original exception propagates. Fails without this change (reconnect called 0×).
- **`testExecuteInsideTransactionReconnectsThenRethrows`** (updated) — `execute()` losing the connection inside a transaction now drops the socket before rethrowing. Fails without this change.
- **`testDoesNotReconnectForNonExecuteNonConnectionError`** (new) — a non-connection error during `fetchAll()` must **not** reconnect (no pool thrashing).
- The `execute()`-outside-transaction reprepare/replay tests are unchanged and still pass.

```
OK (9 tests, 35 assertions)   # with the fix
Tests: 3, Assertions: 10, Failures: 2   # the two reconnect-asserting tests fail without the fix
```

`vendor/bin/pint --test` passes on the changed files. (The local full-suite run hits a pre-existing, unrelated `Utopia\Cache\Feature\Leasable` fatal in `WithCacheLeaseTest.php` from a stale local `utopia-php/cache` install — present on clean `main`; CI's fresh install is unaffected.)

## Relationship to other work

- **Complements** utopia-php/database#898 (CLOUD-3N2A): that hardens the *stale-transaction rollback* side in `startTransaction()`; this hardens the *poisoned-socket* side so the connection is never reclaimed desynced. Different files, no overlap.
- **Defense in depth**: utopia-php/pools#33 destroys/recreates unhealthy connections on reclaim at the pool layer. This DB-layer fix makes the reclaimed PDO connection fresh regardless.
- **Downstream containment**: appwrite-labs/cloud#4827.

Refs: utopia-php/database#895, utopia-php/database#896, appwrite-labs/cloud#4827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of lost database connections during statement execution and result fetching.
  * Automatically retries eligible executions when no transaction is active.
  * Reconnects before reporting unrecoverable connection errors, helping prevent unstable connections from being reused.
  * Preserves immediate error reporting for non-connection-related failures.

* **Tests**
  * Expanded coverage for connection loss during transactions, fetching, and statement execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->