### PR TITLE
Translate getDocument PDO exceptions

### DIFF
--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -397,17 +397,36 @@ abstract class SQL extends Adapter
 
         $sql = $this->trigger(Database::EVENT_DOCUMENT_READ, $sql);
 
-        $stmt = $this->getPDO()->prepare($sql);
+        $stmt = null;
+        $document = [];
+        $exception = null;
 
-        $stmt->bindValue(':_uid', $id);
+        try {
+            $stmt = $this->getPDO()->prepare($sql);
 
-        if ($this->sharedTables) {
-            $stmt->bindValue(':_tenant', $this->getTenant());
+            $stmt->bindValue(':_uid', $id);
+
+            if ($this->sharedTables) {
+                $stmt->bindValue(':_tenant', $this->getTenant());
+            }
+
+            $this->execute($stmt);
+            $document = $stmt->fetchAll();
+        } catch (PDOException $e) {
+            $exception = $e;
+        } finally {
+            if ($stmt !== null) {
+                try {
+                    $stmt->closeCursor();
+                } catch (PDOException $e) {
+                    $exception ??= $e;
+                }
+            }
         }
 
-        $stmt->execute();
-        $document = $stmt->fetchAll();
-        $stmt->closeCursor();
+        if ($exception !== null) {
+            throw $this->processException($exception);
+        }
 
         if (empty($document)) {
             return new Document([]);

--- a/tests/unit/SQLGetDocumentTest.php
+++ b/tests/unit/SQLGetDocumentTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Unit;
+
+use Exception;
+use PDOException;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use Utopia\Database\Adapter\MySQL;
+use Utopia\Database\Adapter\Postgres;
+use Utopia\Database\Document;
+use Utopia\Database\Exception\Timeout as TimeoutException;
+
+final class SQLGetDocumentTest extends TestCase
+{
+    public function testTranslatesExecuteTimeoutClosesCursorAndPreservesOriginalWhenCleanupFails(): void
+    {
+        $exception = $this->createTimeoutException();
+
+        $statement = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statement->expects($this->once())
+            ->method('bindValue')
+            ->with(':_uid', 'document')
+            ->willReturn(true);
+        $statement->expects($this->once())
+            ->method('execute')
+            ->willThrowException($exception);
+        $statement->expects($this->never())
+            ->method('fetchAll');
+        $statement->expects($this->once())
+            ->method('closeCursor')
+            ->willThrowException(new PDOException('Failed to close cursor'));
+
+        $this->assertTimeout($this->createMySQL($statement), $exception);
+    }
+
+    public function testTranslatesFetchTimeoutAndClosesCursor(): void
+    {
+        $exception = $this->createTimeoutException();
+
+        $statement = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statement->expects($this->once())
+            ->method('bindValue')
+            ->with(':_uid', 'document')
+            ->willReturn(true);
+        $statement->expects($this->once())
+            ->method('execute')
+            ->willReturn(true);
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->willThrowException($exception);
+        $statement->expects($this->once())
+            ->method('closeCursor')
+            ->willReturn(true);
+
+        $this->assertTimeout($this->createMySQL($statement), $exception);
+    }
+
+    public function testUsesPostgresExecuteHook(): void
+    {
+        $statement = $this->getMockBuilder(\PDOStatement::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $statement->expects($this->once())
+            ->method('bindValue')
+            ->with(':_uid', 'document')
+            ->willReturn(true);
+        $statement->expects($this->once())
+            ->method('execute')
+            ->willReturn(true);
+        $statement->expects($this->once())
+            ->method('fetchAll')
+            ->willReturn([]);
+        $statement->expects($this->once())
+            ->method('closeCursor')
+            ->willReturn(true);
+
+        $pdo = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->willReturn($statement);
+        $pdo->expects($this->exactly(2))
+            ->method('exec')
+            ->withConsecutive(
+                ["SET statement_timeout = '25ms'"],
+                ['RESET statement_timeout']
+            )
+            ->willReturnOnConsecutiveCalls(0, 0);
+
+        $adapter = new Postgres($pdo);
+        $adapter->setDatabase('database');
+        $adapter->setNamespace('namespace');
+        $adapter->setTimeout(25);
+
+        $document = $adapter->getDocument(
+            new Document(['$id' => 'collection']),
+            'document'
+        );
+
+        $this->assertSame([], $document->getArrayCopy());
+    }
+
+    private function assertTimeout(MySQL $adapter, PDOException $exception): void
+    {
+        try {
+            $adapter->getDocument(
+                new Document(['$id' => 'collection']),
+                'document'
+            );
+        } catch (TimeoutException $timeout) {
+            $this->assertSame($exception, $timeout->getPrevious());
+
+            return;
+        }
+
+        $this->fail('Expected a timeout exception.');
+    }
+
+    private function createMySQL(\PDOStatement $statement): MySQL
+    {
+        $pdo = $this->getMockBuilder(\PDO::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $pdo->expects($this->once())
+            ->method('prepare')
+            ->willReturn($statement);
+
+        $adapter = new MySQL($pdo);
+        $adapter->setDatabase('database');
+        $adapter->setNamespace('namespace');
+
+        return $adapter;
+    }
+
+    private function createTimeoutException(): PDOException
+    {
+        $exception = new PDOException('Query execution was interrupted');
+        $code = new ReflectionProperty(Exception::class, 'code');
+        $code->setValue($exception, 'HY000');
+        $exception->errorInfo = ['HY000', 3024, 'Query execution was interrupted'];
+
+        return $exception;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Translate PDO failures from `SQL::getDocument()` through the adapter-specific exception mapper.

A request timeout can fire while `Database::find()` resolves collection metadata. `getDocument()` previously leaked the raw `PDOException`, so Appwrite returned a generic HTTP 500 instead of the expected database-timeout 408. The result depended on whether collection metadata was already cached.

The query now uses the adapter execution hook, always attempts cursor cleanup, and preserves the primary operation exception if cleanup also fails. This also ensures Postgres applies and resets its statement timeout on this path.

## Tests

- Added focused MySQL execute/fetch timeout translation coverage
- Added cleanup exception precedence coverage
- Added Postgres execute-hook timeout coverage
- Full unit suite: 404 tests, 2,263 assertions
- Pint
- PHPStan level 7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database document retrieval error handling.
  * Timeout errors are now consistently translated and preserved, even when cleanup encounters an additional error.
  * Ensured database cursors are closed reliably after document reads.
  * Improved PostgreSQL statement-timeout handling during document retrieval.

* **Tests**
  * Added coverage for timeout handling, cursor cleanup, and PostgreSQL execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->