### PR TITLE
Fix race condition in bulk upsert verification

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -7488,11 +7488,28 @@ class Database
             /**
              * @var array<Change> $chunk
              */
-            $batch = $this->withTransaction(fn () => $this->authorization->skip(fn () => $this->adapter->upsertDocuments(
-                $collection,
-                $attribute,
-                $chunk
-            )));
+            $batch = $this->withTransaction(function () use ($collection, $attribute, $chunk) {
+                // Re-fetch each existing document with FOR UPDATE to lock the rows
+                // and verify no concurrent modification occurred since the initial read.
+                foreach ($chunk as $change) {
+                    $old = $change->getOld();
+                    if ($old->isEmpty()) {
+                        continue;
+                    }
+                    $fresh = $this->authorization->skip(fn () => $this->silent(
+                        fn () => $this->getDocument($collection->getId(), $old->getId(), forUpdate: true)
+                    ));
+                    if (!$fresh->isEmpty() && $fresh->getUpdatedAt() !== $old->getUpdatedAt()) {
+                        throw new ConflictException('Document was updated after the request timestamp');
+                    }
+                }
+
+                return $this->authorization->skip(fn () => $this->adapter->upsertDocuments(
+                    $collection,
+                    $attribute,
+                    $chunk
+                ));
+            });
 
             $batch = $this->adapter->getSequences($collection->getId(), $batch);
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -7499,7 +7499,10 @@ class Database
                     $fresh = $this->authorization->skip(fn () => $this->silent(
                         fn () => $this->getDocument($collection->getId(), $old->getId(), forUpdate: true)
                     ));
-                    if (!$fresh->isEmpty() && $fresh->getUpdatedAt() !== $old->getUpdatedAt()) {
+                    if ($fresh->isEmpty()) {
+                        throw new ConflictException('Document was deleted after the request timestamp');
+                    }
+                    if ($fresh->getUpdatedAt() !== $old->getUpdatedAt()) {
                         throw new ConflictException('Document was updated after the request timestamp');
                     }
                 }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -7497,7 +7497,9 @@ class Database
                         continue;
                     }
                     $fresh = $this->authorization->skip(fn () => $this->silent(
-                        fn () => $this->getDocument($collection->getId(), $old->getId(), forUpdate: true)
+                        fn () => $this->getSharedTables() && $this->getTenantPerDocument()
+                            ? $this->withTenant($old->getTenant(), fn () => $this->getDocument($collection->getId(), $old->getId(), forUpdate: true))
+                            : $this->getDocument($collection->getId(), $old->getId(), forUpdate: true)
                     ));
                     if ($fresh->isEmpty()) {
                         throw new ConflictException('Document was deleted after the request timestamp');


### PR DESCRIPTION
## Summary

- Re-fetch existing documents with `FOR UPDATE` inside the transaction.
- Detect concurrent modifications before bulk upsert.
- Prevent silent data loss caused by stale reads during concurrent bulk updates.

Fixes appwrite/appwrite#12960

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger safeguards against conflicting simultaneous document updates.
  * Changes are now validated against the latest stored version before applying, including checking the persisted last-updated time to prevent accidental overwrites when data has changed since it was read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->