### PR TITLE
fix: refuse a non-string select value instead of fatalling on it

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -9520,6 +9520,9 @@ class Database
         foreach ($queries as $query) {
             if ($query->getMethod() == Query::TYPE_SELECT) {
                 foreach ($query->getValues() as $value) {
+                    if (!\is_string($value)) {
+                        throw new QueryException('Attribute selection must be a string, got ' . \get_debug_type($value));
+                    }
                     if (\str_contains($value, '.')) {
                         $relationshipSelections[] = $value;
                         continue;
@@ -10011,7 +10014,7 @@ class Database
 
             $values = $query->getValues();
             foreach ($values as $valueIndex => $value) {
-                if (!\str_contains($value, '.')) {
+                if (!\is_string($value) || !\str_contains($value, '.')) {
                     continue;
                 }
 

--- a/src/Database/Validator/Query/Select.php
+++ b/src/Database/Validator/Query/Select.php
@@ -68,6 +68,16 @@ class Select extends Base
             return false;
         }
 
+        // Before the duplicate check: array_unique() stringifies every array element
+        // to "Array", so two nested values collapse into one and report a misleading
+        // duplicate instead of the type error that is actually there.
+        foreach ($value->getValues() as $attribute) {
+            if (!\is_string($attribute)) {
+                $this->message = 'Attribute selection must be a string, got ' . \get_debug_type($attribute);
+                return false;
+            }
+        }
+
         if (\count($value->getValues()) !== \count(\array_unique($value->getValues()))) {
             $this->message = 'Duplicate attributes selected';
             return false;

--- a/tests/unit/SelectProjectionTest.php
+++ b/tests/unit/SelectProjectionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Cache\Adapter\Memory as CacheMemory;
+use Utopia\Cache\Cache;
+use Utopia\Database\Adapter\Memory as DatabaseMemory;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Exception\Query as QueryException;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+use Utopia\Database\Query;
+
+/**
+ * Drives Database::find(), the entry point the HTTP layer calls, rather than the
+ * validator alone.
+ *
+ * A malformed `select` value reached str_contains() and raised a TypeError. A
+ * TypeError is an Error, not an Exception, so it escaped the QueryException catch
+ * in the callers and surfaced as a 500 — where every other query method answers the
+ * same malformation with a typed refusal that becomes a 400.
+ */
+class SelectProjectionTest extends TestCase
+{
+    private Database $database;
+
+    protected function setUp(): void
+    {
+        $this->database = new Database(new DatabaseMemory(), new Cache(new CacheMemory()));
+        $this->database
+            ->setDatabase('utopiaTests')
+            ->setNamespace('select_' . \uniqid());
+
+        $this->database->create();
+        $this->database->createCollection('widgets');
+        $this->database->createAttribute('widgets', 'sku', Database::VAR_STRING, 255, false);
+        $this->database->createDocument('widgets', new Document([
+            '$id' => 'widget',
+            '$permissions' => [Permission::read(Role::any())],
+            'sku' => 'abc',
+        ]));
+    }
+
+    /**
+     * @param array<mixed> $values
+     *
+     * @dataProvider malformedSelections
+     */
+    public function testAMalformedSelectionIsRefusedRatherThanFatal(array $values): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Attribute selection must be a string, got');
+
+        $this->database->find('widgets', [Query::select($values)]);
+    }
+
+    /**
+     * @return array<string, array{array<mixed>}>
+     */
+    public static function malformedSelections(): array
+    {
+        return [
+            'nested array' => [[['sku']]],
+            'nested wildcard' => [[['*']]],
+            'mixed flat and nested' => [['sku', ['x']]],
+            'two nested values' => [[['a'], ['b']]],
+        ];
+    }
+
+    /**
+     * The refusal must be a catchable Exception. A TypeError is an Error, so a caller
+     * catching Exception — as the HTTP layer does — never sees it and returns a 500.
+     *
+     * @param array<mixed> $values
+     *
+     * @dataProvider malformedSelections
+     */
+    public function testTheRefusalIsCatchableAsAnException(array $values): void
+    {
+        $caught = null;
+
+        try {
+            $this->database->find('widgets', [Query::select($values)]);
+        } catch (\Exception $exception) {
+            $caught = $exception;
+        }
+
+        $this->assertInstanceOf(
+            QueryException::class,
+            $caught,
+            'a malformed selection must be catchable as an Exception, otherwise it escapes as a 500',
+        );
+    }
+
+    public function testTheLegitimateFlatFormStillProjects(): void
+    {
+        $rows = $this->database->find('widgets', [Query::select(['sku'])]);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('abc', $rows[0]->getAttribute('sku'));
+    }
+
+    public function testTheWildcardStillProjects(): void
+    {
+        $this->assertCount(1, $this->database->find('widgets', [Query::select(['*'])]));
+    }
+
+    /**
+     * The type check must not swallow the schema check that already worked.
+     */
+    public function testAnUnknownAttributeIsStillRefusedBySchema(): void
+    {
+        $this->expectException(QueryException::class);
+        $this->expectExceptionMessage('Attribute not found in schema: nope');
+
+        $this->database->find('widgets', [Query::select(['nope'])]);
+    }
+}

--- a/tests/unit/Validator/Query/SelectTest.php
+++ b/tests/unit/Validator/Query/SelectTest.php
@@ -49,4 +49,60 @@ class SelectTest extends TestCase
         $this->assertEquals('Invalid query', $this->validator->getDescription());
         $this->assertFalse($this->validator->isValid(Query::select(['name.artist'])));
     }
+
+    /**
+     * A non-string selection used to reach str_contains() and raise a TypeError,
+     * which is an Error rather than an Exception, so it escaped every catch on the
+     * way out and surfaced as a 500. Select was the only query method that answered
+     * a malformed value that way.
+     *
+     * @param array<mixed> $values
+     *
+     * @dataProvider nonStringSelections
+     */
+    public function testANonStringSelectionIsRefusedByType(array $values, string $expected): void
+    {
+        $this->assertFalse($this->validator->isValid(Query::select($values)));
+        $this->assertSame($expected, $this->validator->getDescription());
+    }
+
+    /**
+     * @return array<string, array{array<mixed>, string}>
+     */
+    public static function nonStringSelections(): array
+    {
+        return [
+            'nested array' => [[['attr']], 'Attribute selection must be a string, got array'],
+            'nested wildcard' => [[['*']], 'Attribute selection must be a string, got array'],
+            'mixed flat and nested' => [['attr', ['x']], 'Attribute selection must be a string, got array'],
+            'assoc array' => [[['a' => 1]], 'Attribute selection must be a string, got array'],
+            'integer' => [[1], 'Attribute selection must be a string, got int'],
+            'null' => [[null], 'Attribute selection must be a string, got null'],
+        ];
+    }
+
+    /**
+     * Two nested values used to collapse to one under array_unique(), which casts
+     * every array to the string "Array", so the duplicate check tripped first and
+     * reported a duplicate that was not there. The type check has to run before it.
+     *
+     * Parsed from JSON rather than built with Query::select(), because that is the
+     * path a hand-written HTTP client takes and the only one that can carry a value
+     * the constructor's array<string> type would reject.
+     */
+    public function testTwoNestedSelectionsReportTheTypeNotAFalseDuplicate(): void
+    {
+        $query = Query::parse('{"method":"select","values":[["a"],["b"]]}');
+
+        $this->assertFalse($this->validator->isValid($query));
+        $this->assertSame('Attribute selection must be a string, got array', $this->validator->getDescription());
+    }
+
+    public function testTheLegitimateFlatFormStillPasses(): void
+    {
+        $this->assertTrue($this->validator->isValid(Query::select(['attr'])));
+        $this->assertTrue($this->validator->isValid(Query::select(['*'])));
+        $this->assertTrue($this->validator->isValid(Query::select(['$id', '$createdAt'])));
+        $this->assertTrue($this->validator->isValid(Query::select(['artist.name'])));
+    }
 }


### PR DESCRIPTION
Fixes Appwrite [DAT-2222](https://linear.app/appwrite/issue/DAT-2222).

## The defect

A nested-array value on `select` returns **500 Server Error**. Every other query method answers the same malformation with a typed 400.

| query | before | after |
|---|---|---|
| `{"method":"select","values":["sku"]}` | 200 | 200 |
| `{"method":"select","values":[["sku"]]}` | **500** | 400 `Attribute selection must be a string, got array` |
| `{"method":"select","values":[["*"]]}` | **500** | 400 |
| `{"method":"equal","attribute":"sku","values":[["x"]]}` | 400 | 400 |
| `{"method":"limit","values":[[5]]}` | 400 | 400 |

`Select::isValid()` fed a `values` element straight into `str_contains()`. A `TypeError` is an `Error`, not an `Exception`, so it escaped the `QueryException` catch in every caller and came out as an unhandled 500.

## Why `select` was the only one

Structural, not accidental:

- `Filter` and `Order` read `$query->getAttribute()`, backed by `protected string $attribute` on `Query` — it can never be an array.
- `Limit` and `Offset` read `getValue()` into a `Numeric` validator, which does no string operation.
- `Cursor` reads `getValue()` through `UID`.
- `Select` is the only method whose payload lives in the untyped `values` array **and** is consumed as a string.

`Query::parseQuery()` validates that `values` *is* an array but never its element types, and `getValues()` is honestly typed `array<mixed>` — the callers were not.

## Sweep of the other query methods

Asked for by the issue, and answered by execution rather than reading: every method constant on `Query` was driven through `Validator\Queries\Documents` with the same nested-array value, before and after.

**Before — 1 fatal of 49:**
```
=== FATAL (would be HTTP 500) ===
select                 -> FATAL TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given
```

**After — 0 fatals of 49:**
```
=== FATAL (would be HTTP 500) ===
(none)
...
select                 -> 400  Invalid query: Attribute selection must be a string, got array
```

The remaining 48 already refused cleanly and are unchanged. Five (`exists`, `notExists`, `orderAsc`, `orderDesc`, `orderRandom`) accept the query because they ignore `values` entirely, which is correct.

## The fix

1. `Select::isValid()` rejects a non-string element with a typed message before any string operation.
2. It runs **before** the duplicate check on purpose: `array_unique()` casts every array to the string `"Array"`, so `[["a"],["b"]]` collapsed to one element and reported `Duplicate attributes selected` — a wrong answer that masked the real error. That is also why this looked intermittent: only value sets surviving the stringified dedupe reached the fatal.
3. The two downstream `str_contains()` sites in `Database.php` (`validateSelections()`, `processRelationshipQueries()`) are guarded too. They are unreachable while the validator refuses first, but live whenever validation is skipped (`skipValidation()`, internal and worker calls).

`[1]` and `[null]` now report the type rather than `Attribute not found in schema: 1` and a pair of PHP deprecations.

## Regression tests, seen red

Two levels. `tests/unit/SelectProjectionTest.php` drives **`Database::find()`** — the entry point the HTTP layer calls — not the validator alone.

### Red — fix reverted

```
Tests: 11, Assertions: 9, Errors: 4, Failures: 4.

3) SelectProjectionTest::testTheRefusalIsCatchableAsAnException with data set "nested array"
TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given

src/Database/Validator/Query/Select.php:77
src/Database/Validator/Queries.php:139
src/Database/Validator/IndexedQueries.php:89
src/Database/Database.php:8531
tests/unit/SelectProjectionTest.php:85

1) SelectProjectionTest::testAMalformedSelectionIsRefusedRatherThanFatal with data set "nested array"
Failed asserting that exception of type "TypeError" matches expected exception
"Utopia\Database\Exception\Query". Message was: "str_contains(): Argument #1
($haystack) must be of type string, array given"
```

Validator level, same revert:

```
There were 5 errors:

1) SelectTest::testANonStringSelectionIsRefusedByType with data set "nested array"
TypeError: str_contains(): Argument #1 ($haystack) must be of type string, array given
src/Database/Validator/Query/Select.php:77

3) SelectTest::testANonStringSelectionIsRefusedByType with data set "mixed flat and nested"
Array to string conversion
src/Database/Validator/Query/Select.php:71
```

Note error 3 lands on line 71, the `array_unique()` duplicate check — the reason the type check has to precede it.

### Green

```
tests/unit/SelectProjectionTest.php          OK (11 tests, 17 assertions)
tests/unit/Validator/Query/SelectTest.php    OK (10 tests, 23 assertions)
--testsuite unit                             OK (428 tests, 2309 assertions)
```

Coverage: nested array, nested wildcard, mixed flat+nested, two nested values, assoc array, int, null; that the refusal is catchable as an `Exception` (a `TypeError` is not, which is the whole defect); and that the legitimate flat form still projects, the wildcard still projects, and an unknown attribute is still refused by schema rather than swallowed by the new check.

The `testTwoNestedSelectionsReportTheTypeNotAFalseDuplicate` case is built with `Query::parse()` from JSON rather than `Query::select()`, because that is the path a hand-written HTTP client takes and the only one that can carry a value the constructor's `array<string>` type would reject.

## Verification

- `composer lint` (Pint) — passed
- `composer check` (PHPStan level 7, `src` + `tests`) — no errors
- `composer test --testsuite unit` — 428 tests, 2309 assertions, OK

The `e2e` suite needs MySQL/Postgres/Mongo/Redis via docker-compose and was not run locally; the change is adapter-independent (validator plus two guards in `Database.php`), and the new tests use the Memory adapter so they run in the unit suite everywhere.

## Blast radius for consumers

`Queries\Base::isSelectQueryAllowed()` wires `Select` wherever it is true, so in Appwrite the identical 500 is reachable on `listProjects` and `listDeployments`, not only on documents/rows.

Consumers need a release: `appwrite/cloud` locks `utopia-php/database` at **7.1.0** and resolves it through `appwrite/server-ce`'s `^7.0.0`, so a **7.1.1** patch tag flows to it with a plain `composer update utopia-php/database`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid, non-text field selections now return clear, catchable query errors instead of causing fatal failures.
  * Nested selections are reported with accurate type validation messages rather than misleading duplicate-selection errors.
  * Valid flat-field and wildcard projections continue to work as expected.
  * Unknown fields remain correctly rejected by schema validation.

* **Tests**
  * Added coverage for malformed selections, valid projections, wildcard queries, and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->