### PR TITLE
Allow validators 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-mongodb": "*",
         "ext-mbstring": "*",
         "ext-redis": "*",
-        "utopia-php/validators": "0.3.*",
+        "utopia-php/validators": "^0.4",
         "utopia-php/console": "0.1.*",
         "utopia-php/cache": "^4.0.0",
         "utopia-php/pools": "2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3730b91e8fc95a7ec85362b9bbfea3c0",
+    "content-hash": "fafbe3b9360593631979771dd786acbf",
     "packages": [
         {
             "name": "brick/math",
@@ -2368,16 +2368,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.3.1",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "d9c2269ebd2596a09681ccd2fd133eeedfcdf9ba"
+                "reference": "444a3dbfcd5f2d167214f07f6e8a9962048def1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/d9c2269ebd2596a09681ccd2fd133eeedfcdf9ba",
-                "reference": "d9c2269ebd2596a09681ccd2fd133eeedfcdf9ba",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/444a3dbfcd5f2d167214f07f6e8a9962048def1c",
+                "reference": "444a3dbfcd5f2d167214f07f6e8a9962048def1c",
                 "shasum": ""
             },
             "require": {
@@ -2402,9 +2402,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.3.1"
+                "source": "https://github.com/utopia-php/validators/tree/0.4.0"
             },
-            "time": "2026-07-14T11:55:48+00:00"
+            "time": "2026-08-07T10:53:49+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## What does this PR do?

Allows `utopia-php/database` to install with `utopia-php/validators` 0.4.

```json
"utopia-php/validators": "^0.4"
```

## Why?

Appwrite needs to consume validators 0.4, and database currently blocks resolution by requiring validators 0.3.

## Test Plan

```text
composer lint
composer check
composer test # blocked locally: docker compose tests service was not running
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the validation package dependency to the newer 0.4 release series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->