### PR TITLE
fix(mongo): bump to 1.5.3 so integers past int32 survive a read

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2202,16 +2202,16 @@
         },
         {
             "name": "utopia-php/mongo",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/mongo.git",
-                "reference": "20f9a644a356599fdd6265ba48696fc42a1f1881"
+                "reference": "be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/20f9a644a356599fdd6265ba48696fc42a1f1881",
-                "reference": "20f9a644a356599fdd6265ba48696fc42a1f1881",
+                "url": "https://api.github.com/repos/utopia-php/mongo/zipball/be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4",
+                "reference": "be29ee2d84b9f7efdfc6fea5b4b2d4bf95ff5ec4",
                 "shasum": ""
             },
             "require": {
@@ -2257,9 +2257,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/mongo/issues",
-                "source": "https://github.com/utopia-php/mongo/tree/1.5.2"
+                "source": "https://github.com/utopia-php/mongo/tree/1.5.3"
             },
-            "time": "2026-08-12T06:57:25+00:00"
+            "time": "2026-08-13T01:55:11+00:00"
         },
         {
             "name": "utopia-php/pools",

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -4934,6 +4934,77 @@ trait DocumentTests
         $this->assertEquals(round(39.50 + 25.99, 2), round($sum, 2));
     }
 
+    public function testIntegersBeyondInt32(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $database->createCollection(__FUNCTION__, attributes: [
+            new Document([
+                '$id' => 'amount',
+                'type' => Database::VAR_INTEGER,
+                'size' => 8,
+                'required' => true,
+                'signed' => true,
+                'array' => false,
+                'filters' => [],
+            ]),
+            new Document([
+                '$id' => 'amounts',
+                'type' => Database::VAR_INTEGER,
+                'size' => 8,
+                'required' => true,
+                'signed' => true,
+                'array' => true,
+                'filters' => [],
+            ]),
+        ], permissions: [
+            Permission::read(Role::any()),
+            Permission::create(Role::any()),
+        ], documentSecurity: false);
+
+        // Small values encode as int32, large ones as int64. Mongo hands the
+        // latter back wrapped, so both widths have to appear in one row.
+        $database->createDocument(__FUNCTION__, new Document([
+            '$id' => 'row1',
+            'amount' => 2000000000,
+            'amounts' => [-3408048000, -42, 3408048000, Database::MAX_BIG_INT],
+        ]));
+        $database->createDocument(__FUNCTION__, new Document([
+            '$id' => 'row2',
+            'amount' => 2000000000,
+            'amounts' => [-42],
+        ]));
+
+        foreach (['getDocument' => $database->getDocument(__FUNCTION__, 'row1'), 'find' => $database->find(__FUNCTION__, [Query::equal('$id', ['row1'])])[0]] as $path => $document) {
+            $this->assertIsInt($document->getAttribute('amount'), $path . ' returned a non-int scalar');
+
+            $amounts = $document->getAttribute('amounts');
+            foreach ($amounts as $index => $amount) {
+                $this->assertIsInt($amount, $path . ' returned a non-int at amounts[' . $index . ']');
+            }
+
+            $this->assertSame([-3408048000, -42, 3408048000, Database::MAX_BIG_INT], $amounts);
+
+            // An Int64 wrapper survives assertSame above but serialises as
+            // {"$numberLong":"..."}, which is what reaches an API client.
+            $this->assertSame(
+                '{"amount":2000000000,"amounts":[-3408048000,-42,3408048000,' . Database::MAX_BIG_INT . ']}',
+                \json_encode([
+                    'amount' => $document->getAttribute('amount'),
+                    'amounts' => $amounts,
+                ]),
+                $path . ' did not serialise as plain JSON numbers'
+            );
+        }
+
+        // sum() declares float|int, so a total past int32 is a return type
+        // violation unless the adapter hands back a native integer.
+        $sum = $database->sum(__FUNCTION__, 'amount');
+        $this->assertIsInt($sum);
+        $this->assertSame(4000000000, $sum);
+    }
+
     public function testEncodeDecode(): void
     {
         $collection = new Document([

--- a/tests/e2e/Adapter/Scopes/ObjectAttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/ObjectAttributeTests.php
@@ -964,6 +964,51 @@ trait ObjectAttributeTests
         $database->deleteCollection($collectionId);
     }
 
+    public function testObjectAttributeIntegersBeyondInt32(): void
+    {
+        /** @var Database $database */
+        $database = static::getDatabase();
+
+        if (!$database->getAdapter()->getSupportForObject()) {
+            $this->markTestSkipped('Adapter does not support object attributes');
+        }
+
+        $collectionId = ID::unique();
+        $database->createCollection($collectionId);
+        $this->createAttribute($database, $collectionId, 'meta', Database::VAR_OBJECT, 0, false);
+
+        // An object attribute has no per-key schema, so there is no typed cast
+        // to lean on: whatever the adapter decodes is what reaches the client.
+        $database->createDocument($collectionId, new Document([
+            '$id' => 'bigInts',
+            '$permissions' => [Permission::read(Role::any())],
+            'meta' => [
+                'small' => -42,
+                'count' => -3408048000,
+                'nested' => ['deep' => 3408048000],
+            ],
+        ]));
+
+        $database->purgeCachedDocument($collectionId, 'bigInts');
+        $meta = $database->getDocument($collectionId, 'bigInts')->getAttribute('meta');
+
+        $this->assertIsInt($meta['small']);
+        $this->assertIsInt($meta['count']);
+        $this->assertIsInt($meta['nested']['deep']);
+        $this->assertEquals([
+            'small' => -42,
+            'count' => -3408048000,
+            'nested' => ['deep' => 3408048000],
+        ], $meta);
+
+        // A BSON wrapper serialises as {"$numberLong":"..."}, which is what
+        // would reach an API client. Key order is not asserted because jsonb
+        // does not preserve it.
+        $this->assertStringNotContainsString('$numberLong', json_encode($meta));
+
+        $database->deleteCollection($collectionId);
+    }
+
     public function testObjectAttributeEmptyObject(): void
     {
         /** @var Database $database */

--- a/tests/e2e/Adapter/Scopes/ObjectAttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/ObjectAttributeTests.php
@@ -1004,7 +1004,7 @@ trait ObjectAttributeTests
         // A BSON wrapper serialises as {"$numberLong":"..."}, which is what
         // would reach an API client. Key order is not asserted because jsonb
         // does not preserve it.
-        $this->assertStringNotContainsString('$numberLong', json_encode($meta));
+        $this->assertStringNotContainsString('$numberLong', json_encode($meta, JSON_THROW_ON_ERROR));
 
         $database->deleteCollection($collectionId);
     }


### PR DESCRIPTION
Closes the utopia-php/database half of appwrite/appwrite#13175 — *BigInt[] Breaks MongoDb*.

## What was broken

`MongoDB\BSON\Document::toPHP()` decodes every 64-bit BSON integer as a `MongoDB\BSON\Int64` wrapper on all platforms, so anything outside the int32 range came back from Mongo as an object. utopia-php/mongo#49 fixes that at the decode boundary; this bumps the lock to 1.5.3 and adds the two regression tests that hold it in place.

Only `utopia-php/mongo` moves in the lock, 1.5.2 → 1.5.3.

## Why the tests target these two paths

Typed `integer`/`bigint` attributes were already fine on `main`: `castingAfter()` applies `(int)$node`, and ext-mongodb 2.x gives `Int64` a numeric cast handler, so that returns the right value. The two paths with no cast to lean on were the real leaks:

1. **`sum()`** returns the aggregate total straight off the cursor and declares `float|int`, so any total past int32 was a hard return type violation:

   ```
   TypeError: Utopia\Database\Adapter\Mongo::sum(): Return value must be of type int|float, MongoDB\BSON\Int64 returned
   ```

   Two rows of `2000000000` is enough to trip it.

2. **Object attributes** have no per-key schema, so `castingAfter()` has nothing to cast against. The wrapper reached the response and serialised as `{"count":{"$numberLong":"-3408048000"}}` instead of a number — wrong data on the wire, no error anywhere.

Both are in shared scopes rather than `MongoDBTest`, because the assertion (native PHP integers, no `$numberLong` in the JSON) is a contract every adapter should meet, not Mongo trivia.

## Verification

- Both tests **seen red** before the bump, on the exact failures quoted above, and green after.
- New tests pass on MongoDB, Postgres and Memory; the object one skips on MySQL, MariaDB and SQLite, which have no object support.
- Full `MongoDBTest` against the real released 1.5.3: **663 tests, 4997 assertions, 0 failures, 5 pre-existing skips.**
- `pint --test` passes on both changed files.

Note for anyone reproducing locally: a stale `vendor` in the test image shows up as two `testObjectAttribute*EmptyObject*` failures (`{}` vs `[]`). That is `utopia-php/cache` 4.0.1 against a lock that wants 4.0.2, not this change. Rebuilding the image clears it.

## Not verified

- **Key order in the object test.** Asserted with `assertEquals` plus a `$numberLong` substring check rather than an exact JSON string, because Postgres `jsonb` does not preserve key order. So the test pins types and values, not serialised layout.
- **32-bit PHP.** 1.5.3 deliberately keeps the wrapper there, since it is the only lossless representation. Neither repo has a 32-bit CI target, so that branch is reasoned, not exercised.
- **Full e2e for every adapter locally.** I ran the two new tests against all six and the complete suite for Mongo only; CI covers the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for signed 64-bit integers beyond the 32-bit range.
  * Verified large integer values remain native integers across document retrieval, searching, aggregation, caching, and JSON serialization.
  * Confirmed both positive and negative values serialize as standard JSON numbers without numeric wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->