### PR TITLE
Allow validators 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-mongodb": "*",
         "ext-mbstring": "*",
         "ext-redis": "*",
-        "utopia-php/validators": "^0.4",
+        "utopia-php/validators": "^0.5",
         "utopia-php/console": "0.1.*",
         "utopia-php/cache": "^4.0.0",
         "utopia-php/pools": "2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fafbe3b9360593631979771dd786acbf",
+    "content-hash": "1bc02bfd99426b9d44b1c3238f9b568f",
     "packages": [
         {
             "name": "brick/math",
@@ -2370,16 +2370,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.4.1",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "61832b7c863831466ccdeccd4e4f76a43765fbbf"
+                "reference": "ea6c1ad13019c8a088866cf422c232928de5a25e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/61832b7c863831466ccdeccd4e4f76a43765fbbf",
-                "reference": "61832b7c863831466ccdeccd4e4f76a43765fbbf",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/ea6c1ad13019c8a088866cf422c232928de5a25e",
+                "reference": "ea6c1ad13019c8a088866cf422c232928de5a25e",
                 "shasum": ""
             },
             "require": {
@@ -2404,9 +2404,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.4.1"
+                "source": "https://github.com/utopia-php/validators/tree/0.5.0"
             },
-            "time": "2026-08-10T04:15:37+00:00"
+            "time": "2026-08-14T05:12:07+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## What does this PR do?

Allows `utopia-php/database` to install with `utopia-php/validators` 0.5 and refreshes the locked validators version.

```json
"utopia-php/validators": "^0.5"
```

## Why?

Validators 0.5 adds the optional `requireNonBlank` constraint to `Text`. Database currently requires `^0.4`, which blocks dependency resolution for the monorepo dependent bump in [utopia-php/monorepo#134](https://github.com/utopia-php/monorepo/pull/134).

## Test plan

```text
composer validate --no-check-publish
composer lint
composer check
vendor/bin/phpunit --configuration phpunit.xml --testsuite unit
```

All 443 unit tests pass with 2,333 assertions. The Docker-backed adapter suites are left to CI because Docker is unavailable locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the validation package dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->