### PR TITLE
feat: nested join ON queries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "utopia-php/cache": "^4.0",
         "utopia-php/pools": "^2.0",
         "utopia-php/mongo": "^1.0",
-        "utopia-php/query": "^0.4",
+        "utopia-php/query": "dev-feat-join-on-queries as 0.4.99",
         "utopia-php/async": "^0.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "utopia-php/cache": "^4.0",
         "utopia-php/pools": "^2.0",
         "utopia-php/mongo": "^1.0",
-        "utopia-php/query": "dev-feat-join-on-queries as 0.4.99",
+        "utopia-php/query": "^0.5",
         "utopia-php/async": "^0.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06e557629ca5035c6833b8a457e340c7",
+    "content-hash": "4b4873437c14ffc79444ab839e8ab774",
     "packages": [
         {
             "name": "brick/math",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b4873437c14ffc79444ab839e8ab774",
+    "content-hash": "9ff3e93246620585fdcbcb7e0ae72315",
     "packages": [
         {
             "name": "brick/math",
@@ -2492,16 +2492,16 @@
         },
         {
             "name": "utopia-php/query",
-            "version": "dev-feat-join-on-queries",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/query.git",
-                "reference": "5ae83aa9f1f42d2c54e61b985da9789c1209efbf"
+                "reference": "802821c6fb0470410e1f0e65561cc16224c343c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/query/zipball/5ae83aa9f1f42d2c54e61b985da9789c1209efbf",
-                "reference": "5ae83aa9f1f42d2c54e61b985da9789c1209efbf",
+                "url": "https://api.github.com/repos/utopia-php/query/zipball/802821c6fb0470410e1f0e65561cc16224c343c0",
+                "reference": "802821c6fb0470410e1f0e65561cc16224c343c0",
                 "shasum": ""
             },
             "require": {
@@ -2535,9 +2535,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/query/issues",
-                "source": "https://github.com/utopia-php/query/tree/feat-join-on-queries"
+                "source": "https://github.com/utopia-php/query/tree/0.5.0"
             },
-            "time": "2026-08-21T05:05:30+00:00"
+            "time": "2026-08-21T06:16:10+00:00"
         },
         {
             "name": "utopia-php/telemetry",
@@ -5427,18 +5427,9 @@
             "time": "2026-02-10T04:21:53+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "utopia-php/query",
-            "version": "dev-feat-join-on-queries",
-            "alias": "0.4.99",
-            "alias_normalized": "0.4.99.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "utopia-php/query": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c32de508f93aa0e9269bdd86779b3ae",
+    "content-hash": "06e557629ca5035c6833b8a457e340c7",
     "packages": [
         {
             "name": "brick/math",
@@ -2492,16 +2492,16 @@
         },
         {
             "name": "utopia-php/query",
-            "version": "0.4.0",
+            "version": "dev-feat-join-on-queries",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/query.git",
-                "reference": "c334515035a2ab0aa49176eeca96de3e1c096e22"
+                "reference": "5ae83aa9f1f42d2c54e61b985da9789c1209efbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/query/zipball/c334515035a2ab0aa49176eeca96de3e1c096e22",
-                "reference": "c334515035a2ab0aa49176eeca96de3e1c096e22",
+                "url": "https://api.github.com/repos/utopia-php/query/zipball/5ae83aa9f1f42d2c54e61b985da9789c1209efbf",
+                "reference": "5ae83aa9f1f42d2c54e61b985da9789c1209efbf",
                 "shasum": ""
             },
             "require": {
@@ -2535,9 +2535,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/query/issues",
-                "source": "https://github.com/utopia-php/query/tree/0.4.0"
+                "source": "https://github.com/utopia-php/query/tree/feat-join-on-queries"
             },
-            "time": "2026-08-14T01:42:36+00:00"
+            "time": "2026-08-21T05:05:30+00:00"
         },
         {
             "name": "utopia-php/telemetry",
@@ -5427,9 +5427,18 @@
             "time": "2026-02-10T04:21:53+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "utopia-php/query",
+            "version": "dev-feat-join-on-queries",
+            "alias": "0.4.99",
+            "alias_normalized": "0.4.99.0"
+        }
+    ],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "utopia-php/query": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/src/Database/Adapter/SQL.php
+++ b/src/Database/Adapter/SQL.php
@@ -3551,7 +3551,20 @@ abstract class SQL extends Adapter implements Feature\RawQuery, Feature\QueryBui
     private function remapDottedQuery(BaseQuery $query, array $aliasSet, array $mainAttributes): void
     {
         $method = $query->getMethod();
-        if ($method->isJoin() || $method === Method::Select) {
+        if ($method === Method::Select) {
+            return;
+        }
+
+        if ($method->isJoin()) {
+            if ($query->isNestedJoin()) {
+                foreach ($query->getJoinOnQueries() as $onQuery) {
+                    if ($onQuery->getMethod() === Method::On) {
+                        continue;
+                    }
+                    $this->remapDottedQuery($onQuery, $aliasSet, $mainAttributes);
+                }
+            }
+
             return;
         }
 
@@ -3815,36 +3828,69 @@ abstract class SQL extends Adapter implements Feature\RawQuery, Feature\QueryBui
             $resolvedTable = $this->getSQLTableRaw($this->filter($joinTable));
             $query->setAttribute($resolvedTable);
 
-            $values = $query->getValues();
             $method = $query->getMethod();
-            $aliasIndex = ($method === Method::CrossJoin || $method === Method::NaturalJoin) ? 0 : 3;
-            $joinAlias = $this->sanitizeJoinAlias(
-                \is_string($values[$aliasIndex] ?? null) ? $values[$aliasIndex] : ''
-            );
+            $joinAlias = $this->sanitizeJoinAlias($query->getJoinAlias());
             if ($joinAlias === '') {
                 $joinAlias = 'j'.$joinIndex;
             }
             $joinIndex++;
 
-            if ($aliasIndex === 3 && \count($values) >= 3) {
-                $left = $values[0] ?? null;
-                $right = $values[2] ?? null;
-                if (! \is_string($left) || ! \is_string($right)) {
-                    throw new QueryException('Join columns must be strings');
+            if ($method === Method::CrossJoin || $method === Method::NaturalJoin) {
+                $query->setValues([$joinAlias]);
+            } elseif ($query->isNestedJoin()) {
+                $query->setValues($this->remapNestedJoinValues($query, $alias, $joinAlias));
+            } else {
+                $values = $query->getValues();
+                if (\count($values) >= 3) {
+                    $left = $values[0] ?? null;
+                    $right = $values[2] ?? null;
+                    if (! \is_string($left) || ! \is_string($right)) {
+                        throw new QueryException('Join columns must be strings');
+                    }
+                    $values[0] = $this->qualifyJoinColumn($left, $alias);
+                    $values[2] = $this->qualifyJoinColumn($right, $joinAlias);
+                    $values[3] = $joinAlias;
+                    $query->setValues($values);
                 }
-                $values[0] = $this->qualifyJoinColumn($left, $alias);
-                $values[2] = $this->qualifyJoinColumn($right, $joinAlias);
-                $values[3] = $joinAlias;
-                $query->setValues($values);
-            } elseif ($aliasIndex === 0) {
-                $values[0] = $joinAlias;
-                $query->setValues($values);
             }
 
             $joinTablePrefixes[] = ['table' => $joinTable, 'alias' => $joinAlias];
         }
 
         return $joinTablePrefixes;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function remapNestedJoinValues(BaseQuery $query, string $mainAlias, string $joinAlias): array
+    {
+        $values = [$joinAlias];
+        foreach ($query->getJoinOnQueries() as $onQuery) {
+            $values[] = $this->remapNestedJoinOnQuery($onQuery, $mainAlias, $joinAlias);
+        }
+
+        return $values;
+    }
+
+    private function remapNestedJoinOnQuery(BaseQuery $onQuery, string $mainAlias, string $joinAlias): BaseQuery
+    {
+        if ($onQuery->getMethod() !== Method::On) {
+            return $onQuery;
+        }
+
+        $values = $onQuery->getValues();
+        $left = $values[0] ?? null;
+        $right = $values[2] ?? null;
+        if (! \is_string($left) || $left === '' || ! \is_string($right) || $right === '') {
+            throw new QueryException('Join ON requires left and right columns');
+        }
+
+        $values[0] = $this->qualifyJoinColumn($left, $mainAlias);
+        $values[2] = $this->qualifyJoinColumn($right, $joinAlias);
+        $onQuery->setValues($values);
+
+        return $onQuery;
     }
 
     /**

--- a/src/Database/Validator/IndexedQueries.php
+++ b/src/Database/Validator/IndexedQueries.php
@@ -98,11 +98,8 @@ class IndexedQueries extends Queries
                 continue;
             }
 
-            $method = $query->getMethod();
-            $values = $query->getValues();
-            $aliasIndex = ($method === Method::CrossJoin || $method === Method::NaturalJoin) ? 0 : 3;
-            $alias = $values[$aliasIndex] ?? '';
-            if (\is_string($alias) && $alias !== '') {
+            $alias = $query->getJoinAlias();
+            if ($alias !== '') {
                 $aliases[$alias] = true;
             }
         }

--- a/src/Database/Validator/IndexedQueries.php
+++ b/src/Database/Validator/IndexedQueries.php
@@ -10,6 +10,7 @@ use Utopia\Database\Index as IndexVO;
 use Utopia\Database\Query;
 use Utopia\Database\Validator\Query\Base;
 use Utopia\Query\Method;
+use Utopia\Query\Query as BaseQuery;
 use Utopia\Query\Schema\IndexType;
 
 /**
@@ -64,7 +65,7 @@ class IndexedQueries extends Queries
     /**
      * Count vector queries across entire query tree
      *
-     * @param  array<Query>  $queries
+     * @param  array<BaseQuery>  $queries
      */
     private function countVectorQueries(array $queries): int
     {
@@ -76,7 +77,7 @@ class IndexedQueries extends Queries
             }
 
             if ($query->isNested()) {
-                /** @var array<Query> $nestedValues */
+                /** @var array<BaseQuery> $nestedValues */
                 $nestedValues = $query->getValues();
                 $count += $this->countVectorQueries($nestedValues);
             }
@@ -90,7 +91,7 @@ class IndexedQueries extends Queries
     }
 
     /**
-     * @param  array<Query>  $queries
+     * @param  array<BaseQuery>  $queries
      * @return array<string, true>
      */
     private function joinAliases(array $queries): array
@@ -148,7 +149,7 @@ class IndexedQueries extends Queries
     }
 
     /**
-     * @param  array<Query>  $queries
+     * @param  array<BaseQuery>  $queries
      * @param  array<string, true>  $joinAliases
      */
     private function validateSearchIndexes(array $queries, array $joinAliases): bool
@@ -183,7 +184,7 @@ class IndexedQueries extends Queries
             }
 
             if ($query->isNested() && $query->getMethod() !== Method::Having) {
-                /** @var array<Query> $nested */
+                /** @var array<BaseQuery> $nested */
                 $nested = $query->getValues();
                 if (! $this->validateSearchIndexes($nested, $joinAliases)) {
                     return false;

--- a/src/Database/Validator/IndexedQueries.php
+++ b/src/Database/Validator/IndexedQueries.php
@@ -76,14 +76,12 @@ class IndexedQueries extends Queries
                 $count++;
             }
 
-            if ($query->isNested()) {
+            if ($query->isNestedJoin()) {
+                $count += $this->countVectorQueries($query->getJoinOnQueries());
+            } elseif ($query->isNested()) {
                 /** @var array<BaseQuery> $nestedValues */
                 $nestedValues = $query->getValues();
                 $count += $this->countVectorQueries($nestedValues);
-            }
-
-            if ($query->isNestedJoin()) {
-                $count += $this->countVectorQueries($query->getJoinOnQueries());
             }
         }
 
@@ -183,16 +181,14 @@ class IndexedQueries extends Queries
                 }
             }
 
-            if ($query->isNested() && $query->getMethod() !== Method::Having) {
+            if ($query->isNestedJoin()) {
+                if (! $this->validateSearchIndexes($query->getJoinOnQueries(), $joinAliases)) {
+                    return false;
+                }
+            } elseif ($query->isNested() && $query->getMethod() !== Method::Having) {
                 /** @var array<BaseQuery> $nested */
                 $nested = $query->getValues();
                 if (! $this->validateSearchIndexes($nested, $joinAliases)) {
-                    return false;
-                }
-            }
-
-            if ($query->isNestedJoin()) {
-                if (! $this->validateSearchIndexes($query->getJoinOnQueries(), $joinAliases)) {
                     return false;
                 }
             }

--- a/src/Database/Validator/IndexedQueries.php
+++ b/src/Database/Validator/IndexedQueries.php
@@ -80,6 +80,10 @@ class IndexedQueries extends Queries
                 $nestedValues = $query->getValues();
                 $count += $this->countVectorQueries($nestedValues);
             }
+
+            if ($query->isNestedJoin()) {
+                $count += $this->countVectorQueries($query->getJoinOnQueries());
+            }
         }
 
         return $count;
@@ -182,6 +186,12 @@ class IndexedQueries extends Queries
                 /** @var array<Query> $nested */
                 $nested = $query->getValues();
                 if (! $this->validateSearchIndexes($nested, $joinAliases)) {
+                    return false;
+                }
+            }
+
+            if ($query->isNestedJoin()) {
+                if (! $this->validateSearchIndexes($query->getJoinOnQueries(), $joinAliases)) {
                     return false;
                 }
             }

--- a/src/Database/Validator/Queries.php
+++ b/src/Database/Validator/Queries.php
@@ -123,13 +123,8 @@ class Queries extends Validator
             if (! $query->getMethod()->isJoin()) {
                 continue;
             }
-            $values = $query->getValues();
-            $method = $query->getMethod();
-            $alias = match ($method) {
-                Method::CrossJoin, Method::NaturalJoin => $values[0] ?? '',
-                default => $values[3] ?? '',
-            };
-            if (\is_string($alias) && $alias !== '') {
+            $alias = $query->getJoinAlias();
+            if ($alias !== '') {
                 $joinAliases[] = $alias;
             }
         }
@@ -142,6 +137,14 @@ class Queries extends Validator
                 ) {
                     $validator->allowJoinAliases($joinAliases);
                 }
+            }
+        }
+
+        $hasFilterValidator = false;
+        foreach ($this->validators as $validator) {
+            if ($validator->getMethodType() === Base::METHOD_TYPE_FILTER) {
+                $hasFilterValidator = true;
+                break;
             }
         }
 
@@ -167,6 +170,15 @@ class Queries extends Validator
                         }
                     }
                     $pending[] = $nested;
+                }
+            }
+
+            if ($hasFilterValidator && $query->getMethod()->isJoin() && $query->isNestedJoin()) {
+                foreach ($query->getJoinOnQueries() as $onQuery) {
+                    if ($onQuery->getMethod() === Method::On) {
+                        continue;
+                    }
+                    $pending[] = $onQuery;
                 }
             }
 

--- a/src/Database/Validator/Query/Join.php
+++ b/src/Database/Validator/Query/Join.php
@@ -47,6 +47,39 @@ class Join extends Base
             return false;
         }
 
+        if (! $value->isNestedJoin()) {
+            return true;
+        }
+
+        $onQueries = $value->getJoinOnQueries();
+        if ($onQueries === []) {
+            $this->message = 'Join ON requires at least one condition';
+
+            return false;
+        }
+
+        $allowedOperators = ['=', '!=', '<', '>', '<=', '>=', '<>'];
+        foreach ($onQueries as $onQuery) {
+            if ($onQuery->getMethod() !== Method::On) {
+                continue;
+            }
+
+            $values = $onQuery->getValues();
+            $left = $values[0] ?? '';
+            $operator = $values[1] ?? '=';
+            $right = $values[2] ?? '';
+            if (! \is_string($left) || $left === '' || ! \is_string($right) || $right === '') {
+                $this->message = 'Join ON requires left and right columns';
+
+                return false;
+            }
+            if (! \is_string($operator) || ! \in_array($operator, $allowedOperators, true)) {
+                $this->message = 'Invalid join operator: '.(\is_string($operator) ? $operator : \gettype($operator));
+
+                return false;
+            }
+        }
+
         return true;
     }
 }

--- a/tests/e2e/Adapter/Scopes/JoinTests.php
+++ b/tests/e2e/Adapter/Scopes/JoinTests.php
@@ -5666,4 +5666,63 @@ trait JoinTests
 
         return $scores;
     }
+
+    public function testLeftJoinOnFilterKeepsUnmatchedMainRows(): void
+    {
+        $database = static::getDatabase();
+        if (! $database->getAdapter()->supports(Capability::Joins)) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $pCol = 'ljon_p';
+        $rCol = 'ljon_r';
+        $cols = [$pCol, $rCol];
+        $this->cleanupAggCollections($database, $cols);
+
+        $database->createCollection($pCol, permissions: [Permission::create(Role::any()), Permission::read(Role::any())]);
+        $database->createAttribute($pCol, Attribute::string(key: 'name', size: 100, required: true));
+
+        $database->createCollection($rCol, permissions: [Permission::create(Role::any()), Permission::read(Role::any())]);
+        $database->createAttribute($rCol, Attribute::string(key: 'prod_uid', required: true));
+        $database->createAttribute($rCol, Attribute::integer(key: 'score', required: true));
+
+        foreach (['p1' => 'Alpha', 'p2' => 'Beta', 'p3' => 'Gamma'] as $id => $name) {
+            $database->createDocument($pCol, new Document([
+                '$id' => $id,
+                'name' => $name,
+                '$permissions' => [Permission::read(Role::any())],
+            ]));
+        }
+
+        foreach ([
+            ['prod_uid' => 'p1', 'score' => 5],
+            ['prod_uid' => 'p2', 'score' => 2],
+        ] as $review) {
+            $database->createDocument($rCol, new Document(array_merge($review, [
+                '$permissions' => [Permission::read(Role::any())],
+            ])));
+        }
+
+        $results = $database->find($pCol, [
+            Query::leftJoin($rCol, 'rev', [
+                Query::on('$id', 'prod_uid'),
+                Query::greaterThanEqual('rev.score', 4),
+            ]),
+            Query::select(['name', 'rev.score']),
+        ]);
+
+        $this->assertCount(3, $results);
+        $mapped = [];
+        foreach ($results as $doc) {
+            $name = $doc->getAttribute('name');
+            $this->assertIsString($name);
+            $mapped[$name] = $doc->getAttribute('rev.score');
+        }
+        $this->assertEquals(5, $mapped['Alpha']);
+        $this->assertTrue($mapped['Beta'] === null || $mapped['Beta'] === '');
+        $this->assertTrue($mapped['Gamma'] === null || $mapped['Gamma'] === '');
+
+        $this->cleanupAggCollections($database, $cols);
+    }
 }

--- a/tests/unit/SQLFindTest.php
+++ b/tests/unit/SQLFindTest.php
@@ -101,6 +101,23 @@ final class SQLFindTest extends TestCase
         $this->assertStringContainsString('LEFT JOIN', $sql);
     }
 
+    public function testNestedJoinOnCompilesPredicatesOntoJoin(): void
+    {
+        $sql = $this->captureFindSql([
+            Query::leftJoin('orders', 'ord', [
+                Query::on('$id', 'customerId'),
+                Query::equal('ord.status', ['paid']),
+            ]),
+        ]);
+
+        $this->assertQualifiedJoinStars($sql, joinAlias: 'ord');
+        $this->assertStringContainsString('LEFT JOIN', $sql);
+        $this->assertStringContainsString('AS `ord`', $sql);
+        $this->assertMatchesRegularExpression('/ON\s+`table_main`\.`_uid`\s*=\s*`ord`\.`customerId`/i', $sql);
+        $this->assertStringContainsString('`ord`.`status`', $sql);
+        $this->assertDoesNotMatchRegularExpression('/WHERE[\s\S]*`ord`\.`status`/i', $sql);
+    }
+
     public function testEmulatesFullOuterJoinWithOuterLimit(): void
     {
         $sql = $this->captureFindSql(

--- a/tests/unit/Validator/DocumentQueriesTest.php
+++ b/tests/unit/Validator/DocumentQueriesTest.php
@@ -178,6 +178,53 @@ class DocumentQueriesTest extends TestCase
         $this->assertStringContainsString('Natural joins are not supported', $validator->getDescription());
     }
 
+    public function testNestedJoinOnIsValid(): void
+    {
+        $validator = new DocumentQueries($this->documentAttributes());
+
+        $this->assertSame(true, $validator->isValid([
+            Query::leftJoin('orders', 'ord', [
+                Query::on('$id', 'customerId'),
+            ]),
+        ]), $validator->getDescription());
+    }
+
+    public function testNestedJoinOnWithFilterIsValidWithoutFilterValidator(): void
+    {
+        $validator = new DocumentQueries($this->documentAttributes());
+
+        $this->assertSame(true, $validator->isValid([
+            Query::leftJoin('orders', 'ord', [
+                Query::on('$id', 'customerId'),
+                Query::equal('ord.status', ['paid']),
+            ]),
+        ]), $validator->getDescription());
+    }
+
+    public function testNestedJoinOnRequiresColumns(): void
+    {
+        $validator = new DocumentQueries($this->documentAttributes());
+
+        $this->assertSame(false, $validator->isValid([
+            Query::leftJoin('orders', 'ord', [
+                Query::on('', 'customerId'),
+            ]),
+        ]));
+        $this->assertStringContainsString('Join ON requires left and right columns', $validator->getDescription());
+    }
+
+    public function testSelectWithNestedJoinAliasIsValid(): void
+    {
+        $validator = new DocumentQueries($this->documentAttributes());
+
+        $this->assertSame(true, $validator->isValid([
+            Query::select(['ord.amount']),
+            Query::leftJoin('orders', 'ord', [
+                Query::on('$id', 'customerId'),
+            ]),
+        ]), $validator->getDescription());
+    }
+
     /**
      * @return array<Document>
      */

--- a/tests/unit/Validator/IndexedQueriesTest.php
+++ b/tests/unit/Validator/IndexedQueriesTest.php
@@ -276,6 +276,35 @@ class IndexedQueriesTest extends TestCase
         );
     }
 
+    public function testNestedJoinOnSingleVectorIsValid(): void
+    {
+        $attributes = [
+            new Document([
+                '$id' => 'embedding',
+                'key' => 'embedding',
+                'type' => ColumnType::Vector->value,
+                'size' => 3,
+                'array' => false,
+            ]),
+        ];
+
+        $validator = new IndexedQueries(
+            $attributes,
+            [],
+            [
+                new Filter($attributes, ColumnType::Integer->value),
+                new Join(),
+            ]
+        );
+
+        $this->assertTrue($validator->isValid([
+            Query::leftJoin('meta', 'meta', [
+                Query::on('$id', 'mainId'),
+                Query::vectorCosine('embedding', [0.3, 0.4, 0.5]),
+            ]),
+        ]), $validator->getDescription());
+    }
+
     public function test_two_attributes_fulltext(): void
     {
         $attributes = [

--- a/tests/unit/Validator/IndexedQueriesTest.php
+++ b/tests/unit/Validator/IndexedQueriesTest.php
@@ -203,7 +203,7 @@ class IndexedQueriesTest extends TestCase
         );
     }
 
-    public function test_nested_join_on_search_requires_fulltext_index(): void
+    public function testNestedJoinOnSearchRequiresFulltextIndex(): void
     {
         $attributes = [
             new Document([
@@ -242,7 +242,7 @@ class IndexedQueriesTest extends TestCase
         ]), $validator->getDescription());
     }
 
-    public function test_nested_join_on_vector_counts_toward_limit(): void
+    public function testNestedJoinOnVectorCountsTowardLimit(): void
     {
         $attributes = [
             new Document([

--- a/tests/unit/Validator/IndexedQueriesTest.php
+++ b/tests/unit/Validator/IndexedQueriesTest.php
@@ -203,6 +203,79 @@ class IndexedQueriesTest extends TestCase
         );
     }
 
+    public function test_nested_join_on_search_requires_fulltext_index(): void
+    {
+        $attributes = [
+            new Document([
+                '$id' => 'name',
+                'key' => 'name',
+                'type' => ColumnType::String->value,
+                'array' => false,
+            ]),
+        ];
+
+        $validator = new IndexedQueries(
+            $attributes,
+            [],
+            [
+                new Filter($attributes, ColumnType::Integer->value),
+                new Join(),
+            ]
+        );
+
+        $this->assertFalse($validator->isValid([
+            Query::leftJoin('meta', 'meta', [
+                Query::on('$id', 'mainId'),
+                Query::search('name', 'needle'),
+            ]),
+        ]));
+        $this->assertSame(
+            'Searching by attribute "name" requires a fulltext index.',
+            $validator->getDescription()
+        );
+
+        $this->assertTrue($validator->isValid([
+            Query::leftJoin('meta', 'meta', [
+                Query::on('$id', 'mainId'),
+                Query::search('meta.body', 'needle'),
+            ]),
+        ]), $validator->getDescription());
+    }
+
+    public function test_nested_join_on_vector_counts_toward_limit(): void
+    {
+        $attributes = [
+            new Document([
+                '$id' => 'embedding',
+                'key' => 'embedding',
+                'type' => ColumnType::Vector->value,
+                'size' => 3,
+                'array' => false,
+            ]),
+        ];
+
+        $validator = new IndexedQueries(
+            $attributes,
+            [],
+            [
+                new Filter($attributes, ColumnType::Integer->value),
+                new Join(),
+            ]
+        );
+
+        $this->assertFalse($validator->isValid([
+            Query::vectorDot('embedding', [0.1, 0.2, 0.3]),
+            Query::leftJoin('meta', 'meta', [
+                Query::on('$id', 'mainId'),
+                Query::vectorCosine('embedding', [0.3, 0.4, 0.5]),
+            ]),
+        ]));
+        $this->assertSame(
+            'Cannot use multiple vector queries in a single request',
+            $validator->getDescription()
+        );
+    }
+
     public function test_two_attributes_fulltext(): void
     {
         $attributes = [

--- a/tests/unit/Validator/QueriesTest.php
+++ b/tests/unit/Validator/QueriesTest.php
@@ -248,6 +248,57 @@ class QueriesTest extends TestCase
         ]), $validator->getDescription());
     }
 
+    public function test_nested_join_alias_is_collected(): void
+    {
+        $attributes = [
+            new Document([
+                '$id' => 'name',
+                'key' => 'name',
+                'type' => ColumnType::String->value,
+                'array' => false,
+            ]),
+        ];
+
+        $validator = new Queries([
+            new Select($attributes),
+            new Filter($attributes, ColumnType::Integer->value),
+            new Join(),
+        ]);
+
+        $this->assertTrue($validator->isValid([
+            Query::select(['ord.amount']),
+            Query::leftJoin('orders', 'ord', [
+                Query::on('$id', 'customer_uid'),
+                Query::equal('ord.status', ['paid']),
+            ]),
+        ]), $validator->getDescription());
+    }
+
+    public function test_nested_join_on_filter_unknown_alias_is_invalid(): void
+    {
+        $attributes = [
+            new Document([
+                '$id' => 'name',
+                'key' => 'name',
+                'type' => ColumnType::String->value,
+                'array' => false,
+            ]),
+        ];
+
+        $validator = new Queries([
+            new Filter($attributes, ColumnType::Integer->value),
+            new Join(),
+        ]);
+
+        $this->assertFalse($validator->isValid([
+            Query::leftJoin('orders', 'ord', [
+                Query::on('$id', 'customer_uid'),
+                Query::equal('missing.status', ['paid']),
+            ]),
+        ]));
+        $this->assertStringContainsString('Attribute not found in schema', $validator->getDescription());
+    }
+
     public function test_order_before_join_accepts_dotted_alias(): void
     {
         $attributes = [

--- a/tests/unit/Validator/QueriesTest.php
+++ b/tests/unit/Validator/QueriesTest.php
@@ -248,7 +248,7 @@ class QueriesTest extends TestCase
         ]), $validator->getDescription());
     }
 
-    public function test_nested_join_alias_is_collected(): void
+    public function testNestedJoinAliasIsCollected(): void
     {
         $attributes = [
             new Document([
@@ -274,7 +274,7 @@ class QueriesTest extends TestCase
         ]), $validator->getDescription());
     }
 
-    public function test_nested_join_on_filter_unknown_alias_is_invalid(): void
+    public function testNestedJoinOnFilterUnknownAliasIsInvalid(): void
     {
         $attributes = [
             new Document([


### PR DESCRIPTION
## Summary
- Depends on [utopia-php/query#20](https://github.com/utopia-php/query/pull/20) (`dev-feat-join-on-queries as 0.4.99`).
- Join validator accepts nested ON conditions (`Query::on` plus filter queries).
- Alias collection uses `getJoinAlias()` so nested `leftJoin('orders', 'ord', [...])` unlocks `ord.*` in select/filter/order.
- SQL remapping qualifies `Query::on` columns and dotted ON filters; extra ON predicates compile onto the JOIN (LEFT JOIN semantics).

Stacked on `feat-query-lib`. Do not merge until query#20 is in.

## Test plan
- [x] Unit validators + SQLFindTest nested ON compile
- [x] E2E LEFT JOIN ON filter keeps unmatched main rows
- [ ] CI