### PR TITLE
chore: allow utopia-php/cache ^5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ext-redis": "*",
         "utopia-php/validators": "^0.5",
         "utopia-php/console": "0.1.*",
-        "utopia-php/cache": "^4.0.0",
+        "utopia-php/cache": "^4.0 || ^5.0",
         "utopia-php/pools": "2.*",
         "utopia-php/mongo": "1.*"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bc02bfd99426b9d44b1c3238f9b568f",
+    "content-hash": "1869c4857b037fdf3ee92ed55404f46b",
     "packages": [
         {
             "name": "brick/math",
@@ -2036,22 +2036,22 @@
         },
         {
             "name": "utopia-php/cache",
-            "version": "4.0.2",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cache.git",
-                "reference": "92e02dab63606234b993b841ebf4c58845dd4620"
+                "reference": "0d0752785fc81b5afd6571f4291763166a6532bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cache/zipball/92e02dab63606234b993b841ebf4c58845dd4620",
-                "reference": "92e02dab63606234b993b841ebf4c58845dd4620",
+                "url": "https://api.github.com/repos/utopia-php/cache/zipball/0d0752785fc81b5afd6571f4291763166a6532bc",
+                "reference": "0d0752785fc81b5afd6571f4291763166a6532bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": ">=8.4",
-                "utopia-php/circuit-breaker": "^0.3",
+                "utopia-php/circuit-breaker": "^0.4",
                 "utopia-php/pools": "^2.0",
                 "utopia-php/telemetry": "^0.4"
             },
@@ -2089,22 +2089,22 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/cache/issues",
-                "source": "https://github.com/utopia-php/cache/tree/4.0.2"
+                "source": "https://github.com/utopia-php/cache/tree/5.0.0"
             },
-            "time": "2026-08-12T07:48:59+00:00"
+            "time": "2026-08-21T11:04:48+00:00"
         },
         {
             "name": "utopia-php/circuit-breaker",
-            "version": "0.3.2",
+            "version": "0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/circuit-breaker.git",
-                "reference": "5fbc3802471b0d1b4260bd9f5544514e6929b481"
+                "reference": "c6d93c7ba9d895cf906360e000f74ff762d83e17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/circuit-breaker/zipball/5fbc3802471b0d1b4260bd9f5544514e6929b481",
-                "reference": "5fbc3802471b0d1b4260bd9f5544514e6929b481",
+                "url": "https://api.github.com/repos/utopia-php/circuit-breaker/zipball/c6d93c7ba9d895cf906360e000f74ff762d83e17",
+                "reference": "c6d93c7ba9d895cf906360e000f74ff762d83e17",
                 "shasum": ""
             },
             "require": {
@@ -2148,9 +2148,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/circuit-breaker/issues",
-                "source": "https://github.com/utopia-php/circuit-breaker/tree/0.3.2"
+                "source": "https://github.com/utopia-php/circuit-breaker/tree/0.4.0"
             },
-            "time": "2026-08-05T18:07:20+00:00"
+            "time": "2026-08-21T10:20:24+00:00"
         },
         {
             "name": "utopia-php/console",


### PR DESCRIPTION
## Why

`utopia-php/cache` 5.0.0 is out. This package pins `^4`, and because Composer resolves the whole graph, that pin blocks **every** consumer downstream — `appwrite/appwrite` cannot move to cache 5 while any of its dependencies still require cache 4.

## Why this is safe

Cache 5.0.0's major is not about the general cache API, which is unchanged. It is a major for two reasons:

1. `Redis\Multiplexing` changed how a per-call read deadline is handled — a timeout no longer tears down the shared connection ([utopia-php/monorepo#152](https://github.com/utopia-php/monorepo/pull/152)).
2. It now requires `utopia-php/circuit-breaker ^0.4`, which removed the `threshold` constructor argument in favour of a failure rate ([utopia-php/monorepo#153](https://github.com/utopia-php/monorepo/pull/153)).

This package uses neither. `grep` for `Multiplexing` and `CircuitBreaker` across `src/` and `tests/` returns nothing — only the generic `Cache`/`Adapter` surface is used, and that is identical between 4 and 5.

## The constraint

`^4.0 || ^5.0` rather than `^5.0`, so this package does not force the upgrade on anyone still on cache 4. Consumers pick the version; this just stops being the thing that says no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded cache component compatibility to support versions 4 and 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->