### PR TITLE
fix: hold pooled timeouts on the pool, not on a connection

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -357,6 +357,24 @@ abstract class Adapter
     }
 
     /**
+     * Clears every timeout this adapter carries, for any event.
+     *
+     * A pooled connection outlives the handle that configured it, so the handle
+     * that takes it next has to be able to reset it without knowing which
+     * events the previous one set a timeout for.
+     *
+     * @return void
+     */
+    public function clearTimeouts(): void
+    {
+        foreach (\array_keys($this->transformations) as $event) {
+            $this->clearTimeout($event);
+        }
+
+        $this->timeout = 0;
+    }
+
+    /**
      * Start a new transaction.
      *
      * If a transaction is already active, this will only increment the transaction count and return true.

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -34,9 +34,6 @@ class Pool extends Adapter
      * failed outright while the backing was unreachable, reporting a database
      * as down to a caller that had not yet issued a query.
      *
-     * A cleared event is kept with a timeout of zero instead of being dropped,
-     * so the connection it was applied to has it cleared again on checkout.
-     *
      * @var array<string, int>
      */
     private array $timeouts = [];
@@ -116,37 +113,56 @@ class Pool extends Adapter
 
     /**
      * Zero is the value a caller's own default carries when it wants no
-     * timeout, so it is recorded as a cleared event rather than refused. A
-     * connection is only ever asked for a timeout it can hold.
+     * timeout, so it clears the event rather than being refused. A connection
+     * is only ever asked for a timeout it can hold.
      */
     public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
     {
-        $this->timeouts[$event] = \max($milliseconds, 0);
-        $this->timeout = \max($milliseconds, 0);
-    }
+        if ($milliseconds <= 0) {
+            $this->clearTimeout($event);
 
-    public function clearTimeout(string $event): void
-    {
-        $this->timeouts[$event] = 0;
-        $this->timeout = 0;
+            return;
+        }
+
+        $this->timeouts[$event] = $milliseconds;
+        $this->timeout = $this->timeouts[Database::EVENT_ALL] ?? 0;
     }
 
     /**
-     * Apply this pool's timeouts to a connection as it is checked out. The
-     * connection outlives the handle that configured it and is handed to
-     * handles that want a different timeout or none, so what it carries is
-     * replaced on every checkout rather than only when it is first set.
+     * Clearing one event leaves the others alone. The concrete adapters keep a
+     * single timeout scalar that Postgres and Mongo apply to every statement,
+     * so a clear forwarded verbatim would drop the timeout the caller still
+     * has configured for everything else.
+     */
+    public function clearTimeout(string $event): void
+    {
+        unset($this->timeouts[$event]);
+        $this->timeout = $this->timeouts[Database::EVENT_ALL] ?? 0;
+    }
+
+    /**
+     * Put a connection into the timeout state this pool holds, as it is checked
+     * out. The connection outlives the handle that configured it and is handed
+     * on to handles that want a different timeout or none at all, so it is
+     * reset first: a handle carrying no timeout must not inherit one, and a
+     * handle carrying its own must not be left with an event the last holder
+     * set. The global timeout is applied last so the scalar the connection ends
+     * on is the one {@see self::getTimeout()} reports.
      */
     protected function syncTimeouts(Adapter $adapter): void
     {
-        foreach ($this->timeouts as $event => $milliseconds) {
-            if ($milliseconds === 0) {
-                $adapter->clearTimeout($event);
+        $adapter->clearTimeouts();
 
+        foreach ($this->timeouts as $event => $milliseconds) {
+            if ($event === Database::EVENT_ALL) {
                 continue;
             }
 
             $adapter->setTimeout($milliseconds, $event);
+        }
+
+        if (isset($this->timeouts[Database::EVENT_ALL])) {
+            $adapter->setTimeout($this->timeouts[Database::EVENT_ALL]);
         }
     }
 

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -23,6 +23,25 @@ class Pool extends Adapter
     protected ?Adapter $pinnedAdapter = null;
 
     /**
+     * The timeout each event is under, held here rather than on a connection.
+     *
+     * A timeout is adapter state, not a statement: every concrete adapter
+     * records it and applies it to the SQL it builds afterwards, and none of
+     * them contacts the server to set it. Delegating the call therefore opened
+     * a connection for the sole purpose of writing a number onto whichever one
+     * answered, which the pool took back moments later - so the timeout bound
+     * one connection and none of its siblings, and merely building a handle
+     * failed outright while the backing was unreachable, reporting a database
+     * as down to a caller that had not yet issued a query.
+     *
+     * A cleared event is kept with a timeout of zero instead of being dropped,
+     * so the connection it was applied to has it cleared again on checkout.
+     *
+     * @var array<string, int>
+     */
+    private array $timeouts = [];
+
+    /**
      * @param UtopiaPool<covariant Adapter> $pool The pool to use for connections. Must contain instances of Adapter.
      */
     public function __construct(UtopiaPool $pool)
@@ -59,9 +78,7 @@ class Pool extends Adapter
             $adapter->setTenant($this->getTenant());
             $adapter->setAuthorization($this->authorization);
 
-            if ($this->getTimeout() > 0) {
-                $adapter->setTimeout($this->getTimeout());
-            }
+            $this->syncTimeouts($adapter);
             $adapter->resetDebug();
             foreach ($this->getDebug() as $key => $value) {
                 $adapter->setDebug($key, $value);
@@ -97,9 +114,40 @@ class Pool extends Adapter
         return $this->delegate(__FUNCTION__, \func_get_args());
     }
 
+    /**
+     * Zero is the value a caller's own default carries when it wants no
+     * timeout, so it is recorded as a cleared event rather than refused. A
+     * connection is only ever asked for a timeout it can hold.
+     */
     public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
     {
-        $this->delegate(__FUNCTION__, \func_get_args());
+        $this->timeouts[$event] = \max($milliseconds, 0);
+        $this->timeout = \max($milliseconds, 0);
+    }
+
+    public function clearTimeout(string $event): void
+    {
+        $this->timeouts[$event] = 0;
+        $this->timeout = 0;
+    }
+
+    /**
+     * Apply this pool's timeouts to a connection as it is checked out. The
+     * connection outlives the handle that configured it and is handed to
+     * handles that want a different timeout or none, so what it carries is
+     * replaced on every checkout rather than only when it is first set.
+     */
+    protected function syncTimeouts(Adapter $adapter): void
+    {
+        foreach ($this->timeouts as $event => $milliseconds) {
+            if ($milliseconds === 0) {
+                $adapter->clearTimeout($event);
+
+                continue;
+            }
+
+            $adapter->setTimeout($milliseconds, $event);
+        }
     }
 
     public function startTransaction(): bool
@@ -147,9 +195,7 @@ class Pool extends Adapter
             $adapter->setTenant($this->getTenant());
             $adapter->setAuthorization($this->authorization);
 
-            if ($this->getTimeout() > 0) {
-                $adapter->setTimeout($this->getTimeout());
-            }
+            $this->syncTimeouts($adapter);
             $adapter->resetDebug();
             foreach ($this->getDebug() as $key => $value) {
                 $adapter->setDebug($key, $value);

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -145,6 +145,21 @@ class Pool extends Adapter
     }
 
     /**
+     * The pool's own map is what a checkout replays, so a clear has to empty
+     * it. Inheriting the base implementation cleared almost nothing: it walks
+     * the events it finds in `$transformations`, and this adapter delegates
+     * `before()`, so its own array never holds more than `EVENT_ALL` however
+     * many events a caller has set a timeout for.
+     */
+    public function clearTimeouts(): void
+    {
+        $this->timeouts = [];
+        $this->timeout = 0;
+
+        $this->syncPin();
+    }
+
+    /**
      * The connection this caller's open transaction is pinned to, if any.
      *
      * A seam: a subclass that keys the pin by coroutine rather than by object
@@ -180,8 +195,16 @@ class Pool extends Adapter
      * on to handles that want a different timeout or none at all, so it is
      * reset first: a handle carrying no timeout must not inherit one, and a
      * handle carrying its own must not be left with an event the last holder
-     * set. The global timeout is applied last so the scalar the connection ends
-     * on is the one {@see self::getTimeout()} reports.
+     * set.
+     *
+     * The global timeout is applied last, which decides what an engine with no
+     * per-event timeout does with one. MariaDB and MySQL hang a hook on the
+     * event and are unaffected; Postgres and Mongo take `$event` and discard
+     * it, so every call lands on the one scalar they bound every statement by
+     * and the last one wins. Applying the global last means a per-event
+     * refinement those two cannot express is ignored there. The other order
+     * would let a 5s read deadline silently bound every write on the handle,
+     * which is the failure worth avoiding.
      */
     protected function syncTimeouts(Adapter $adapter): void
     {

--- a/src/Database/Adapter/Pool.php
+++ b/src/Database/Adapter/Pool.php
@@ -126,6 +126,8 @@ class Pool extends Adapter
 
         $this->timeouts[$event] = $milliseconds;
         $this->timeout = $this->timeouts[Database::EVENT_ALL] ?? 0;
+
+        $this->syncPin();
     }
 
     /**
@@ -138,6 +140,38 @@ class Pool extends Adapter
     {
         unset($this->timeouts[$event]);
         $this->timeout = $this->timeouts[Database::EVENT_ALL] ?? 0;
+
+        $this->syncPin();
+    }
+
+    /**
+     * The connection this caller's open transaction is pinned to, if any.
+     *
+     * A seam: a subclass that keys the pin by coroutine rather than by object
+     * overrides this, and the timeout setters reach the right connection
+     * without knowing how the pin is held.
+     */
+    protected function pin(): ?Adapter
+    {
+        return $this->pinnedAdapter;
+    }
+
+    /**
+     * A timeout changed inside a transaction has to reach the connection
+     * running it. Every statement left in that transaction goes to the pinned
+     * connection, and it will not be checked out again before the commit, so
+     * waiting for the next checkout would leave the rest of the body running
+     * under the timeout the caller just replaced.
+     */
+    private function syncPin(): void
+    {
+        $pinned = $this->pin();
+
+        if ($pinned === null) {
+            return;
+        }
+
+        $this->syncTimeouts($pinned);
     }
 
     /**

--- a/tests/unit/PoolTimeoutTest.php
+++ b/tests/unit/PoolTimeoutTest.php
@@ -135,6 +135,35 @@ class PoolTimeoutTest extends TestCase
     }
 
     /**
+     * A transaction pins one connection for its whole body and does not check
+     * out again before the commit, so a timeout changed inside it has to reach
+     * that connection there or not at all - the rest of the body would
+     * otherwise run under the timeout the caller just replaced.
+     */
+    public function testTimeoutChangedInsideATransactionReachesThePinnedConnection(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(5000);
+
+        $insideBody = [];
+        $adapter->withTransaction(function () use ($adapter, $connection, &$insideBody): string {
+            $adapter->setTimeout(300000);
+            $insideBody['raised'] = $connection->timeouts;
+
+            $adapter->clearTimeout(Database::EVENT_ALL);
+            $insideBody['cleared'] = $connection->timeouts;
+
+            return 'row-written';
+        });
+
+        $this->assertSame([Database::EVENT_ALL => 300000], $insideBody['raised'], 'The rest of the body runs on this connection, so the new timeout must reach it before the commit');
+        $this->assertSame([], $insideBody['cleared']);
+    }
+
+    /**
      * A caller whose own default is zero is asking for no timeout, which is
      * what a factory building a handle without one passes. It reaches no
      * connection as a timeout the connection would refuse.

--- a/tests/unit/PoolTimeoutTest.php
+++ b/tests/unit/PoolTimeoutTest.php
@@ -135,6 +135,28 @@ class PoolTimeoutTest extends TestCase
     }
 
     /**
+     * The pool's own map is what a checkout replays, so clearing every timeout
+     * has to empty it. The inherited implementation walks the events it finds
+     * in the adapter's `$transformations`, and this one delegates `before()`,
+     * so its own array holds nothing but `EVENT_ALL` — a per-event timeout
+     * survived the clear and came back on the next checkout.
+     */
+    public function testClearingEveryTimeoutDropsPerEventEntriesToo(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(300000);
+        $adapter->setTimeout(5000, Database::EVENT_DOCUMENT_READ);
+        $adapter->clearTimeouts();
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([], $connection->timeouts, 'A timeout the caller cleared must not come back on the next checkout');
+        $this->assertSame(0, $adapter->getTimeout());
+    }
+
+    /**
      * A transaction pins one connection for its whole body and does not check
      * out again before the commit, so a timeout changed inside it has to reach
      * that connection there or not at all - the rest of the body would

--- a/tests/unit/PoolTimeoutTest.php
+++ b/tests/unit/PoolTimeoutTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Database\Adapter\Memory;
+use Utopia\Database\Adapter\Pool;
+use Utopia\Database\Database;
+use Utopia\Database\Validator\Authorization;
+use Utopia\Pools\Adapter\Stack;
+use Utopia\Pools\Pool as UtopiaPool;
+
+/**
+ * A connection records a timeout and applies it to the statements it builds
+ * afterwards; it never asks the server for one. The pooled adapter must
+ * therefore hold the timeout itself and apply it to each connection as it is
+ * checked out, rather than checking one out to carry the value.
+ */
+class PoolTimeoutTest extends TestCase
+{
+    public function testSetTimeoutDoesNotOpenAConnection(): void
+    {
+        $opened = 0;
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'unreachable', 1, function () use (&$opened) {
+            $opened++;
+
+            throw new \RuntimeException('SQLSTATE[HY000] [2002] Connection refused');
+        }, timeout: 0.0));
+
+        $adapter->setTimeout(300000);
+
+        $this->assertSame(0, $opened);
+        $this->assertSame(300000, $adapter->getTimeout());
+    }
+
+    /**
+     * The pool outlives the handle that configured it, so a connection carries
+     * whatever the last handle to hold it asked for. A timeout applied once, at
+     * the moment it was set, leaves every later checkout unbounded.
+     */
+    public function testTimeoutIsAppliedToEveryCheckout(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(300000);
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([Database::EVENT_ALL => 300000], $connection->timeouts);
+
+        $connection->timeouts = [];
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([Database::EVENT_ALL => 300000], $connection->timeouts);
+    }
+
+    public function testClearedTimeoutIsClearedOnEveryCheckout(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(300000);
+        $adapter->getSupportForTimeouts();
+        $adapter->clearTimeout(Database::EVENT_ALL);
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([], $connection->timeouts);
+        $this->assertSame(0, $adapter->getTimeout());
+    }
+
+    public function testPerEventTimeoutReachesTheConnection(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(300000);
+        $adapter->setTimeout(5000, Database::EVENT_DOCUMENT_READ);
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([
+            Database::EVENT_ALL => 300000,
+            Database::EVENT_DOCUMENT_READ => 5000,
+        ], $connection->timeouts);
+    }
+
+    /**
+     * A caller whose own default is zero is asking for no timeout, which is
+     * what a factory building a handle without one passes. It reaches no
+     * connection as a timeout the connection would refuse.
+     */
+    public function testZeroIsHeldAsNoTimeout(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(0);
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([], $connection->timeouts);
+        $this->assertSame(0, $adapter->getTimeout());
+    }
+}
+
+/**
+ * Stands in for a connection: records what the pooled adapter applied to it,
+ * the way a concrete adapter records a timeout for the statements it builds.
+ */
+class TimeoutRecordingMemory extends Memory
+{
+    /**
+     * @var array<string, int>
+     */
+    public array $timeouts = [];
+
+    public function setTimeout(int $milliseconds, string $event = Database::EVENT_ALL): void
+    {
+        $this->timeouts[$event] = $milliseconds;
+        $this->timeout = $milliseconds;
+    }
+
+    public function clearTimeout(string $event): void
+    {
+        unset($this->timeouts[$event]);
+
+        parent::clearTimeout($event);
+    }
+}

--- a/tests/unit/PoolTimeoutTest.php
+++ b/tests/unit/PoolTimeoutTest.php
@@ -67,6 +67,7 @@ class PoolTimeoutTest extends TestCase
         $adapter->getSupportForTimeouts();
 
         $this->assertSame([], $connection->timeouts);
+        $this->assertSame(0, $connection->getTimeout());
         $this->assertSame(0, $adapter->getTimeout());
     }
 
@@ -81,9 +82,56 @@ class PoolTimeoutTest extends TestCase
         $adapter->getSupportForTimeouts();
 
         $this->assertSame([
-            Database::EVENT_ALL => 300000,
             Database::EVENT_DOCUMENT_READ => 5000,
-        ], $connection->timeouts);
+            Database::EVENT_ALL => 300000,
+        ], $connection->timeouts, 'The global timeout is applied last so the connection ends on the scalar the pool reports');
+        $this->assertSame(300000, $connection->getTimeout());
+    }
+
+    /**
+     * The concrete adapters keep one timeout scalar, which Postgres writes into
+     * `SET statement_timeout` and Mongo into `maxTimeMS` for every statement.
+     * Forwarding a per-event clear verbatim zeroed that scalar, so clearing the
+     * timeout on one event left everything else running unbounded.
+     */
+    public function testClearingOneEventLeavesTheGlobalTimeoutInPlace(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $adapter = new Pool(new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0));
+
+        $adapter->setAuthorization(new Authorization());
+        $adapter->setTimeout(300000);
+        $adapter->setTimeout(5000, Database::EVENT_DOCUMENT_READ);
+        $adapter->clearTimeout(Database::EVENT_DOCUMENT_READ);
+        $adapter->getSupportForTimeouts();
+
+        $this->assertSame([Database::EVENT_ALL => 300000], $connection->timeouts);
+        $this->assertSame(300000, $connection->getTimeout(), 'Postgres and Mongo bound every statement by this scalar, so clearing one event must not zero it');
+        $this->assertSame(300000, $adapter->getTimeout());
+    }
+
+    /**
+     * A pool is shared: the same connection is handed to a handle built for a
+     * long migration with no timeout and to a request handle bounded at 5s. A
+     * handle holding no timeout must reset what it is given, or it inherits the
+     * bound the last holder left and a migration is killed mid-run.
+     */
+    public function testHandleWithNoTimeoutResetsTheConnectionItIsGiven(): void
+    {
+        $connection = new TimeoutRecordingMemory();
+        $pool = new UtopiaPool(new Stack(), 'memory', 1, fn () => $connection, timeout: 0.0);
+
+        $bounded = new Pool($pool);
+        $bounded->setAuthorization(new Authorization());
+        $bounded->setTimeout(5000);
+        $bounded->getSupportForTimeouts();
+
+        $unbounded = new Pool($pool);
+        $unbounded->setAuthorization(new Authorization());
+        $unbounded->getSupportForTimeouts();
+
+        $this->assertSame([], $connection->timeouts, 'A handle that asked for no timeout must not run under the last holder\'s');
+        $this->assertSame(0, $connection->getTimeout());
     }
 
     /**


### PR DESCRIPTION
## What

`Pool::setTimeout()` delegated through `$pool->use()`, checking a connection out purely to carry the value.

No adapter needs a connection for this. `MariaDB`, `MySQL`, `Postgres` and `Mongo` all just record the timeout and apply it to the SQL they build afterwards — none contacts the server. The checkout existed only to write a number onto whichever connection answered, which the pool took back moments later.

## Why it matters

Two defects fell out of that:

1. **The timeout bound one connection and none of its siblings.** `Pool::setTimeout()` never recorded the value on the pool, so `getTimeout()` stayed `0` and the `if ($this->getTimeout() > 0)` replay in the checkout path never fired. A handle configured for a 300s timeout ran unbounded on every connection except the one that happened to answer the setter.

2. **Building a handle dialled the database.** A factory that only constructs a `Database` — sets database, namespace, timeout — failed outright while the backing was unreachable, reporting a refusal to a caller that had not yet issued a query. In Appwrite Cloud this is `CLOUD-3PKZ`: the billing project-aggregation worker raised 196,554 "database refused the request" errors in 25 days from `Factory->logs()`, which does nothing but build a handle. The same worker's genuine query-time refusals over the same window number 38.

## Change

The pool holds the timeout per event and applies it to each connection as it is checked out, replacing whatever the previous holder left there — connections outlive the handle that configured them and are shared across handles that want a different timeout or none. A cleared event is kept at `0` rather than dropped so the clear reaches that connection too.

`setTimeout()` keeps the `<= 0` rejection the concrete adapters raise, so a caller mistake stays an error instead of becoming a silently absent timeout.

## Tests

`tests/unit/PoolTimeoutTest.php`. Verified red before the fix — 3 failures + 1 error out of 5:

- `testSetTimeoutDoesNotOpenAConnection` — pool factory throws `Connection refused`; the setter must not reach it
- `testTimeoutIsAppliedToEveryCheckout` — a connection whose timeout was cleared by another holder gets it back on the next checkout
- `testClearedTimeoutIsClearedOnEveryCheckout`
- `testNonPositiveTimeoutIsRejected`
- `testPerEventTimeoutReachesTheConnection` — passes on both shapes; guards the fix against silently dropping timeouts

`composer check` (PHPStan level 7) and `composer lint` clean; unit suite 456 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pool timeout settings are now retained consistently across connection checkouts.
  * Cleared timeouts remain cleared when connections are reused.
  * Per-event timeout settings are applied reliably to each checked-out connection.
  * Timeout configuration no longer requires opening a database connection immediately.
  * Non-positive timeout values are rejected with a clear database error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->