### PR TITLE
feat: drop unknown attributes on schema-managed writes instead of failing

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5771,7 +5771,6 @@ class Database
         }
 
         $document = $this->encode($collection, $document);
-        $document = $this->removeUnknownAttributes($collection, $document);
 
         if ($this->validate) {
             $validator = new Permissions();
@@ -5893,7 +5892,6 @@ class Database
             }
 
             $document = $this->encode($collection, $document);
-            $document = $this->removeUnknownAttributes($collection, $document);
 
             if ($this->validate) {
                 $validator = new Structure(
@@ -6661,7 +6659,6 @@ class Database
             $updates,
             applyDefaults: false
         );
-        $updates = $this->removeUnknownAttributes($collection, $updates);
 
         if ($this->validate) {
             $validator = new PartialStructure(
@@ -9263,22 +9260,28 @@ class Database
     }
 
     /**
-     * Remove attributes the collection schema does not declare
+     * Remove attributes the collection schema does not declare.
+     *
+     * Used ahead of change detection on update/upsert so a dropped key is not
+     * counted as a write. Encode also calls this after iterating attributes.
      *
      * @param Document $collection
      * @param Document $document
+     * @param array<string, true>|null $known Attribute ids already collected (e.g. during encode)
      *
      * @return Document
      */
-    protected function removeUnknownAttributes(Document $collection, Document $document): Document
+    protected function removeUnknownAttributes(Document $collection, Document $document, ?array $known = null): Document
     {
         if (!$this->dropUnknownAttributes || !$this->adapter->getSupportForAttributes()) {
             return $document;
         }
 
-        $known = [];
-        foreach ($collection->getAttribute('attributes', []) as $attribute) {
-            $known[$attribute['$id'] ?? ''] = true;
+        if ($known === null) {
+            $known = [];
+            foreach ($collection->getAttribute('attributes', []) as $attribute) {
+                $known[$attribute['$id'] ?? ''] = true;
+            }
         }
 
         $dropped = [];
@@ -9304,6 +9307,9 @@ class Database
     /**
      * Encode Document
      *
+     * When dropUnknownAttributes is enabled, attributes missing from the
+     * collection schema are removed here while the known set is collected.
+     *
      * @param Document $collection
      * @param Document $document
      * @param bool $applyDefaults Whether to apply default values to null attributes
@@ -9319,8 +9325,10 @@ class Database
             $attributes[] = $attribute;
         }
 
+        $known = [];
         foreach ($attributes as $attribute) {
             $key = $attribute['$id'] ?? '';
+            $known[$key] = true;
             $array = $attribute['array'] ?? false;
             $default = $attribute['default'] ?? null;
             $filters = $attribute['filters'] ?? [];
@@ -9373,7 +9381,7 @@ class Database
             $document->setAttribute($key, $value);
         }
 
-        return $document;
+        return $this->removeUnknownAttributes($collection, $document, $known);
     }
 
     /**

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -6339,6 +6339,11 @@ class Database
             }
             $document = new Document($document);
 
+            // Ahead of change detection: a dropped attribute is never persisted, so
+            // counting it as a change would bump $updatedAt and fire an update event
+            // for a write that leaves the stored document identical.
+            $document = $this->removeUnknownAttributes($collection, $document);
+
             $attributes = $collection->getAttribute('attributes', []);
 
             $relationships = \array_filter($attributes, function ($attribute) {
@@ -6480,7 +6485,6 @@ class Database
             }
 
             $document = $this->encode($collection, $document);
-            $document = $this->removeUnknownAttributes($collection, $document);
 
             if ($this->validate) {
                 $structureValidator = new Structure(
@@ -7417,6 +7421,8 @@ class Database
         foreach ($documents as $key => $document) {
             $old = $existingDocs[$this->tenantKey($document)] ?? new Document();
 
+            $document = $this->removeUnknownAttributes($collection, $document);
+
             // Extract operators early to avoid comparison issues
             $documentArray = $document->getArrayCopy();
             $extracted = Operator::extractOperators($documentArray);
@@ -7549,7 +7555,6 @@ class Database
             }
 
             $document = $this->encode($collection, $document);
-            $document = $this->removeUnknownAttributes($collection, $document);
 
             if ($this->validate) {
                 $validator = new Structure(

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -428,6 +428,8 @@ class Database
 
     protected bool $validate = true;
 
+    protected bool $dropUnknownAttributes = false;
+
     protected bool $preserveDates = false;
 
     protected bool $skipDuplicates = false;
@@ -1493,6 +1495,25 @@ class Database
         $className = $this->documentTypes[$collection] ?? Document::class;
 
         return new $className($data);
+    }
+
+    public function getDropUnknownAttributes(): bool
+    {
+        return $this->dropUnknownAttributes;
+    }
+
+    /**
+     * Drop attributes missing from the collection schema instead of rejecting the write.
+     *
+     * Enable this where the schema is owned by the application rather than the caller, so a
+     * deploy that writes an attribute before its migration has run degrades to a warning
+     * instead of failing every write.
+     */
+    public function setDropUnknownAttributes(bool $drop): static
+    {
+        $this->dropUnknownAttributes = $drop;
+
+        return $this;
     }
 
     public function getPreserveDates(): bool
@@ -5750,6 +5771,7 @@ class Database
         }
 
         $document = $this->encode($collection, $document);
+        $document = $this->removeUnknownAttributes($collection, $document);
 
         if ($this->validate) {
             $validator = new Permissions();
@@ -5871,6 +5893,7 @@ class Database
             }
 
             $document = $this->encode($collection, $document);
+            $document = $this->removeUnknownAttributes($collection, $document);
 
             if ($this->validate) {
                 $validator = new Structure(
@@ -6457,6 +6480,7 @@ class Database
             }
 
             $document = $this->encode($collection, $document);
+            $document = $this->removeUnknownAttributes($collection, $document);
 
             if ($this->validate) {
                 $structureValidator = new Structure(
@@ -6633,6 +6657,7 @@ class Database
             $updates,
             applyDefaults: false
         );
+        $updates = $this->removeUnknownAttributes($collection, $updates);
 
         if ($this->validate) {
             $validator = new PartialStructure(
@@ -7524,6 +7549,7 @@ class Database
             }
 
             $document = $this->encode($collection, $document);
+            $document = $this->removeUnknownAttributes($collection, $document);
 
             if ($this->validate) {
                 $validator = new Structure(
@@ -9229,6 +9255,45 @@ class Database
             'decode' => $decode,
             'signature' => self::computeCallableSignature($encode) . ':' . self::computeCallableSignature($decode),
         ];
+    }
+
+    /**
+     * Remove attributes the collection schema does not declare
+     *
+     * @param Document $collection
+     * @param Document $document
+     *
+     * @return Document
+     */
+    protected function removeUnknownAttributes(Document $collection, Document $document): Document
+    {
+        if (!$this->dropUnknownAttributes || !$this->adapter->getSupportForAttributes()) {
+            return $document;
+        }
+
+        $known = [];
+        foreach ($collection->getAttribute('attributes', []) as $attribute) {
+            $known[$attribute['$id'] ?? ''] = true;
+        }
+
+        $dropped = [];
+        foreach (\array_keys($document->getArrayCopy()) as $key) {
+            if (\str_starts_with($key, '$') || isset($known[$key])) {
+                continue;
+            }
+
+            $dropped[] = $key;
+            $document->removeAttribute($key);
+        }
+
+        if (!empty($dropped)) {
+            Console::warning(
+                'Dropped unknown attributes "' . \implode('", "', $dropped) . '" from collection "' . $collection->getId() . '"'
+                . ($this->adapter->getTenant() === null ? '' : ' on tenant ' . $this->adapter->getTenant())
+            );
+        }
+
+        return $document;
     }
 
     /**

--- a/src/Database/Mirror.php
+++ b/src/Database/Mirror.php
@@ -130,6 +130,15 @@ class Mirror extends Database
         return $this;
     }
 
+    public function setDropUnknownAttributes(bool $drop): static
+    {
+        $this->delegate(__FUNCTION__, \func_get_args());
+
+        $this->dropUnknownAttributes = $drop;
+
+        return $this;
+    }
+
     public function setPreserveDates(bool $preserve): static
     {
         $this->delegate(__FUNCTION__, \func_get_args());

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -9149,4 +9149,73 @@ trait DocumentTests
         $this->assertSame(['existingChild', 'newChild', 'retryChild'], $allChildIds);
     }
 
+
+    public function testDropUnknownAttributes(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        if (!$database->getAdapter()->getSupportForAttributes()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $permissions = [
+            Permission::read(Role::any()),
+            Permission::create(Role::any()),
+            Permission::update(Role::any()),
+            Permission::delete(Role::any()),
+        ];
+
+        $database->createCollection(__FUNCTION__);
+        $this->assertEquals(true, $database->createAttribute(__FUNCTION__, 'known', Database::VAR_STRING, 128, false));
+
+        try {
+            $database->createDocument(__FUNCTION__, new Document([
+                '$id' => 'strict',
+                '$permissions' => $permissions,
+                'known' => 'kept',
+                'unknown' => 'dropped',
+            ]));
+            $this->fail('Unknown attribute was accepted while dropping is disabled');
+        } catch (StructureException $e) {
+            $this->assertEquals('Invalid document structure: Unknown attribute: "unknown"', $e->getMessage());
+        }
+
+        $database->setDropUnknownAttributes(true);
+
+        try {
+            $created = $database->createDocument(__FUNCTION__, new Document([
+                '$id' => 'lenient',
+                '$permissions' => $permissions,
+                'known' => 'kept',
+                'unknown' => 'dropped',
+            ]));
+
+            $this->assertEquals('kept', $created->getAttribute('known'));
+            $this->assertNull($created->getAttribute('unknown'), 'Unknown attribute survived the create');
+
+            $database->purgeCachedDocument(__FUNCTION__, 'lenient');
+            $stored = $database->getDocument(__FUNCTION__, 'lenient');
+            $this->assertEquals('kept', $stored->getAttribute('known'));
+            $this->assertNull($stored->getAttribute('unknown'), 'Unknown attribute reached storage on create');
+
+            $updated = $database->updateDocument(__FUNCTION__, 'lenient', new Document([
+                '$id' => 'lenient',
+                '$permissions' => $permissions,
+                'known' => 'changed',
+                'unknown' => 'dropped',
+            ]));
+
+            $this->assertEquals('changed', $updated->getAttribute('known'));
+            $this->assertNull($updated->getAttribute('unknown'), 'Unknown attribute survived the update');
+
+            $database->purgeCachedDocument(__FUNCTION__, 'lenient');
+            $stored = $database->getDocument(__FUNCTION__, 'lenient');
+            $this->assertEquals('changed', $stored->getAttribute('known'));
+            $this->assertNull($stored->getAttribute('unknown'), 'Unknown attribute reached storage on update');
+        } finally {
+            $database->setDropUnknownAttributes(false);
+        }
+    }
 }

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -9214,6 +9214,21 @@ trait DocumentTests
             $stored = $database->getDocument(__FUNCTION__, 'lenient');
             $this->assertEquals('changed', $stored->getAttribute('known'));
             $this->assertNull($stored->getAttribute('unknown'), 'Unknown attribute reached storage on update');
+
+            \usleep(5000);
+
+            $unchanged = $database->updateDocument(__FUNCTION__, 'lenient', new Document([
+                '$id' => 'lenient',
+                '$permissions' => $permissions,
+                'known' => 'changed',
+                'unknown' => 'dropped',
+            ]));
+
+            $this->assertEquals(
+                $stored->getUpdatedAt(),
+                $unchanged->getUpdatedAt(),
+                'A write carrying only a dropped attribute counted as a change'
+            );
         } finally {
             $database->setDropUnknownAttributes(false);
         }

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -9185,6 +9185,16 @@ trait DocumentTests
         $database->setDropUnknownAttributes(true);
 
         try {
+            $collection = $database->getCollection(__FUNCTION__);
+            $encoded = $database->encode($collection, new Document([
+                '$id' => 'encoded',
+                '$collection' => __FUNCTION__,
+                'known' => 'kept',
+                'unknown' => 'dropped',
+            ]));
+            $this->assertEquals('kept', $encoded->getAttribute('known'));
+            $this->assertNull($encoded->getAttribute('unknown'), 'Unknown attribute survived encode');
+
             $created = $database->createDocument(__FUNCTION__, new Document([
                 '$id' => 'lenient',
                 '$permissions' => $permissions,


### PR DESCRIPTION
## What

Adds `Database::setDropUnknownAttributes(bool)`. When enabled, an attribute the collection schema does not declare is removed from the document before the write and logged as a warning, instead of failing the write with `Invalid document structure: Unknown attribute: "x"`.

Off by default, so nothing changes for any existing caller.

## Why

A deploy that starts writing an attribute before the migration that creates its column has run makes **every** write to that collection throw. On Appwrite Cloud this took OAuth2 login down for every provider: the `identities` row carried `photoUrl`, the deployed schema did not, and `/v1/account/sessions/oauth2/:provider/redirect` 500'd on each login until the feature was reverted (appwrite/appwrite#13326, reverted by appwrite/appwrite#13355).

The rejection is right when the caller owns the schema, and wrong when the application owns it. A column that has not been created yet is a deploy-ordering fact, not bad input, and refusing the write turns it into an outage. This lets the schema owner opt into the degradation: the request completes with the columns that exist, the missing value is lost until the migration runs and the writer sends it again, and the warning names what was dropped.

It stays off by default because for a caller writing into their own schema, silently discarding data they sent is worse than refusing it.

## Scope

The drop removes **exactly** the set `Structure` would have rejected: keys that are neither `$`-prefixed nor declared in `collection.attributes`. So any write that validates today is unchanged, and the only writes whose behaviour changes are the ones that throw today.

Adapters without attribute support are skipped entirely, so schemaless collections are untouched.

Applied on all five write paths that validate structure: `createDocument`, `createDocuments`, `updateDocument`, `updateDocuments`, `upsertDocumentsWithIncrease`.

On `updateDocument` and `upsertDocumentsWithIncrease` the removal runs **before** the change-detection diff, not after `encode()`. A dropped attribute is never in the stored document, so diffing against it first made a write carrying one look like a real change: `$updatedAt` bumped and `EVENT_DOCUMENT_UPDATE` fired on an identical row. That is the exact shape of the deploy window this flag is for, so it would have meant a spurious update event per request to every webhook, function and realtime subscriber on the collection.

`Mirror` forwards every write to its source and destination, so it delegates the setter the same way it already delegates `preserveDates` and `preserveSequence`. Without that the flag decided nothing on a mirrored deployment, which the new test caught under the Mirror adapter.

## Tests

`testDropUnknownAttributes` in `DocumentTests` drives the public entry points and asserts what the database is holding afterwards, not just that no exception was raised:

- with the flag off, `createDocument` still throws `Invalid document structure: Unknown attribute: "unknown"`
- with the flag on, create and update both succeed, the declared attribute persists, and the undeclared one is absent from a cache-purged read on both paths
- a further update whose only new value is the dropped attribute leaves `$updatedAt` untouched

Both halves were seen red before being fixed:

- with `removeUnknownAttributes` reverted to a pass-through, the test fails with `Utopia\Database\Exception\Structure: Invalid document structure: Unknown attribute: "unknown"`, the production error verbatim
- with the removal moved back after `encode()`, the `$updatedAt` assertion fails on a 10ms difference

The Mirror delegation was found by the test, not by inspection: it failed under `MirrorTest` before the override existed.

## Follow-up

Consumers opt in separately: appwrite/appwrite#13357 enables it on the platform, project and logs handles and leaves tenant handles strict, and appwrite-labs/cloud#5463 does the same for cloud's own factory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for removing attributes that are not defined in the document schema when configured.
  - Added configuration support for applying this behavior consistently across mirrored databases.

- **Bug Fixes**
  - Unknown attributes are now removed during encoding and persistence.
  - Updates containing only unknown attributes no longer register as document changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->