### PR TITLE
CLOUD-3JK8

### DIFF
--- a/src/Database/Query.php
+++ b/src/Database/Query.php
@@ -393,7 +393,13 @@ class Query
 
         if (\in_array($method, self::LOGICAL_TYPES)) {
             foreach ($values as $index => $value) {
-                $values[$index] = self::parseQuery($value);
+                if (\is_string($value)) {
+                    $values[$index] = self::parse($value);
+                } elseif (\is_array($value)) {
+                    $values[$index] = self::parseQuery($value);
+                } else {
+                    throw new QueryException('Invalid nested query. Must be an array or string, got ' . \gettype($value));
+                }
             }
         }
 

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -399,7 +399,7 @@ class QueryTest extends TestCase
     {
         // Some clients serialize the children of a logical query as JSON strings
         // rather than nested objects. Parsing must handle that without a TypeError.
-        $json = \json_encode([
+        $json = (string) \json_encode([
             'method' => Query::TYPE_OR,
             'values' => [
                 Query::equal('actors', ['Brad Pitt'])->toString(),
@@ -422,7 +422,7 @@ class QueryTest extends TestCase
         // A nested value that is neither an array nor a string is a clean
         // QueryException, never an uncaught TypeError.
         try {
-            Query::parse(\json_encode(['method' => Query::TYPE_OR, 'values' => [123]]));
+            Query::parse((string) \json_encode(['method' => Query::TYPE_OR, 'values' => [123]]));
             $this->fail('Failed to throw exception');
         } catch (QueryException $e) {
             $this->assertEquals('Invalid nested query. Must be an array or string, got integer', $e->getMessage());

--- a/tests/unit/QueryTest.php
+++ b/tests/unit/QueryTest.php
@@ -395,6 +395,40 @@ class QueryTest extends TestCase
         $this->assertEquals([], $query->getValues());
     }
 
+    public function testParseNestedStringValues(): void
+    {
+        // Some clients serialize the children of a logical query as JSON strings
+        // rather than nested objects. Parsing must handle that without a TypeError.
+        $json = \json_encode([
+            'method' => Query::TYPE_OR,
+            'values' => [
+                Query::equal('actors', ['Brad Pitt'])->toString(),
+                Query::equal('actors', ['Johnny Depp'])->toString(),
+            ],
+        ]);
+
+        $query = Query::parse($json);
+
+        /** @var array<Query> $queries */
+        $queries = $query->getValues();
+        $this->assertEquals(Query::TYPE_OR, $query->getMethod());
+        $this->assertCount(2, $queries);
+        $this->assertEquals(Query::TYPE_EQUAL, $queries[0]->getMethod());
+        $this->assertEquals('actors', $queries[0]->getAttribute());
+        $this->assertEquals(['Brad Pitt'], $queries[0]->getValues());
+        $this->assertEquals(Query::TYPE_EQUAL, $queries[1]->getMethod());
+        $this->assertEquals(['Johnny Depp'], $queries[1]->getValues());
+
+        // A nested value that is neither an array nor a string is a clean
+        // QueryException, never an uncaught TypeError.
+        try {
+            Query::parse(\json_encode(['method' => Query::TYPE_OR, 'values' => [123]]));
+            $this->fail('Failed to throw exception');
+        } catch (QueryException $e) {
+            $this->assertEquals('Invalid nested query. Must be an array or string, got integer', $e->getMessage());
+        }
+    }
+
     public function testIsMethod(): void
     {
         $this->assertTrue(Query::isMethod('equal'));


### PR DESCRIPTION
The bug

  Query::parseQuery()'s logical-operator branch (or/and/elemMatch) assumed every nested value is a decoded array:

  foreach ($values as $index => $value) {
      $values[$index] = self::parseQuery($value); // $value can be a string → TypeError
  }

  When a client sends nested queries double-encoded (each child as a JSON string, e.g. {"method":"or","values":["{\"method\":\"equal\"...}"]}) — which some SDKs do — $value is a string.
  Passing it to parseQuery(array $query) throws a TypeError, not a QueryException. Appwrite's catch (QueryException) in Documents/XList.php:107 doesn't catch it, so it escaped as an
  uncaught 500.

  The fix (src/Database/Query.php)

  Normalize nested values — decode strings, recurse arrays, and reject anything else as a clean QueryException:

  if (\is_string($value)) {
      $values[$index] = self::parse($value);
  } elseif (\is_array($value)) {
      $values[$index] = self::parseQuery($value);
  } else {
      throw new QueryException('Invalid nested query. Must be an array or string, got ' . \gettype($value));
  }
  (→ 500).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested logical queries provided as JSON strings or structured values.
  * Invalid nested query value types now return a clear query error instead of causing an unexpected runtime failure.

* **Tests**
  * Added coverage for serialized nested queries and validation of invalid nested values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->