### PR TITLE
fix(adapter): write permission rows with the document's tenant on update

### DIFF
--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1001,7 +1001,11 @@ class MariaDB extends SQL
                 $stmtRemovePermissions = $this->getPDO()->prepare($sql);
                 $stmtRemovePermissions->bindValue(':_uid', $id);
                 if ($this->sharedTables) {
-                    $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+                    // The document's own tenant, not the adapter's: a row whose
+                    // tenant differs from the selected one (a shared collection's
+                    // null-tenant _metadata row) would otherwise keep its old
+                    // permissions and gain a second, wrongly-tenanted copy.
+                    $stmtRemovePermissions->bindValue(':_tenant', $document->getTenant());
                 }
 
                 $values = [];
@@ -1026,7 +1030,7 @@ class MariaDB extends SQL
                     $stmtAddPermissions = $this->getPDO()->prepare($sql);
                     $stmtAddPermissions->bindValue(":_uid", $newUid);
                     if ($this->sharedTables) {
-                        $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+                        $stmtAddPermissions->bindValue(":_tenant", $document->getTenant());
                     }
 
                     foreach ($binds as $key => $permission) {

--- a/src/Database/Adapter/MariaDB.php
+++ b/src/Database/Adapter/MariaDB.php
@@ -1001,10 +1001,6 @@ class MariaDB extends SQL
                 $stmtRemovePermissions = $this->getPDO()->prepare($sql);
                 $stmtRemovePermissions->bindValue(':_uid', $id);
                 if ($this->sharedTables) {
-                    // The document's own tenant, not the adapter's: a row whose
-                    // tenant differs from the selected one (a shared collection's
-                    // null-tenant _metadata row) would otherwise keep its old
-                    // permissions and gain a second, wrongly-tenanted copy.
                     $stmtRemovePermissions->bindValue(':_tenant', $document->getTenant());
                 }
 

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1127,7 +1127,11 @@ class Postgres extends SQL
             $stmtRemovePermissions = $this->getPDO()->prepare($sql);
             $stmtRemovePermissions->bindValue(':_uid', $id);
             if ($this->sharedTables) {
-                $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+                // The document's own tenant, not the adapter's: a row whose
+                // tenant differs from the selected one (a shared collection's
+                // null-tenant _metadata row) would otherwise keep its old
+                // permissions and gain a second, wrongly-tenanted copy.
+                $stmtRemovePermissions->bindValue(':_tenant', $document->getTenant());
             }
 
             $values = [];
@@ -1152,7 +1156,7 @@ class Postgres extends SQL
                 $stmtAddPermissions = $this->getPDO()->prepare($sql);
                 $stmtAddPermissions->bindValue(":_uid", $newUid);
                 if ($this->sharedTables) {
-                    $stmtAddPermissions->bindValue(':_tenant', $this->tenant);
+                    $stmtAddPermissions->bindValue(':_tenant', $document->getTenant());
                 }
 
                 foreach ($binds as $key => $permission) {

--- a/src/Database/Adapter/Postgres.php
+++ b/src/Database/Adapter/Postgres.php
@@ -1127,10 +1127,6 @@ class Postgres extends SQL
             $stmtRemovePermissions = $this->getPDO()->prepare($sql);
             $stmtRemovePermissions->bindValue(':_uid', $id);
             if ($this->sharedTables) {
-                // The document's own tenant, not the adapter's: a row whose
-                // tenant differs from the selected one (a shared collection's
-                // null-tenant _metadata row) would otherwise keep its old
-                // permissions and gain a second, wrongly-tenanted copy.
                 $stmtRemovePermissions->bindValue(':_tenant', $document->getTenant());
             }
 

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -1269,9 +1269,6 @@ class SQLite extends MariaDB
         $attributes['_uid'] = $document->getId();
 
         if ($this->sharedTables) {
-            // The document's own tenant, not the adapter's: writing the
-            // selected tenant here moves a row (a shared collection's
-            // null-tenant _metadata row) onto whoever happened to be selected.
             $attributes['_tenant'] = $document->getTenant();
         }
 

--- a/src/Database/Adapter/SQLite.php
+++ b/src/Database/Adapter/SQLite.php
@@ -1269,7 +1269,10 @@ class SQLite extends MariaDB
         $attributes['_uid'] = $document->getId();
 
         if ($this->sharedTables) {
-            $attributes['_tenant'] = $this->tenant;
+            // The document's own tenant, not the adapter's: writing the
+            // selected tenant here moves a row (a shared collection's
+            // null-tenant _metadata row) onto whoever happened to be selected.
+            $attributes['_tenant'] = $document->getTenant();
         }
 
         $name = $this->filter($collection);
@@ -1289,7 +1292,7 @@ class SQLite extends MariaDB
             $stmtRemovePermissions = $this->getPDO()->prepare($sql);
             $stmtRemovePermissions->bindValue(':_uid', $id);
             if ($this->sharedTables) {
-                $stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
+                $stmtRemovePermissions->bindValue(':_tenant', $document->getTenant());
             }
 
             $values = [];
@@ -1314,7 +1317,7 @@ class SQLite extends MariaDB
                 $stmtAddPermissions = $this->getPDO()->prepare($sql);
                 $stmtAddPermissions->bindValue(":_uid", $newUid);
                 if ($this->sharedTables) {
-                    $stmtAddPermissions->bindValue(":_tenant", $this->tenant);
+                    $stmtAddPermissions->bindValue(":_tenant", $document->getTenant());
                 }
 
                 foreach ($binds as $key => $permission) {

--- a/tests/e2e/Adapter/Scopes/PermissionTests.php
+++ b/tests/e2e/Adapter/Scopes/PermissionTests.php
@@ -3,6 +3,7 @@
 namespace Tests\E2E\Adapter\Scopes;
 
 use Exception;
+use Utopia\Database\Adapter\SQL;
 use Utopia\Database\Database;
 use Utopia\Database\Document;
 use Utopia\Database\Exception as DatabaseException;
@@ -10,9 +11,55 @@ use Utopia\Database\Exception\Authorization as AuthorizationException;
 use Utopia\Database\Helpers\ID;
 use Utopia\Database\Helpers\Permission;
 use Utopia\Database\Helpers\Role;
+use Utopia\Database\Query;
 
 trait PermissionTests
 {
+    public function testUpdatingASharedDefinitionKeepsItsPermissionRowsTenantless(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        // Only the SQL adapters keep permissions in a side table that carries
+        // its own tenant column; Mongo stores them on the document itself.
+        if (!$database->getSharedTables() || !$database->getAdapter() instanceof SQL) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $tenant = $database->getTenant();
+        $collection = 'sharedDefinitionPerms';
+
+        try {
+            // A shared pool's system collections are created once with no
+            // tenant, so every tenant on the pool reads the one definition.
+            $database->setTenant(null);
+            $database->createCollection($collection, [], [], [Permission::read(Role::any())], false);
+
+            // A per-project pass rewrites that definition while it holds one
+            // project's tenant. The rows it writes belong to the document, not
+            // to whoever happened to be selected.
+            $database->setTenant(989);
+            $database->updateDocument(Database::METADATA, $collection, new Document([
+                '$id' => $collection,
+                '$permissions' => [Permission::read(Role::any()), Permission::update(Role::any())],
+            ]));
+
+            // Permission filtering reads the permission rows, so tenanting them
+            // to 989 hides the shared definition from every other tenant.
+            $database->setTenant(990);
+            $found = $database->find(Database::METADATA, [Query::equal('$id', [$collection])]);
+
+            $this->assertCount(
+                1,
+                $found,
+                'A shared definition updated under one tenant must stay visible to the rest of the pool.',
+            );
+        } finally {
+            $database->setTenant($tenant);
+        }
+    }
+
     public function testUnsetPermissions(): void
     {
         /** @var Database $database */


### PR DESCRIPTION
## The bug

`createDocument` binds the **document's** own tenant for the rows it writes to the `_perms` side table. `updateDocument` bound the **adapter's**:

```php
// createDocument
$stmtPermissions->bindValue(':_tenant', $document->getTenant());

// updateDocument
$stmtRemovePermissions->bindValue(':_tenant', $this->tenant);
$stmtAddPermissions->bindValue(':_tenant', $this->tenant);
```

The two only diverge for a row whose tenant is not the selected one. On a shared pool that is the null-tenant `_metadata` row of a collection created once for every tenant: `getTenantQuery()` carves out `OR _tenant IS NULL` when the collection is `Database::METADATA`, so such a row is readable and updatable with any tenant selected, and `Database::updateDocument` deliberately forces `$document['$tenant'] = $old->getTenant()` to keep it where it is.

Updating one under a tenant left the document row on `NULL` and its permission rows on that tenant:

```
after createCollection (tenant null):
  read/any tenant=NULL
after updateDocument under tenant 989:
  read/any   tenant='989'
  update/any tenant='989'
document row tenant=NULL
```

Permission filtering reads those rows (`getSQLPermissionsCondition` subqueries `_perms`), so the shared definition became invisible to every other tenant on the pool — the same repro reports `permission-filtered find as an unrelated tenant: NOT FOUND`.

**SQLite** went further: its own `updateDocument` override rewrote the document row's `_tenant` column itself (`$attributes['_tenant'] = $this->tenant`), moving the row off the shared scope entirely.

## The fix

All three write sites use `$document->getTenant()`, matching `createDocument`. For every ordinary document this is a no-op — `$old` is fetched under the tenant query, so its tenant already equals the adapter's.

**Postgres** is fixed for consistency with its own `createDocument`. Its permission filtering reads the denormalised `_permissions` JSONB column rather than the side table, so the regression test cannot observe the difference there — stated plainly because that adapter's change is not test-covered.

## Testing

`testUpdatingASharedDefinitionKeepsItsPermissionRowsTenantless` in the shared `PermissionTests` scope, guarded to shared-tables runs on `SQL` adapters (Mongo keeps permissions on the document, so it cannot have this bug).

Seen red before green:

| adapter | without fix | with fix |
|---|---|---|
| MariaDB | FAILURES | OK |
| MySQL | FAILURES | OK |
| SQLite | FAILURES | OK |
| Postgres | OK (filters on `_permissions`, cannot observe) | OK |

Full `tests/e2e/Adapter/SharedTables` suites pass on all four: 672 tests each.

`composer lint` already fails on `main` for untouched files (`Mongo.php`, `Redis.php`); the four files here report the same violations before and after this change.

## Follow-up, not changed here

`SQLite::createDocument` also uses `$this->tenant` for the document row where `MariaDB::createDocument` uses `$document->getTenant()` (`src/Database/Adapter/SQLite.php:1155`). Same class of divergence, but nothing here exercises it, so it is left for a change that can prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission handling when updating shared records across tenants.
  * Shared definitions now retain tenant-independent permissions and remain visible to other tenants after updates.
  * Prevented duplicate or incorrectly tenant-scoped permission entries.

* **Tests**
  * Added coverage verifying shared definition visibility and permission behavior across tenants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->