### PR TITLE
perf: skip unused variant hashes when purging cached documents

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8554,7 +8554,7 @@ class Database
             return true;
         }
 
-        [$collectionKey, $documentKey] = $this->getCacheKeys($collectionId, $id, includeHash: false);
+        [$collectionKey, $documentKey] = $this->getCacheBaseKeys($collectionId, $id);
 
         $this->cache->purge($collectionKey, $documentKey);
         $this->cache->purge($documentKey);
@@ -9927,11 +9927,9 @@ class Database
     /**
      * @param string $collectionId
      * @param string|null $documentId
-     * @param array<string> $selects
-     * @param bool $includeHash Whether to compute the selection/filter variant hash. Purges invalidate every variant.
-     * @return array{0: string, 1: string, 2: string}
+     * @return array{0: string, 1: string}
      */
-    public function getCacheKeys(string $collectionId, ?string $documentId = null, array $selects = [], bool $includeHash = true): array
+    public function getCacheBaseKeys(string $collectionId, ?string $documentId = null): array
     {
         if ($this->adapter->getSupportForHostname()) {
             $hostname = $this->adapter->getHostname();
@@ -9956,13 +9954,20 @@ class Database
             $collectionId
         );
 
+        return [$collectionKey, $documentId ? "{$collectionKey}:{$documentId}" : ''];
+    }
+
+    /**
+     * @param string $collectionId
+     * @param string|null $documentId
+     * @param array<string> $selects
+     * @return array{0: string, 1: string, 2: string}
+     */
+    public function getCacheKeys(string $collectionId, ?string $documentId = null, array $selects = []): array
+    {
+        [$collectionKey, $documentKey] = $this->getCacheBaseKeys($collectionId, $documentId);
+
         if ($documentId) {
-            $documentKey = $documentHashKey = "{$collectionKey}:{$documentId}";
-
-            if (!$includeHash) {
-                return [$collectionKey, $documentKey, ''];
-            }
-
             $sortedSelects = $selects;
             \sort($sortedSelects);
 
@@ -9976,7 +9981,7 @@ class Database
 
         return [
             $collectionKey,
-            $documentKey ?? '',
+            $documentKey,
             $documentHashKey ?? ''
         ];
     }

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -8554,7 +8554,7 @@ class Database
             return true;
         }
 
-        [$collectionKey, $documentKey] = $this->getCacheKeys($collectionId, $id);
+        [$collectionKey, $documentKey] = $this->getCacheKeys($collectionId, $id, includeHash: false);
 
         $this->cache->purge($collectionKey, $documentKey);
         $this->cache->purge($documentKey);
@@ -9928,9 +9928,10 @@ class Database
      * @param string $collectionId
      * @param string|null $documentId
      * @param array<string> $selects
+     * @param bool $includeHash Whether to compute the selection/filter variant hash. Purges invalidate every variant.
      * @return array{0: string, 1: string, 2: string}
      */
-    public function getCacheKeys(string $collectionId, ?string $documentId = null, array $selects = []): array
+    public function getCacheKeys(string $collectionId, ?string $documentId = null, array $selects = [], bool $includeHash = true): array
     {
         if ($this->adapter->getSupportForHostname()) {
             $hostname = $this->adapter->getHostname();
@@ -9957,6 +9958,10 @@ class Database
 
         if ($documentId) {
             $documentKey = $documentHashKey = "{$collectionKey}:{$documentId}";
+
+            if (!$includeHash) {
+                return [$collectionKey, $documentKey, ''];
+            }
 
             $sortedSelects = $selects;
             \sort($sortedSelects);

--- a/tests/unit/CacheKeyTest.php
+++ b/tests/unit/CacheKeyTest.php
@@ -33,7 +33,7 @@ class CacheKeyTest extends TestCase
         return $hashKey;
     }
 
-    public function testHashCanBeSkippedWithoutChangingScopedKeys(): void
+    public function testBaseKeysMatchScopedVariantKeys(): void
     {
         $adapter = $this->createMock(Adapter::class);
         $adapter->method('getSupportForHostname')->willReturn(true);
@@ -47,9 +47,9 @@ class CacheKeyTest extends TestCase
 
         foreach ([['col', 'doc'], [Database::METADATA, 'col'], [Database::METADATA, 'global']] as [$collection, $document]) {
             $full = $db->getCacheKeys($collection, $document, ['name']);
-            $withoutHash = $db->getCacheKeys($collection, $document, ['name'], includeHash: false);
+            $withoutHash = $db->getCacheBaseKeys($collection, $document);
 
-            $this->assertSame([$full[0], $full[1], ''], $withoutHash);
+            $this->assertSame([$full[0], $full[1]], $withoutHash);
             $this->assertNotSame('', $full[2]);
         }
     }

--- a/tests/unit/CacheKeyTest.php
+++ b/tests/unit/CacheKeyTest.php
@@ -33,6 +33,27 @@ class CacheKeyTest extends TestCase
         return $hashKey;
     }
 
+    public function testHashCanBeSkippedWithoutChangingScopedKeys(): void
+    {
+        $adapter = $this->createMock(Adapter::class);
+        $adapter->method('getSupportForHostname')->willReturn(true);
+        $adapter->method('getHostname')->willReturn('mysql-project');
+        $adapter->method('getNamespace')->willReturn('project');
+        $adapter->method('getTenant')->willReturn(42);
+        $adapter->method('getSharedTables')->willReturn(true);
+
+        $db = new Database($adapter, new Cache(new None()));
+        $db->setGlobalCollections(['global']);
+
+        foreach ([['col', 'doc'], [Database::METADATA, 'col'], [Database::METADATA, 'global']] as [$collection, $document]) {
+            $full = $db->getCacheKeys($collection, $document, ['name']);
+            $withoutHash = $db->getCacheKeys($collection, $document, ['name'], includeHash: false);
+
+            $this->assertSame([$full[0], $full[1], ''], $withoutHash);
+            $this->assertNotSame('', $full[2]);
+        }
+    }
+
     public function testSameConfigProducesSameCacheKey(): void
     {
         $db1 = $this->createDatabase();

--- a/tests/unit/ForUpdateCacheTest.php
+++ b/tests/unit/ForUpdateCacheTest.php
@@ -53,6 +53,17 @@ class ForUpdateCacheTest extends TestCase
         $this->adapter->updateDocument($collection, 'project', $document, true);
     }
 
+    public function testPurgeMakesTheNextReadReturnFreshData(): void
+    {
+        $this->assertSame('stale', $this->database->getDocument('projects', 'project')->getAttribute('name'));
+        $this->staleCache('name', 'fresh');
+        $this->assertSame('stale', $this->database->getDocument('projects', 'project')->getAttribute('name'));
+
+        $this->database->purgeCachedDocument('projects', 'project');
+
+        $this->assertSame('fresh', $this->database->getDocument('projects', 'project')->getAttribute('name'));
+    }
+
     public function testForUpdateReadBypassesStaleCache(): void
     {
         $cached = $this->database->getDocument('projects', 'project');

--- a/tests/unit/WithCacheLeaseTest.php
+++ b/tests/unit/WithCacheLeaseTest.php
@@ -42,6 +42,25 @@ class WithCacheLeaseTest extends TestCase
         $this->key = $this->database->getQueryCacheKey('projects');
     }
 
+    public function testDocumentPurgeRemovesAllVariantsAndRejectsStaleWrites(): void
+    {
+        [$collectionKey, $documentKey, $firstHash] = $this->database->getCacheKeys('projects', 'project');
+        [, , $secondHash] = $this->database->getCacheKeys('projects', 'project', ['name']);
+        $this->cacheAdapter->save($collectionKey, 'legacy', $documentKey);
+        $this->cacheAdapter->save($documentKey, 'first', $firstHash);
+        $this->cacheAdapter->save($documentKey, 'second', $secondHash);
+        $lease = $this->cacheAdapter->getGeneration($documentKey);
+
+        $this->assertTrue($this->database->purgeCachedDocument('projects', 'project'));
+
+        $this->assertFalse($this->cacheAdapter->load($collectionKey, Database::TTL, $documentKey));
+        $this->assertFalse($this->cacheAdapter->load($documentKey, Database::TTL, $firstHash));
+        $this->assertFalse($this->cacheAdapter->load($documentKey, Database::TTL, $secondHash));
+        $this->cacheAdapter->saveWithLease($documentKey, 'stale', $firstHash, $lease);
+        $this->assertFalse($this->cacheAdapter->load($documentKey, Database::TTL, $firstHash));
+        $this->assertSame('fresh', $this->database->getDocument('projects', 'project')->getAttribute('name'));
+    }
+
     public function testStaleListWriteAfterConcurrentPurgeIsRejected(): void
     {
         $hash = 'list-hash';


### PR DESCRIPTION
Document purges currently compute a selection/filter variant hash and immediately discard it. Extract `getCacheBaseKeys()` for the collection/document keys and call it directly from `purgeCachedDocumentInternal()`, skipping filter-signature assembly, sorting, JSON encoding and MD5 on every document invalidation.

`getCacheKeys()` keeps its existing signature and three-key result, using `getCacheBaseKeys()` before computing the variant hash. Purges retain the hostname/namespace/tenant/global-collection key logic and both cache purge calls, including invalidation of every document variant and its cache leases.

Validation:
- 464 unit tests, 2,387 assertions pass on PHP 8.5.9 / PHPUnit 9.6.34, using a local bootstrap pointing at this checkout and installed Cloud cache/pools/telemetry dependencies.
- New tests cover scoped keys without hashes, fresh reads after public document purges, removal of legacy and variant cache entries, and rejection of stale leased writes. The new key test fails on the baseline; deliberately disabling document invalidation makes the outcome tests fail on stale data and leftover cache entries.
- Targeted Pint and `git diff --check` pass.
- Seven alternating rounds of 100,000 public `purgeCachedDocument()` calls against Memory/None adapters: median 301.90 ms before, 72.60 ms after (76.0% reduction). This measures PHP overhead only, not Redis latency or end-to-end production CPU savings.

Motivation: fresh Cloud 1.50.6 samples showed cache-key generation in 6.5–9.0% of non-scheduler samples across API, database and usage workers. These are wall-stack samples, not on-CPU attribution; only the purge subset benefits here. No production changes or Redis-backed E2E drill were performed for this PR; lease coverage uses the existing generation-aware in-memory cache adapter.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation so purging a document removes all relevant cached versions.
  * Subsequent reads now return fresh data after a cached document is purged.
  * Prevented outdated writes from restoring stale data after cache invalidation.
  * Improved consistency for cached data across different selections and configuration settings.

* **Tests**
  * Added coverage for cache key consistency, document purging, fresh reads, and stale-write prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->