### PR TITLE
fix: stop internal keys stealing user attributes named after them

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -9451,8 +9451,11 @@ class Database
             }
         }
 
+        $internalKeys = [];
+
         foreach ($this->getInternalAttributes() as $attribute) {
             $attributes[] = $attribute;
+            $internalKeys[$attribute['$id']] = true;
         }
 
         $hasRelationshipSelections = false;
@@ -9474,7 +9477,11 @@ class Database
                 continue;
             }
 
-            if (\is_null($value)) {
+            // filter() strips the leading "$" off an internal key, leaving a name a user
+            // attribute is allowed to have ("$collection" -> "collection"). An internal value
+            // never reaches the document under that name, so the alias lookup below has
+            // nothing of its own to find and can only steal the user's attribute.
+            if (\is_null($value) && !isset($internalKeys[$key])) {
                 $filteredKey = $this->adapter->filter($key);
                 $value = $document->getAttribute($filteredKey);
 

--- a/tests/e2e/Adapter/Scopes/DocumentTests.php
+++ b/tests/e2e/Adapter/Scopes/DocumentTests.php
@@ -2684,6 +2684,66 @@ trait DocumentTests
         $this->assertEquals($movieDocuments[0]->getId(), $documents[0]->getId());
     }
 
+    public function testFindAttributeNamedAfterInternalKey(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        $database->createCollection(__FUNCTION__);
+        $this->assertEquals(true, $database->createAttribute(__FUNCTION__, 'collection', Database::VAR_STRING, 128, false));
+
+        $database->createDocument(__FUNCTION__, new Document([
+            '$id' => ID::custom('clash'),
+            '$permissions' => [
+                Permission::read(Role::any()),
+            ],
+            'collection' => 'value',
+        ]));
+
+        $database->createDocument(__FUNCTION__, new Document([
+            '$id' => ID::custom('clashNull'),
+            '$permissions' => [
+                Permission::read(Role::any()),
+            ],
+            'collection' => null,
+        ]));
+
+        $documents = $database->find(__FUNCTION__, [Query::orderAsc('$id')]);
+
+        $this->assertCount(2, $documents);
+        $this->assertEquals('value', $documents[0]->getAttribute('collection'));
+        // getAttribute() reads a dropped key and a null value the same way
+        $this->assertTrue($documents[1]->offsetExists('collection'));
+    }
+
+    public function testFindAttributeNamedAfterTenantKey(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        if (!$database->getSharedTables()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $database->createCollection(__FUNCTION__);
+        $this->assertEquals(true, $database->createAttribute(__FUNCTION__, 'tenant', Database::VAR_STRING, 128, false));
+
+        $database->createDocument(__FUNCTION__, new Document([
+            '$id' => ID::custom('clash'),
+            '$permissions' => [
+                Permission::read(Role::any()),
+            ],
+            'tenant' => 'value',
+        ]));
+
+        // A select leaves _tenant out of the projection, so $tenant is null at decode
+        $documents = $database->find(__FUNCTION__, [Query::select(['tenant'])]);
+
+        $this->assertCount(1, $documents);
+        $this->assertEquals('value', $documents[0]->getAttribute('tenant'));
+    }
+
     public function testFindCheckPermissions(): void
     {
         /** @var Database $database */


### PR DESCRIPTION
## What

`Database::decode()` falls back to the adapter-filtered key when an attribute's value is null:

```php
if (\is_null($value)) {
    $filteredKey = $this->adapter->filter($key);
    $value = $document->getAttribute($filteredKey);
```

`Adapter::filter()` strips everything outside `[A-Za-z0-9_-]`, so for an internal key it strips the leading `$`: `filter('$collection') === 'collection'`, which is a name a user attribute is allowed to have. An internal value never reaches the document under that name — the adapters map their own `_`-prefixed columns back themselves — so the lookup has nothing of its own to find and can only take the user's attribute.

Two keys are actually reachable with a null value at decode time:

- **`$collection`** — `find()` stamps it *after* decode (`$node->setAttribute('$collection', ...)`), while `getDocument()`, `createDocument()`, `createDocuments()` and `upsertDocuments()` all stamp it *before*. So on a list read the fallback removed the user's `collection` attribute from the document and wrote its value into `$collection`; `find()` then overwrote `$collection` with the real id, and the user's value was simply gone. Where the value was null it was worse: the `elseif` alias cleanup deleted the key outright, so the attribute vanished from the response entirely.
- **`$tenant`** — with shared tables on, `getAttributeProjection()` does not project `_tenant`, so any `Query::select(...)` returns a row without it and `$tenant` is null at decode. `validateSelections()` does not list `$tenant` either, so the stolen value was not even re-exposed under `$tenant` — it disappeared silently.

`$permissions` is safe (an earlier `continue`), and `$id` / `$sequence` / `$createdAt` / `$updatedAt` are always projected and mapped back, so they are never null on either read path.

## Fix

Skip the alias fallback for internal keys.

The guard keys off the internal-attribute set rather than the `$` prefix on purpose: a collection id may itself start with `$`, and the derived relationship attribute key then also starts with `$` and *does* need the fallback (its column is the filtered name). Guarding on the prefix breaks `testManyToManyRelationshipKeyWithSymbols`.

## Tests

Two regression tests in `DocumentTests`, so every adapter scope picks them up:

- `testFindAttributeNamedAfterInternalKey` — an attribute named `collection`, with a non-null and a null row. The null row asserts on `offsetExists()`, since `getAttribute()` cannot tell a dropped key from a null value.
- `testFindAttributeNamedAfterTenantKey` — the shared-tables `tenant` case behind a `getSharedTables()` guard, read through `Query::select(['tenant'])`, which is what drops `_tenant` from the projection.

Both fail on `main` and pass here. Verified across all 16 adapter suites: MariaDB, MySQL, SQLite, Redis, Mirror and SharedTables/{MariaDB,MySQL,Redis,SQLite} are green; Postgres, SharedTables/Postgres, Memory and MongoDB carry only their existing `testObjectAttribute*` / `testIntegersBeyondInt32` failures; Pool, Schemaless/MongoDB and SharedTables/MongoDB fail wholesale on clean `main` locally with the same counts, so they are unchanged by this.

Refs appwrite/appwrite#6944 — Appwrite needs a dependency bump before that issue closes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document retrieval so user attributes named `collection` or `tenant` are preserved correctly.
  * Null-valued attributes with names matching internal keys now round-trip consistently.
  * Projected document reads retain user attributes that overlap with internal tenant keys.

* **Tests**
  * Added coverage for attributes that share names with internal metadata keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->