### PR TITLE
fix: keep the library usable on a PHP without ext-swoole

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
     },
     "suggest": {
         "ext-redis": "Needed to support Redis Cache Adapter",
+        "ext-swoole": "Needed to scope lifecycle hook silencing per coroutine and to detect lost connections",
         "ext-pdo": "Needed to support MariaDB, MySQL or SQLite Database Adapter",
         "mongodb/mongodb": "Needed to support MongoDB Database Adapter"
     },

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -15,6 +15,30 @@ class Connection
      */
     protected static array $errors = [
         'Max connect timeout reached',
+        'server has gone away',
+        'no connection to the server',
+        'Lost connection',
+        'is dead or not enabled',
+        'Error while sending',
+        'decryption failed or bad record mac',
+        'server closed the connection unexpectedly',
+        'SSL connection has been closed unexpectedly',
+        'Error writing data to the connection',
+        'Resource deadlock avoided',
+        'Transaction() on null',
+        'child connection forced to terminate due to client_idle_limit',
+        'query_wait_timeout',
+        'reset by peer',
+        'Physical connection is not usable',
+        'TCP Provider: Error code 0x68',
+        'ORA-03114',
+        'Packets out of order. Expected',
+        'Adaptive Server connection failed',
+        'Communication link failure',
+        'connection is no longer usable',
+        'Login timeout expired',
+        'running with the --read-only option so it cannot execute this statement',
+        'SQLSTATE[HY000] [2002] Connection refused',
     ];
 
     /**
@@ -25,7 +49,7 @@ class Connection
      */
     public static function hasError(Throwable $e): bool
     {
-        if (\extension_loaded('swoole') && DetectsLostConnections::causedByLostConnection($e)) {
+        if (\class_exists(DetectsLostConnections::class) && DetectsLostConnections::causedByLostConnection($e)) {
             return true;
         }
 

--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -25,7 +25,7 @@ class Connection
      */
     public static function hasError(Throwable $e): bool
     {
-        if (DetectsLostConnections::causedByLostConnection($e)) {
+        if (\extension_loaded('swoole') && DetectsLostConnections::causedByLostConnection($e)) {
             return true;
         }
 

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -1460,6 +1460,10 @@ class Database
 
     private function getEventContext(): int
     {
+        if (! \extension_loaded('swoole')) {
+            return -1;
+        }
+
         $context = Coroutine::getCid();
 
         return \is_int($context) ? $context : -1;

--- a/tests/unit/Support/swoole-absent.php
+++ b/tests/unit/Support/swoole-absent.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Exercises the lifecycle-hook paths that reach Database::getEventContext(), plus
+ * Connection::hasError(), in a process where ext-swoole is unavailable.
+ *
+ * Run by SwooleAbsentTest through a subprocess started with -n, because an
+ * extension cannot be unloaded from inside a running interpreter.
+ */
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+use Utopia\Cache\Adapter\None;
+use Utopia\Cache\Cache;
+use Utopia\Database\Adapter\Memory;
+use Utopia\Database\Collection;
+use Utopia\Database\Connection;
+use Utopia\Database\Database;
+use Utopia\Database\Document;
+use Utopia\Database\Helpers\Permission;
+use Utopia\Database\Helpers\Role;
+use Utopia\Database\Query;
+
+echo 'swoole=' . (extension_loaded('swoole') ? '1' : '0') . PHP_EOL;
+
+$database = new Database(new Memory(), new Cache(new None()));
+$database->setDatabase('utopiaTests')->setNamespace('swoole_absent');
+$database->create();
+$database->getAuthorization()->addRole(Role::any()->toString());
+
+echo 'create=ok' . PHP_EOL;
+
+echo 'silent=' . $database->silent(fn () => 'ok') . PHP_EOL;
+
+$database->createCollection(new Collection(
+    id: 'logs',
+    permissions: [
+        Permission::read(Role::any()),
+        Permission::create(Role::any()),
+        Permission::delete(Role::any()),
+    ],
+    documentSecurity: false,
+));
+
+foreach (['a', 'b', 'c'] as $id) {
+    $database->createDocument('logs', new Document(['$id' => $id]));
+}
+
+$deleted = $database->deleteDocuments('logs', [Query::limit(10)]);
+
+echo 'deleted=' . $deleted . PHP_EOL;
+echo 'remaining=' . \count($database->find('logs', [Query::limit(10)])) . PHP_EOL;
+echo 'hasError=' . (Connection::hasError(new RuntimeException('boom')) ? '1' : '0') . PHP_EOL;

--- a/tests/unit/Support/swoole-absent.php
+++ b/tests/unit/Support/swoole-absent.php
@@ -50,4 +50,16 @@ $deleted = $database->deleteDocuments('logs', [Query::limit(10)]);
 
 echo 'deleted=' . $deleted . PHP_EOL;
 echo 'remaining=' . \count($database->find('logs', [Query::limit(10)])) . PHP_EOL;
-echo 'hasError=' . (Connection::hasError(new RuntimeException('boom')) ? '1' : '0') . PHP_EOL;
+$lost = 0;
+foreach ([
+    'SQLSTATE[HY000]: General error: 2006 MySQL server has gone away',
+    'Lost connection to MySQL server during query',
+    'SQLSTATE[08006] server closed the connection unexpectedly',
+    'Max connect timeout reached',
+    'Communication link failure',
+] as $message) {
+    $lost += Connection::hasError(new RuntimeException($message)) ? 1 : 0;
+}
+
+echo 'lostDetected=' . $lost . PHP_EOL;
+echo 'unrelatedDetected=' . (Connection::hasError(new RuntimeException('syntax error near FROM')) ? '1' : '0') . PHP_EOL;

--- a/tests/unit/SwooleAbsentTest.php
+++ b/tests/unit/SwooleAbsentTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class SwooleAbsentTest extends TestCase
+{
+    /**
+     * ext-swoole is optional: it is absent from composer.json's require block, so a
+     * consumer may run the library on a PHP that does not have it. The lifecycle-hook
+     * context lookup and the lost-connection check both reach Swoole classes, and an
+     * unguarded reference there is a fatal Error rather than a caught exception.
+     *
+     * An extension cannot be unloaded from a running interpreter, so this drives a
+     * subprocess started with -n, which skips php.ini and every conf.d file and
+     * therefore loads no shared extension. Swoole ships as a shared extension both in
+     * the test image and in every environment that installs it through pecl.
+     */
+    public function testDatabaseOperatesWithoutSwoole(): void
+    {
+        $fixture = __DIR__ . '/Support/swoole-absent.php';
+
+        $command = \escapeshellarg(PHP_BINARY) . ' -n ' . \escapeshellarg($fixture) . ' 2>&1';
+
+        \exec($command, $lines, $status);
+
+        $output = \implode(PHP_EOL, $lines);
+
+        if (\str_contains($output, 'swoole=1')) {
+            $this->markTestSkipped('swoole is statically compiled into ' . PHP_BINARY . ', so its absence cannot be exercised');
+        }
+
+        $this->assertSame(0, $status, "Fixture exited {$status} without swoole:" . PHP_EOL . $output);
+
+        $this->assertStringContainsString('swoole=0', $output, $output);
+        $this->assertStringContainsString('create=ok', $output, $output);
+        $this->assertStringContainsString('silent=ok', $output, $output);
+        $this->assertStringContainsString('deleted=3', $output, $output);
+        $this->assertStringContainsString('remaining=0', $output, $output);
+        $this->assertStringContainsString('hasError=0', $output, $output);
+    }
+}

--- a/tests/unit/SwooleAbsentTest.php
+++ b/tests/unit/SwooleAbsentTest.php
@@ -7,25 +7,35 @@ use PHPUnit\Framework\TestCase;
 class SwooleAbsentTest extends TestCase
 {
     /**
-     * ext-swoole is optional: it is absent from composer.json's require block, so a
-     * consumer may run the library on a PHP that does not have it. The lifecycle-hook
-     * context lookup and the lost-connection check both reach Swoole classes, and an
-     * unguarded reference there is a fatal Error rather than a caught exception.
-     *
-     * An extension cannot be unloaded from a running interpreter, so this drives a
-     * subprocess started with -n, which skips php.ini and every conf.d file and
-     * therefore loads no shared extension. Swoole ships as a shared extension both in
-     * the test image and in every environment that installs it through pecl.
+     * @param array<string> $flags
+     * @return array{status: int, output: string}
      */
-    public function testDatabaseOperatesWithoutSwoole(): void
+    private function runFixture(array $flags): array
     {
-        $fixture = __DIR__ . '/Support/swoole-absent.php';
+        $command = \escapeshellarg(PHP_BINARY);
 
-        $command = \escapeshellarg(PHP_BINARY) . ' -n ' . \escapeshellarg($fixture) . ' 2>&1';
+        foreach ($flags as $flag) {
+            $command .= ' ' . $flag;
+        }
+
+        $command .= ' ' . \escapeshellarg(__DIR__ . '/Support/swoole-absent.php') . ' 2>&1';
 
         \exec($command, $lines, $status);
 
-        $output = \implode(PHP_EOL, $lines);
+        return ['status' => $status, 'output' => \implode(PHP_EOL, $lines)];
+    }
+
+    /**
+     * ext-swoole is optional: it is absent from composer.json's require block, so a
+     * consumer may run the library on a PHP that does not have it. An extension cannot
+     * be unloaded from a running interpreter, so this drives a subprocess started with
+     * -n, which skips php.ini and every conf.d file and therefore loads no shared
+     * extension. Swoole ships as a shared extension in the test image and in every
+     * environment that installs it through pecl.
+     */
+    public function testDatabaseOperatesWithoutSwoole(): void
+    {
+        ['status' => $status, 'output' => $output] = $this->runFixture(['-n']);
 
         if (\str_contains($output, 'swoole=1')) {
             $this->markTestSkipped('swoole is statically compiled into ' . PHP_BINARY . ', so its absence cannot be exercised');
@@ -33,11 +43,30 @@ class SwooleAbsentTest extends TestCase
 
         $this->assertSame(0, $status, "Fixture exited {$status} without swoole:" . PHP_EOL . $output);
 
-        $this->assertStringContainsString('swoole=0', $output, $output);
         $this->assertStringContainsString('create=ok', $output, $output);
         $this->assertStringContainsString('silent=ok', $output, $output);
         $this->assertStringContainsString('deleted=3', $output, $output);
         $this->assertStringContainsString('remaining=0', $output, $output);
-        $this->assertStringContainsString('hasError=0', $output, $output);
+        $this->assertStringContainsString('lostDetected=5', $output, $output);
+        $this->assertStringContainsString('unrelatedDetected=0', $output, $output);
+    }
+
+    /**
+     * Swoole\Database\DetectsLostConnections comes from Swoole's PHP-land library, which
+     * swoole.enable_library=Off switches off while leaving the extension loaded. Lost
+     * connections must still be recognised, so detection cannot rest on that class.
+     */
+    public function testLostConnectionsAreDetectedWithoutSwooleLibrary(): void
+    {
+        if (! \extension_loaded('swoole')) {
+            $this->markTestSkipped('swoole is not loaded, so its library cannot be switched off');
+        }
+
+        ['status' => $status, 'output' => $output] = $this->runFixture(['-d swoole.enable_library=Off']);
+
+        $this->assertSame(0, $status, "Fixture exited {$status} with the swoole library disabled:" . PHP_EOL . $output);
+
+        $this->assertStringContainsString('lostDetected=5', $output, $output);
+        $this->assertStringContainsString('unrelatedDetected=0', $output, $output);
     }
 }


### PR DESCRIPTION
## Problem

`ext-swoole` is not in this package's `composer.json` `require` block, so a consumer can resolve `utopia-php/database` onto a PHP that does not have it. Two call sites referenced Swoole classes unguarded. A missing class is a fatal `Error`, not a catchable exception, so the requirement was invisible until it crashed at runtime.

**1. `Database::getEventContext()`** — backs `silent()` and `areEventsSilenced()`.

This is worse than the originally reported `deleteDocuments()` path. `Database::create()` is itself wrapped in a `silent()` call, so the *first* operation any swoole-less consumer performs crashes:

```
Uncaught Error: Class "Swoole\Coroutine" not found in src/Database/Database.php:1463
#0 src/Database/Database.php(1441): Utopia\Database\Database->getEventContext()
#1 src/Database/Traits/Databases.php(31): Utopia\Database\Database->silent(Object(Closure))
#2 Utopia\Database\Database->create()
```

**2. `Connection::hasError()`** — found while confirming the fix actually made the library usable. It reaches `Swoole\Database\DetectsLostConnections` on the error path of the reconnecting `Utopia\Database\PDO` wrapper, so without the extension *any* query exception becomes a fatal. Same defect class. Flagging it explicitly since it is beyond the literal scope of the report — happy to split it out if you would rather it landed separately.

## Fix

Option 1 from the report: guard the coroutine id lookup with `\extension_loaded('swoole')`, matching the guard already used for the coroutine sleep in `withRetries()`. Without the extension the event context is the same `-1` sentinel already used outside a coroutine.

`Connection::hasError()` needed more than a guard, per review:

- **`extension_loaded()` is not sufficient there.** `DetectsLostConnections` comes from Swoole's PHP-land library, not the extension core, and `swoole.enable_library=Off` switches that library off while leaving the extension loaded — `extension_loaded()` returns `true` while `class_exists()` returns `false`. It is now gated on `class_exists()`. The same is *not* true of `Swoole\Coroutine`, which is extension-core and still resolves with the library off, so `extension_loaded()` remains correct in `Database.php`.
- **The fallback list was inadequate.** Enumerating what Swoole actually matches shows it supplies **24** needles, while the local list held exactly **one** — `Max connect timeout reached`, the single signature Swoole does *not* supply. Guarding alone would have left swoole-less consumers with 1 of 25 signatures, rethrowing `server has gone away` and `Lost connection` instead of reconnecting, silently dropping the retry contract for exactly the consumers this change exists to serve. Those 24 needles now live here, with Swoole's check kept ahead of them so upstream additions still apply where the library is present.

Option 2 (declaring `ext-swoole` in `require`) was not taken — it would turn an optional dependency into a hard one for every consumer. `ext-swoole` is instead documented under `suggest`, so the optionality is visible rather than implied.

## Test

`tests/unit/SwooleAbsentTest.php` covers both environments an optional extension produces:

1. **Absent** — the fixture runs in a subprocess started with `-n`, which skips `php.ini` and every `conf.d` file and so loads no shared extension. An extension cannot be unloaded from a running interpreter, so a subprocess is the only honest way to reach this branch. Swoole is shared both in this repo's test image (`php:8.5-cli-alpine` + `docker-php-ext-enable`) and in any pecl install, so the subprocess genuinely lacks it. The test skips with a loud message if some build has it compiled in statically, rather than passing vacuously.
2. **Present, library off** — the same fixture under `-d swoole.enable_library=Off`, which the `-n` subprocess cannot reach.

The fixture asserts outcomes, not the absence of a throw: `deleted=3` / `remaining=0` for the delete path, and five real lost-connection signatures detected plus one unrelated message *not* detected, so it cannot pass by matching everything.

**Verified red, each guard independently:**

| Reverted | Result |
|---|---|
| Both guards | RED — fatal at `Database.php:1463` |
| `Database` guard only | RED — fatal at `Database.php:1463` |
| `Connection` guard only | RED — fatal at `Connection.php:28` |
| Needle list (single needle) | RED — `lostDetected=1`, expected 5 |
| `class_exists` → `extension_loaded`, library off | RED — fatal at `Connection.php:28` |
| Nothing | GREEN — 2 tests, 10 assertions |

## Checks

- `vendor/bin/phpunit --testsuite unit` — OK, 1595 tests, 6169 assertions. The run exercises `Connection::hasError` with swoole present ("Lost connection detected. Re-preparing statement…"), confirming detection is not regressed.
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/pint --test` — passed

## Not verified

End-to-end on `utopia-php/monorepo` — reproducing `test (audit)` needs Docker plus MariaDB. The reproduction here matches the reported stack exactly (`Class "Swoole\Coroutine" not found` → `getEventContext()` → `silent()` → `deleteDocuments()`), but the monorepo lane has not been run green against this branch.

## Origin

Surfaced on `utopia-php/monorepo` PR #206: dropping the seemingly unused `ext-swoole` dev requirement from `packages/audit/composer.json` failed `test (audit)` with 17 `Class "Swoole\Coroutine" not found` errors via `cleanup()` → `deleteDocuments()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
