### PR TITLE
chore: require Validators ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "ext-mongodb": "*",
         "ext-mbstring": "*",
         "ext-redis": "*",
-        "utopia-php/validators": "^0.6",
+        "utopia-php/validators": "^1.0",
         "utopia-php/console": "0.1.*",
         "utopia-php/cache": "^4.0 || ^5.0",
         "utopia-php/pools": "2.*",
@@ -49,7 +49,7 @@
         "phpunit/phpunit": "9.*",
         "pcov/clobber": "2.*",
         "swoole/ide-helper": "5.1.3",
-        "utopia-php/cli": "0.22.*",
+        "utopia-php/cli": "^0.24.4",
         "laravel/pint": "*",
         "phpstan/phpstan": "1.*",
         "rregeer/phpunit-coverage-check": "0.3.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de1a56a5d39a51711c1f26fcbcf47bdc",
+    "content-hash": "93f4fcf5b88ac10e6bdf468231450659",
     "packages": [
         {
             "name": "brick/math",
@@ -2370,16 +2370,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.6.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "7afdde56a7a635f0cb3d8a5e22ebbef40baf31dc"
+                "reference": "f0a08bd888d035b68c463d22b47ef385984da73d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/7afdde56a7a635f0cb3d8a5e22ebbef40baf31dc",
-                "reference": "7afdde56a7a635f0cb3d8a5e22ebbef40baf31dc",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/f0a08bd888d035b68c463d22b47ef385984da73d",
+                "reference": "f0a08bd888d035b68c463d22b47ef385984da73d",
                 "shasum": ""
             },
             "require": {
@@ -2404,9 +2404,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.6.0"
+                "source": "https://github.com/utopia-php/validators/tree/1.0.1"
             },
-            "time": "2026-08-27T04:46:08+00:00"
+            "time": "2026-09-02T15:57:19+00:00"
         }
     ],
     "packages-dev": [
@@ -4483,27 +4483,23 @@
         },
         {
             "name": "utopia-php/cli",
-            "version": "0.22.0",
+            "version": "0.24.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/cli.git",
-                "reference": "a7ac387ee626fd27075a87e836fb72c5be38add4"
+                "reference": "39d590ffe67b0d63f107ad45533a85163899bc08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/cli/zipball/a7ac387ee626fd27075a87e836fb72c5be38add4",
-                "reference": "a7ac387ee626fd27075a87e836fb72c5be38add4",
+                "url": "https://api.github.com/repos/utopia-php/cli/zipball/39d590ffe67b0d63f107ad45533a85163899bc08",
+                "reference": "39d590ffe67b0d63f107ad45533a85163899bc08",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4",
-                "utopia-php/servers": "0.2.*"
+                "utopia-php/servers": "^0.4"
             },
             "require-dev": {
-                "laravel/pint": "1.2.*",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.3",
-                "squizlabs/php_codesniffer": "^3.6",
                 "swoole/ide-helper": "4.8.8",
                 "utopia-php/console": "0.0.*"
             },
@@ -4528,32 +4524,30 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/cli/issues",
-                "source": "https://github.com/utopia-php/cli/tree/0.22.0"
+                "source": "https://github.com/utopia-php/cli/tree/0.24.4"
             },
-            "time": "2025-10-21T10:42:45+00:00"
+            "time": "2026-09-02T15:57:19+00:00"
         },
         {
             "name": "utopia-php/di",
-            "version": "0.1.0",
+            "version": "0.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/di.git",
-                "reference": "22490c95f7ac3898ed1c33f1b1b5dd577305ee31"
+                "reference": "a72d8ee141c0883145876da95b527ffdff7ae2a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/di/zipball/22490c95f7ac3898ed1c33f1b1b5dd577305ee31",
-                "reference": "22490c95f7ac3898ed1c33f1b1b5dd577305ee31",
+                "url": "https://api.github.com/repos/utopia-php/di/zipball/a72d8ee141c0883145876da95b527ffdff7ae2a9",
+                "reference": "a72d8ee141c0883145876da95b527ffdff7ae2a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "psr/container": "^2.0"
             },
             "require-dev": {
-                "laravel/pint": "^1.2",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5.25",
                 "swoole/ide-helper": "4.8.3"
             },
             "type": "library",
@@ -4569,40 +4563,37 @@
             ],
             "description": "A simple and lite library for managing dependency injections",
             "keywords": [
-                "framework",
-                "http",
+                "PSR-11",
+                "container",
+                "dependency-injection",
+                "di",
                 "php",
-                "upf"
+                "utopia"
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/di/issues",
-                "source": "https://github.com/utopia-php/di/tree/0.1.0"
+                "source": "https://github.com/utopia-php/di/tree/0.3.6"
             },
-            "time": "2024-08-08T14:35:19+00:00"
+            "time": "2026-09-02T15:57:19+00:00"
         },
         {
             "name": "utopia-php/servers",
-            "version": "0.2.5",
+            "version": "0.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "4770e879a90685af4ba14e7e5d95d0a17c7fdf03"
+                "reference": "060da7b356fc9ffecd30d5c3849e8465892e8615"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/4770e879a90685af4ba14e7e5d95d0a17c7fdf03",
-                "reference": "4770e879a90685af4ba14e7e5d95d0a17c7fdf03",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/060da7b356fc9ffecd30d5c3849e8465892e8615",
+                "reference": "060da7b356fc9ffecd30d5c3849e8465892e8615",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
-                "utopia-php/di": "0.1.*",
-                "utopia-php/validators": "0.*"
-            },
-            "require-dev": {
-                "laravel/pint": "^0.2.3",
-                "phpstan/phpstan": "^1.8",
-                "phpunit/phpunit": "^9.5.5"
+                "php": ">=8.5",
+                "utopia-php/di": "^0.3",
+                "utopia-php/validators": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -4630,9 +4621,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.2.5"
+                "source": "https://github.com/utopia-php/servers/tree/0.4.11"
             },
-            "time": "2026-02-10T04:21:53+00:00"
+            "time": "2026-09-02T15:57:19+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary

Require Validators `^1.0` exclusively. No aliases or fallback ranges.

Upgrade the development CLI requirement to `^0.24.4`: CLI 0.22 pins Servers 0.2, which still requires Validators 0.x and prevents installing the development graph. Refresh the tracked lockfile minimally: Validators 1.0.1, CLI 0.24.4, Servers 0.4.11.

Prerequisite for https://github.com/appwrite/appwrite/pull/13575 and https://github.com/appwrite-labs/cloud/pull/5734. Validators 1.0 changes `Assoc`'s declared type from array to object; this does not add a compatibility override. A Database release is needed after merge before Audit/CE/Cloud can resolve.

## Verification

PHP 8.5.10 with released Validators 1.0.1:

- `composer update utopia-php/validators utopia-php/cli --with-all-dependencies --minimal-changes --ignore-platform-reqs --no-interaction --no-progress`: passed.
- `XDEBUG_MODE=off php -d memory_limit=1G vendor/bin/phpunit --testsuite unit`: **469 tests / 2,408 assertions passed**. Existing ReflectionProperty deprecations emitted on PHP 8.5.
- `XDEBUG_MODE=off composer check`: passed across 155 files.
- `composer lint`, `composer validate --no-check-publish`, `git diff --check`: passed.
- Database-engine E2E and downstream application tests were not run. Backend-only; no screenshots apply.
- `composer audit` still reports `PKSA-61k5-cqr9-b8b4` on unchanged `mongodb/mongodb`. This PR does not fix that advisory.

No releases or deployments performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal package requirements to support newer tooling and validation capabilities.
  - No user-facing features, behavior changes, or interface updates are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->