### PR TITLE
fix: respect query value limits when loading relationships

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -146,7 +146,6 @@ class Database
     public const RELATION_SIDE_CHILD = 'child';
 
     public const RELATION_MAX_DEPTH = 3;
-    public const RELATION_QUERY_CHUNK_SIZE = 5000;
 
     // Orders
     public const ORDER_ASC = 'ASC';
@@ -5325,7 +5324,7 @@ class Database
         $relatedDocuments = [];
 
         // Process in chunks to avoid exceeding query value limits
-        foreach (\array_chunk($uniqueRelatedIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
+        foreach (\array_chunk($uniqueRelatedIds, \max(1, $this->maxQueryValues)) as $chunk) {
             $chunkDocs = $this->find($relatedCollection->getId(), [
                 Query::equal('$id', $chunk),
                 Query::limit(PHP_INT_MAX),
@@ -5417,7 +5416,7 @@ class Database
 
         $relatedDocuments = [];
 
-        foreach (\array_chunk($parentIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
+        foreach (\array_chunk($parentIds, \max(1, $this->maxQueryValues)) as $chunk) {
             $chunkDocs = $this->find($relatedCollection->getId(), [
                 Query::equal($twoWayKey, $chunk),
                 Query::limit(PHP_INT_MAX),
@@ -5514,7 +5513,7 @@ class Database
 
         $relatedDocuments = [];
 
-        foreach (\array_chunk($childIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
+        foreach (\array_chunk($childIds, \max(1, $this->maxQueryValues)) as $chunk) {
             $chunkDocs = $this->find($relatedCollection->getId(), [
                 Query::equal($twoWayKey, $chunk),
                 Query::limit(PHP_INT_MAX),
@@ -5593,7 +5592,7 @@ class Database
 
         $junctions = [];
 
-        foreach (\array_chunk($documentIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
+        foreach (\array_chunk($documentIds, \max(1, $this->maxQueryValues)) as $chunk) {
             $chunkJunctions = $this->skipRelationships(fn () => $this->find($junction, [
                 Query::equal($twoWayKey, $chunk),
                 Query::limit(PHP_INT_MAX)
@@ -5623,7 +5622,7 @@ class Database
             $uniqueRelatedIds = array_unique($relatedIds);
             $foundRelated = [];
 
-            foreach (\array_chunk($uniqueRelatedIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
+            foreach (\array_chunk($uniqueRelatedIds, \max(1, $this->maxQueryValues)) as $chunk) {
                 $chunkDocs = $this->find($relatedCollection->getId(), [
                     Query::equal('$id', $chunk),
                     Query::limit(PHP_INT_MAX),

--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -5325,7 +5325,7 @@ class Database
         $relatedDocuments = [];
 
         // Process in chunks to avoid exceeding query value limits
-        foreach (\array_chunk($uniqueRelatedIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+        foreach (\array_chunk($uniqueRelatedIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
             $chunkDocs = $this->find($relatedCollection->getId(), [
                 Query::equal('$id', $chunk),
                 Query::limit(PHP_INT_MAX),
@@ -5417,7 +5417,7 @@ class Database
 
         $relatedDocuments = [];
 
-        foreach (\array_chunk($parentIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+        foreach (\array_chunk($parentIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
             $chunkDocs = $this->find($relatedCollection->getId(), [
                 Query::equal($twoWayKey, $chunk),
                 Query::limit(PHP_INT_MAX),
@@ -5514,7 +5514,7 @@ class Database
 
         $relatedDocuments = [];
 
-        foreach (\array_chunk($childIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+        foreach (\array_chunk($childIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
             $chunkDocs = $this->find($relatedCollection->getId(), [
                 Query::equal($twoWayKey, $chunk),
                 Query::limit(PHP_INT_MAX),
@@ -5593,7 +5593,7 @@ class Database
 
         $junctions = [];
 
-        foreach (\array_chunk($documentIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+        foreach (\array_chunk($documentIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
             $chunkJunctions = $this->skipRelationships(fn () => $this->find($junction, [
                 Query::equal($twoWayKey, $chunk),
                 Query::limit(PHP_INT_MAX)
@@ -5623,7 +5623,7 @@ class Database
             $uniqueRelatedIds = array_unique($relatedIds);
             $foundRelated = [];
 
-            foreach (\array_chunk($uniqueRelatedIds, self::RELATION_QUERY_CHUNK_SIZE) as $chunk) {
+            foreach (\array_chunk($uniqueRelatedIds, \max(1, \min(self::RELATION_QUERY_CHUNK_SIZE, $this->maxQueryValues))) as $chunk) {
                 $chunkDocs = $this->find($relatedCollection->getId(), [
                     Query::equal('$id', $chunk),
                     Query::limit(PHP_INT_MAX),

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -26,6 +26,95 @@ trait RelationshipTests
     use ManyToOneTests;
     use ManyToManyTests;
 
+    /**
+     * @return array<string, array{string, string, int}>
+     */
+    public static function relationshipQueryValueLimitProvider(): array
+    {
+        $cases = [];
+        foreach ([Database::RELATION_ONE_TO_ONE, Database::RELATION_ONE_TO_MANY, Database::RELATION_MANY_TO_ONE, Database::RELATION_MANY_TO_MANY] as $type) {
+            foreach (['parents', 'children'] as $collection) {
+                $cases[$type . ' ' . $collection] = [$type, $collection, 3];
+            }
+        }
+
+        // One parent can exceed the value limit when fetching its related documents.
+        $cases['manyToMany related documents'] = [Database::RELATION_MANY_TO_MANY, 'parents', 1];
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider relationshipQueryValueLimitProvider
+     */
+    public function testRelationshipQueryValueLimit(string $type, string $collection, int $limit): void
+    {
+        $database = $this->getDatabase();
+
+        if (!$database->getAdapter()->getSupportForRelationships()) {
+            $this->expectNotToPerformAssertions();
+            return;
+        }
+
+        $parents = ID::unique();
+        $children = ID::unique();
+        $permissions = [
+            Permission::read(Role::any()),
+            Permission::create(Role::any()),
+            Permission::update(Role::any()),
+            Permission::delete(Role::any()),
+        ];
+        $database->createCollection($parents, permissions: $permissions);
+        $database->createCollection($children, permissions: $permissions);
+        $database->createRelationship($parents, $children, $type, true, 'children', 'parents');
+
+        foreach (['child1', 'child2', 'child3'] as $id) {
+            $database->createDocument($children, new Document(['$id' => $id]));
+        }
+
+        for ($i = 1; $i <= 3; $i++) {
+            $related = match ($type) {
+                Database::RELATION_MANY_TO_MANY => ['child1', 'child2', 'child3'],
+                Database::RELATION_ONE_TO_MANY => ['child' . $i],
+                default => 'child' . $i,
+            };
+            $database->createDocument($parents, new Document([
+                '$id' => 'parent' . $i,
+                'children' => $related,
+            ]));
+        }
+
+        $max = $database->getMaxQueryValues();
+        $database->setMaxQueryValues(2);
+
+        try {
+            $documents = $database->find($collection === 'parents' ? $parents : $children, [Query::limit($limit)]);
+
+            $this->assertCount($limit, $documents);
+            foreach ($documents as $document) {
+                $related = $document->getAttribute($collection === 'parents' ? 'children' : 'parents');
+                $related = $related instanceof Document ? [$related] : $related;
+                $ids = \array_map(fn (Document $related) => $related->getId(), $related);
+                $prefix = $collection === 'parents' ? 'child' : 'parent';
+                $expected = $type === Database::RELATION_MANY_TO_MANY
+                    ? [$prefix . '1', $prefix . '2', $prefix . '3']
+                    : [$prefix . \substr($document->getId(), -1)];
+                $this->assertEqualsCanonicalizing($expected, $ids);
+            }
+
+            try {
+                $database->find($children, [Query::equal('$id', ['child1', 'child2', 'child3'])]);
+                $this->fail('Explicit queries must still respect the configured value limit.');
+            } catch (QueryException $exception) {
+                $this->assertSame('Invalid query: Query on attribute has greater than 2 values: $id', $exception->getMessage());
+            }
+        } finally {
+            $database->setMaxQueryValues($max);
+            $database->deleteCollection($parents);
+            $database->deleteCollection($children);
+        }
+    }
+
     public function testZoo(): void
     {
         /** @var Database $database */

--- a/tests/e2e/Adapter/Scopes/RelationshipTests.php
+++ b/tests/e2e/Adapter/Scopes/RelationshipTests.php
@@ -102,12 +102,8 @@ trait RelationshipTests
                 $this->assertEqualsCanonicalizing($expected, $ids);
             }
 
-            try {
-                $database->find($children, [Query::equal('$id', ['child1', 'child2', 'child3'])]);
-                $this->fail('Explicit queries must still respect the configured value limit.');
-            } catch (QueryException $exception) {
-                $this->assertSame('Invalid query: Query on attribute has greater than 2 values: $id', $exception->getMessage());
-            }
+            $this->expectException(QueryException::class);
+            $database->find($children, [Query::equal('$id', ['child1', 'child2', 'child3'])]);
         } finally {
             $database->setMaxQueryValues($max);
             $database->deleteCollection($parents);


### PR DESCRIPTION
## What does this PR do?

Relationship loading batches up to 5,000 IDs even when the connection permits fewer query values. A document with 501 related IDs therefore fails to load with a 500-value limit.

Use the configured `maxQueryValues` for all five relationship query batches and remove the redundant `RELATION_QUERY_CHUNK_SIZE` constant. Keep the existing `max(1, ...)` guard used by other batch queries. Validation of caller-supplied queries remains unchanged.

A configured limit above 5,000 also permits larger relationship batches. This follows the existing ID-lookup batching policy; [52b189bd](https://github.com/utopia-php/database/commit/52b189bded7ef409bb978483a7231d779051b510) adopted it for other lookups and left these five relationship paths for a follow-up. The default limit remains 5,000.

## Test Plan

- Nine regression cases cover all relationship types in both directions, plus a single parent exceeding the limit. Explicit oversized queries must throw `QueryException`.
- PostgreSQL, SQLite, and shared-table PostgreSQL: 27 tests / 129 assertions passed after the review changes. All nine PostgreSQL cases were confirmed to fail without the fix.
- Merged current `main` at `64f52570`; all CI checks pass on `b0d89bfc`, including all adapter suites, unit tests, lint, and CodeQL. Greptile: 5/5. Local syntax, Pint, and diff checks pass; the local Docker runtime was unavailable for a repeat adapter run.

Appwrite adoption requires a library release and dependency update. The HTTP regression is [appwrite/appwrite#13610](https://github.com/appwrite/appwrite/pull/13610).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Relationship lookups now respect the configured maximum number of query values per request.
  - Related records can be fetched reliably without exceeding query value limits, including many-to-many relationships.

- **Tests**
  - Added coverage for relationship queries under configured value limits.
  - Confirmed that explicit queries exceeding the limit continue to return the expected error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->