### PR TITLE
chore: allow utopia-php/console 0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "ext-mbstring": "*",
         "ext-redis": "*",
         "utopia-php/validators": "^1.0",
-        "utopia-php/console": "0.1.*",
+        "utopia-php/console": "^0.1 || ^0.2",
         "utopia-php/cache": "^4.0 || ^5.0",
         "utopia-php/pools": "2.*",
         "utopia-php/mongo": "1.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93f4fcf5b88ac10e6bdf468231450659",
+    "content-hash": "7a9f496f37199aeff8159e3ee3b9e0f2",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
## Summary

- Widen `utopia-php/console` from `0.1.*` to `^0.1 || ^0.2`.
- console 0.2 only adds `Utopia\Command` and keeps the whole 0.1 `Console` surface this library uses (three call sites in `src/`), so accepting both lines lets consumers upgrade independently instead of forcing every 0.1 consumer to move at once.
- `composer.lock` changes by content hash only; resolved versions are unchanged.

Appwrite is moving to console 0.2 for structured command execution and currently has to alias `0.2.9 as 0.1.1` because of this pin.

Supersedes #882, which hard-bumps to `0.2.*` from a base that predates the cache 5 and validators 1.0 bumps.

## Testing

- `composer update --lock` (no version changes)
- CI adapter matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)