### PR TITLE
fix(attributes): attach the auto filter in the batch creation path

### DIFF
--- a/src/Database/Database.php
+++ b/src/Database/Database.php
@@ -92,9 +92,9 @@ class Database
     public const DELETE_BATCH_SIZE = 1_000;
 
     /**
-     * Attribute types whose stored value is produced by a filter of the same name. Both public
-     * creation paths add it, so an attribute made through createCollection() encodes and decodes
-     * the same way as the identical one made through createAttribute().
+     * Attribute types whose stored value is produced by a filter of the same name. Every public
+     * creation path adds it, so an attribute made through createCollection(), createAttribute()
+     * or createAttributes() encodes and decodes the same way as any identical one.
      *
      * @var list<ColumnType>
      */

--- a/src/Database/Traits/Attributes.php
+++ b/src/Database/Traits/Attributes.php
@@ -227,6 +227,12 @@ trait Attributes
                 throw new DatabaseException('Missing attribute key');
             }
 
+            if (in_array($attribute->type, Database::ATTRIBUTE_FILTER_TYPES, true)) {
+                $attribute->filters = array_values(
+                    array_unique(array_merge($attribute->filters, [$attribute->type->value]))
+                );
+            }
+
             $existsInSchema = false;
 
             try {

--- a/tests/e2e/Adapter/Scopes/AttributeTests.php
+++ b/tests/e2e/Adapter/Scopes/AttributeTests.php
@@ -1935,6 +1935,41 @@ trait AttributeTests
         $database->deleteCollection($collection);
     }
 
+    public function testCreateAttributesAddingAutoFilter(): void
+    {
+        /** @var Database $database */
+        $database = $this->getDatabase();
+
+        if (! $database->getAdapter()->supports(Capability::BatchCreateAttributes)) {
+            $this->markTestSkipped('Adapter does not support batch attribute creation');
+        }
+
+        $collection = 'datetime_batch_auto_filter';
+
+        $database->createCollection(new Collection(
+            id: $collection,
+            permissions: [
+                Permission::create(Role::any()),
+                Permission::read(Role::any()),
+            ],
+            documentSecurity: false,
+        ));
+
+        $database->createAttributes($collection, [Attribute::datetime(key: 'batch')]);
+
+        $database->createDocument($collection, new Document([
+            Document::ID => 'offset',
+            'batch' => '2024-01-02T03:04:05.000+05:00',
+        ]));
+
+        $this->assertSame(
+            '2024-01-01T22:04:05.000+00:00',
+            $database->getDocument($collection, 'offset')->getAttribute('batch')
+        );
+
+        $database->deleteCollection($collection);
+    }
+
     public function testCreateAttributesBigIntIgnoresSizeMetadata(): void
     {
         /** @var Database $database */


### PR DESCRIPTION
## What

`createAttributes()` is the third public path that creates attributes, and it was the only one that never attached the type-named filter listed in `Database::ATTRIBUTE_FILTER_TYPES`. `createAttribute()` and `createCollection()` both attach it before validating.

This adds the same guard to the batch path, right after the "Missing attribute key" check.

## Why it matters

The attribute validator *requires* that filter to be present, so a `datetime`, `point`, `linestring`, `polygon`, `vector` or `object` attribute created through the batch path was rejected outright:

```
Utopia\Database\Exception: Attribute of type: datetime requires the following filters: datetime
```

Had validation let it through, the value would have been stored without the encode/decode the other two paths apply — a datetime written as `+05:00` would never have been normalised to `+00:00`.

## Test

`testCreateAttributesAddingAutoFilter` creates a datetime attribute via `createAttributes()`, writes a `+05:00` offset and asserts it reads back normalised to `+00:00`. It skips on adapters without `Capability::BatchCreateAttributes`.

Verified it is a real regression test — with the `src/` change reverted it fails on the validator error above, and passes with the fix.

## Verification

| Check | Result |
|---|---|
| Unit suite (paratest, 4 procs) | 1606 tests, 6195 assertions — green |
| MariaDB adapter e2e | 793 tests, 22975 assertions — green |
| `composer lint` (Pint, PSR-12) | passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)